### PR TITLE
Implements RFC0013 for app source project metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS+=-X 'github.com/buildpacks/lifecycle/cmd.PlatformAPI=$(PLATFORM_API)'
 GOBUILD=$(GOCMD) build -ldflags "$(LDFLAGS)"
 GOTEST=$(GOCMD) test
 LIFECYCLE_VERSION?=0.0.0
-PLATFORM_API?=0.2
+PLATFORM_API?=0.3
 BUILDPACK_API?=0.2
 SCM_REPO?=
 SCM_COMMIT?=$$(git rev-parse --short HEAD)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -10,41 +10,43 @@ import (
 )
 
 const (
-	DefaultLayersDir     = "/layers"
-	DefaultAppDir        = "/workspace"
-	DefaultBuildpacksDir = "/cnb/buildpacks"
-	DefaultPlatformDir   = "/platform"
-	DefaultOrderPath     = "/cnb/order.toml"
-	DefaultGroupPath     = "./group.toml"
-	DefaultStackPath     = "/cnb/stack.toml"
-	DefaultAnalyzedPath  = "./analyzed.toml"
-	DefaultPlanPath      = "./plan.toml"
-	DefaultProcessType   = "web"
-	DefaultLauncherPath  = "/cnb/lifecycle/launcher"
-	DefaultLogLevel      = "info"
+	DefaultLayersDir           = "/layers"
+	DefaultAppDir              = "/workspace"
+	DefaultBuildpacksDir       = "/cnb/buildpacks"
+	DefaultPlatformDir         = "/platform"
+	DefaultOrderPath           = "/cnb/order.toml"
+	DefaultGroupPath           = "./group.toml"
+	DefaultStackPath           = "/cnb/stack.toml"
+	DefaultAnalyzedPath        = "./analyzed.toml"
+	DefaultPlanPath            = "./plan.toml"
+	DefaultProcessType         = "web"
+	DefaultLauncherPath        = "/cnb/lifecycle/launcher"
+	DefaultLogLevel            = "info"
+	DefaultProjectMetadataPath = "./project-metadata.toml"
 
-	EnvLayersDir         = "CNB_LAYERS_DIR"
-	EnvAppDir            = "CNB_APP_DIR"
-	EnvBuildpacksDir     = "CNB_BUILDPACKS_DIR"
-	EnvPlatformDir       = "CNB_PLATFORM_DIR"
-	EnvAnalyzedPath      = "CNB_ANALYZED_PATH"
-	EnvOrderPath         = "CNB_ORDER_PATH"
-	EnvGroupPath         = "CNB_GROUP_PATH"
-	EnvStackPath         = "CNB_STACK_PATH"
-	EnvPlanPath          = "CNB_PLAN_PATH"
-	EnvUseDaemon         = "CNB_USE_DAEMON"       // defaults to false
-	EnvUseHelpers        = "CNB_USE_CRED_HELPERS" // defaults to false
-	EnvRunImage          = "CNB_RUN_IMAGE"
-	EnvCacheImage        = "CNB_CACHE_IMAGE"
-	EnvCacheDir          = "CNB_CACHE_DIR"
-	EnvLaunchCacheDir    = "CNB_LAUNCH_CACHE_DIR"
-	EnvUID               = "CNB_USER_ID"
-	EnvGID               = "CNB_GROUP_ID"
-	EnvRegistryAuth      = "CNB_REGISTRY_AUTH"
-	EnvSkipLayers        = "CNB_ANALYZE_SKIP_LAYERS" // defaults to false
-	EnvProcessType       = "CNB_PROCESS_TYPE"
-	EnvProcessTypeLegacy = "PACK_PROCESS_TYPE" // deprecated
-	EnvLogLevel          = "CNB_LOG_LEVEL"
+	EnvLayersDir           = "CNB_LAYERS_DIR"
+	EnvAppDir              = "CNB_APP_DIR"
+	EnvBuildpacksDir       = "CNB_BUILDPACKS_DIR"
+	EnvPlatformDir         = "CNB_PLATFORM_DIR"
+	EnvAnalyzedPath        = "CNB_ANALYZED_PATH"
+	EnvOrderPath           = "CNB_ORDER_PATH"
+	EnvGroupPath           = "CNB_GROUP_PATH"
+	EnvStackPath           = "CNB_STACK_PATH"
+	EnvPlanPath            = "CNB_PLAN_PATH"
+	EnvUseDaemon           = "CNB_USE_DAEMON"       // defaults to false
+	EnvUseHelpers          = "CNB_USE_CRED_HELPERS" // defaults to false
+	EnvRunImage            = "CNB_RUN_IMAGE"
+	EnvCacheImage          = "CNB_CACHE_IMAGE"
+	EnvCacheDir            = "CNB_CACHE_DIR"
+	EnvLaunchCacheDir      = "CNB_LAUNCH_CACHE_DIR"
+	EnvUID                 = "CNB_USER_ID"
+	EnvGID                 = "CNB_GROUP_ID"
+	EnvRegistryAuth        = "CNB_REGISTRY_AUTH"
+	EnvSkipLayers          = "CNB_ANALYZE_SKIP_LAYERS" // defaults to false
+	EnvProcessType         = "CNB_PROCESS_TYPE"
+	EnvProcessTypeLegacy   = "PACK_PROCESS_TYPE" // deprecated
+	EnvLogLevel            = "CNB_LOG_LEVEL"
+	EnvProjectMetadataPath = "CNB_PROJECT_METADATA_PATH"
 )
 
 var flagSet = flag.NewFlagSet("lifecycle", flag.ExitOnError)
