### PR TITLE
Faster Untar

### DIFF
--- a/archive/tar.go
+++ b/archive/tar.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func WriteFilesToTar(dest string, uid, gid int, files ...string) (string, map[string]struct{}, error) {
@@ -220,6 +222,13 @@ type PathMode struct {
 }
 
 func Untar(r io.Reader, dest string) error {
+	// Avoid umask from changing the file permissions in the tar file.
+	old := unix.Umask(0)
+	defer unix.Umask(old)
+
+	buf := make([]byte, 32*32*1024)
+	dirsFound := make(map[string]bool)
+
 	tr := tar.NewReader(r)
 	var pathModes []PathMode
 	for {
@@ -247,18 +256,20 @@ func Untar(r io.Reader, dest string) error {
 			if err := os.MkdirAll(path, os.ModePerm); err != nil {
 				return err
 			}
+			dirsFound[path] = true
+
 		case tar.TypeReg, tar.TypeRegA:
-			_, err := os.Stat(filepath.Dir(path))
-			if os.IsNotExist(err) {
-				if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
-					return err
+			dirPath := filepath.Dir(path)
+			if !dirsFound[dirPath] {
+				if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+					if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+						return err
+					}
+					dirsFound[dirPath] = true
 				}
 			}
-			if err := writeFile(tr, path, hdr.FileInfo().Mode()); err != nil {
-				return err
-			}
-			// Update permissions in case umask was applied.
-			if err := os.Chmod(path, hdr.FileInfo().Mode()); err != nil {
+
+			if err := writeFile(tr, path, hdr.FileInfo().Mode(), buf); err != nil {
 				return err
 			}
 		case tar.TypeSymlink:
@@ -271,12 +282,12 @@ func Untar(r io.Reader, dest string) error {
 	}
 }
 
-func writeFile(in io.Reader, path string, mode os.FileMode) error {
+func writeFile(in io.Reader, path string, mode os.FileMode, buf []byte) error {
 	fh, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
 	defer fh.Close()
-	_, err = io.Copy(fh, in)
+	_, err = io.CopyBuffer(fh, in, buf)
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/sclevine/spec v1.4.0
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sys v0.0.0-20191010194322-b09406accb47
 	google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8 // indirect
 )
 


### PR DESCRIPTION
 + Avoid changing file permissions two times
 + Reuse the copy buffer
 + Don’t check if a folder exists if we just created it

On my Mac, with a 1.2G tarball (go-build cache folder), this takes consistently around 4.5s rather than consistently around 6s.
It’s harder to test with a cold fs cache, though.

Signed-off-by: David Gageot <david@gageot.net>