### PR TITLE
Fix: Set proper variables for version and SCM at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export GO111MODULE = on
 
 GOCMD?=go
 GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-GOBUILD=$(GOCMD) build -mod=vendor -ldflags "-X 'github.com/buildpack/lifecycle.Version=$(LIFECYCLE_VERSION)' -X 'github.com/buildpack/lifecycle.SCMRepository=$(SCM_REPO)' -X 'github.com/buildpack/lifecycle.SCMCommit=$(SCM_COMMIT)'"
+GOBUILD=$(GOCMD) build -mod=vendor -ldflags "-X 'github.com/buildpack/lifecycle/cmd.Version=$(LIFECYCLE_VERSION)' -X 'github.com/buildpack/lifecycle/cmd.SCMRepository=$(SCM_REPO)' -X 'github.com/buildpack/lifecycle/cmd.SCMCommit=$(SCM_COMMIT)'"
 GOTEST=$(GOCMD) test -mod=vendor
 LIFECYCLE_VERSION?=0.0.0
 PLATFORM_API=0.1


### PR DESCRIPTION
Signed-off-by: Javier Romero <jromero@pivotal.io>
Signed-off-by: Andrew Meyer <ameyer@pivotal.io>