@@ -131,6 +133,10 @@ func FlagVersion(version *bool) {
 
 func FlagLogLevel(level *string) {
 	flagSet.StringVar(level, "log-level", envOrDefault(EnvLogLevel, DefaultLogLevel), "logging level")
+}
+
+func FlagProjectMetadataPath(projectMetadataPath *string) {
+	flagSet.StringVar(projectMetadataPath, "project-metadata", envOrDefault(EnvProjectMetadataPath, DefaultProjectMetadataPath), "path to project-metadata.toml")
 }
 
 func intEnv(k string) int {

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
@@ -107,6 +108,13 @@ func (e *exportCmd) Exec() error {
 	_, err = toml.DecodeFile(e.stackPath, &stackMD)
 	if err != nil {
 		cmd.Logger.Infof("no stack metadata found at path '%s', stack metadata will not be exported\n", e.stackPath)
+	}
+
+	projectMetadataPath := path.Join(".", lifecycle.ProjectMetadataFileName)
+	var projectMD lifecycle.ProjectMetadata
+	_, err = toml.DecodeFile(projectMetadataPath, &projectMD)
+	if err != nil {
+		cmd.Logger.Infof("no project metadata found at path '%s', project metadata will not be exported\n", projectMetadataPath)
 	}
 
 	if e.runImageRef == "" {
@@ -215,7 +223,7 @@ func (e *exportCmd) Exec() error {
 		},
 	}
 
-	if err := exporter.Export(e.layersDir, e.appDir, appImage, runImageID.String(), analyzedMD.Metadata, e.imageNames[1:], launcherConfig, stackMD); err != nil {
+	if err := exporter.Export(e.layersDir, e.appDir, appImage, runImageID.String(), analyzedMD.Metadata, e.imageNames[1:], launcherConfig, stackMD, projectMD); err != nil {
 		if _, isSaveError := err.(*imgutil.SaveError); isSaveError {
 			return cmd.FailErrCode(err, cmd.CodeFailedSave, "export")
 		}

--- a/exporter.go
+++ b/exporter.go
@@ -55,6 +55,7 @@ func (e *Exporter) Export(
 	additionalNames []string,
 	launcherConfig LauncherConfig,
 	stack StackMetadata,
+	project ProjectMetadata,
 ) error {
 	var err error
 
@@ -175,6 +176,14 @@ func (e *Exporter) Export(
 	}
 	if err := workingImage.SetLabel(BuildMetadataLabel, string(buildJSON)); err != nil {
 		return errors.Wrap(err, "set build image metadata label")
+	}
+
+	projectJSON, err := json.Marshal(project)
+	if err != nil {
+		return errors.Wrap(err, "parse project metadata")
+	}
+	if err := workingImage.SetLabel(ProjectMetadataLabel, string(projectJSON)); err != nil {
+		return errors.Wrap(err, "set project metadata label")
 	}
 
 	if err = workingImage.SetEnv(cmd.EnvLayersDir, layersDir); err != nil {

--- a/project_metadata.go
+++ b/project_metadata.go
@@ -1,0 +1,16 @@
+package lifecycle
+
+const (
+	ProjectMetadataLabel    = "io.buildpacks.project"
+	ProjectMetadataFileName = "project-metadata.toml"
+)
+
+type ProjectMetadata struct {
+	Source ProjectSource `toml:"source" json:"source"`
+}
+
+type ProjectSource struct {
+	Type     string                 `toml:"type" json:"type"`
+	Version  map[string]interface{} `toml:"version" json:"version"`
+	Metadata map[string]interface{} `toml:"metadata" json:"metadata"`
+}

--- a/project_metadata.go
+++ b/project_metadata.go
@@ -1,8 +1,7 @@
 package lifecycle
 
 const (
-	ProjectMetadataLabel    = "io.buildpacks.project"
-	ProjectMetadataFileName = "project-metadata.toml"
+	ProjectMetadataLabel = "io.buildpacks.project"
 )
 
 type ProjectMetadata struct {


### PR DESCRIPTION
Implements https://github.com/buildpacks/spec/pull/68

- Adds ProjectMetadataPath flag to Export command
- ~~If flag is not provided,~~ sets default path to "./project-metadata.toml"
- If project metadata path is not present or cannot be unmarshalled, it logs for info and
continues
- Provides types for ProjectMetadata ~~, and Git source code~~
- Amends Export method parameters to include ProjectMetadata
- Tests provided for Export method for context when Project Metadata is
provided

[#170698084]