### PR TITLE
Allow Rebaser to parse metadata of older app images

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -52,8 +52,21 @@ func (cm *CacheMetadata) MetadataForBuildpack(id string) BuildpackLayersMetadata
 	return BuildpackLayersMetadata{}
 }
 
+// NOTE: This struct MUST be kept in sync with `LayersMetadataCompat`
 type LayersMetadata struct {
 	App        []LayerMetadata           `json:"app" toml:"app"`
+	Config     LayerMetadata             `json:"config" toml:"config"`
+	Launcher   LayerMetadata             `json:"launcher" toml:"launcher"`
+	Buildpacks []BuildpackLayersMetadata `json:"buildpacks" toml:"buildpacks"`
+	RunImage   RunImageMetadata          `json:"runImage" toml:"run-image"`
+	Stack      StackMetadata             `json:"stack" toml:"stack"`
+}
+
+// NOTE: This struct MUST be kept in sync with `LayersMetadata`.
+// It exists for situations where the `App` field type cannot be
+// guaranteed, yet the original struct data must be maintained.
+type LayersMetadataCompat struct {
+	App        interface{}               `json:"app" toml:"app"`
 	Config     LayerMetadata             `json:"config" toml:"config"`
 	Launcher   LayerMetadata             `json:"launcher" toml:"launcher"`
 	Buildpacks []BuildpackLayersMetadata `json:"buildpacks" toml:"buildpacks"`

--- a/rebaser.go
+++ b/rebaser.go
@@ -17,7 +17,7 @@ func (r *Rebaser) Rebase(
 	newBaseImage imgutil.Image,
 	additionalNames []string,
 ) error {
-	var origMetadata LayersMetadata
+	var origMetadata LayersMetadataCompat
 	if err := DecodeLabel(workingImage, LayerMetadataLabel, &origMetadata); err != nil {
 		return errors.Wrap(err, "get image metadata")
 	}

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -27,7 +27,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		fakeWorkingImage *fakes.Image
 		fakeNewBaseImage *fakes.Image
 		additionalNames  []string
-		md               lifecycle.LayersMetadata
+		md               lifecycle.LayersMetadataCompat
 	)
 
 	it.Before(func() {
@@ -90,13 +90,14 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			it("preserves other existing metadata", func() {
 				h.AssertNil(t, fakeWorkingImage.SetLabel(
 					lifecycle.LayerMetadataLabel,
-					`{"buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
+					`{"app": [{"sha": "123456"}], "buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
 				))
 				h.AssertNil(t, rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames))
 				h.AssertNil(t, lifecycle.DecodeLabel(fakeWorkingImage, lifecycle.LayerMetadataLabel, &md))
 
 				h.AssertEq(t, len(md.Buildpacks), 1)
 				h.AssertEq(t, md.Buildpacks[0].ID, "buildpack.id")
+				h.AssertEq(t, md.App, []interface{}{map[string]interface{}{"sha": "123456"}})
 			})
 		})
 


### PR DESCRIPTION
Resolves #219 