### PR TITLE
Faster sha256 computation

### DIFF
--- a/archive/digest.go
+++ b/archive/digest.go
@@ -1,0 +1,46 @@
+package archive
+
+import (
+	"hash"
+	"sync"
+)
+
+// concurrentHasher wraps a hash.Hash so that writes to it
+// happen on a separate go routine.
+type concurrentHasher struct {
+	hash    hash.Hash
+	wg      sync.WaitGroup
+	buffers chan []byte
+}
+
+func newConcurrentHasher(h hash.Hash) *concurrentHasher {
+	ch := &concurrentHasher{
+		hash:    h,
+		buffers: make(chan []byte, 10),
+	}
+
+	go func() {
+		for b := range ch.buffers {
+			_, _ = ch.hash.Write(b)
+			ch.wg.Done()
+		}
+	}()
+
+	return ch
+}
+
+func (ch *concurrentHasher) Write(p []byte) (int, error) {
+	cp := make([]byte, len(p))
+	copy(cp, p)
+
+	ch.wg.Add(1)
+	ch.buffers <- cp
+
+	return len(p), nil
+}
+
+func (ch *concurrentHasher) Sum(b []byte) []byte {
+	ch.wg.Wait()
+	close(ch.buffers)
+	return ch.hash.Sum(b)
+}

--- a/archive/digest_test.go
+++ b/archive/digest_test.go
@@ -1,0 +1,23 @@
+package archive
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+func TestConcurrentHasher(t *testing.T) {
+	msg := []byte("Some important message")
+
+	hasher := sha256.New()
+	hasher.Write(msg)
+	digest := hex.EncodeToString(hasher.Sum(nil))
+
+	cHasher := newConcurrentHasher(sha256.New())
+	cHasher.Write(msg)
+	cDigest := hex.EncodeToString(cHasher.Sum(nil))
+
+	if digest != cDigest {
+		t.Fatalf(`both digests should be the same, got %s and %s`, digest, cDigest)
+	}
+}


### PR DESCRIPTION
The computation of the sh256 digest is now done concurrently to the tarball creation.
This gives a 30% boost on my tests (with a hot cache)

Signed-off-by: David Gageot <david@gageot.net>