### PR TITLE
Add make package targets for windows and darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ all: test build package
 build: build-linux build-windows
 
 build-linux: export GOOS:=linux
-build-linux: export OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
+build-linux: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
 build-linux:
 	@echo "> Building for linux..."
 	mkdir -p $(OUT_DIR)
@@ -45,7 +45,7 @@ build-linux:
 	ln -sf lifecycle $(OUT_DIR)/rebaser
 
 build-windows: export GOOS:=windows
-build-windows: export OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
+build-windows: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
 build-windows:
 	@echo "> Building for windows..."
 	mkdir -p $(OUT_DIR)
@@ -58,7 +58,7 @@ build-windows:
 	ln -sf lifecycle.exe $(OUT_DIR)/rebaser.exe
 
 build-darwin: export GOOS:=darwin
-build-darwin: export OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
+build-darwin: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
 build-darwin:
 	@echo "> Building for macos..."
 	mkdir -p $(OUT_DIR)
@@ -141,18 +141,6 @@ package-windows: GOOS:=windows
 package-windows: GOOS_DIR:=$(BUILD_DIR)/$(GOOS)
 package-windows: ARCHIVE_NAME=lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64
 package-windows:
-	@echo "> Writing descriptor file for $(GOOS)..."
-	mkdir -p $(GOOS_DIR)
-	echo "$${LIFECYCLE_DESCRIPTOR}" > $(GOOS_DIR)/lifecycle.toml
-
-	@echo "> Packaging lifecycle for $(GOOS)..."
-	tar czf $(BUILD_DIR)/$(ARCHIVE_NAME).tgz -C $(GOOS_DIR) lifecycle.toml lifecycle
-
-package-darwin: export LIFECYCLE_DESCRIPTOR:=$(LIFECYCLE_DESCRIPTOR)
-package-darwin: GOOS:=darwin
-package-darwin: GOOS_DIR:=$(BUILD_DIR)/$(GOOS)
-package-darwin: ARCHIVE_NAME=lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64
-package-darwin:
 	@echo "> Writing descriptor file for $(GOOS)..."
 	mkdir -p $(GOOS_DIR)
 	echo "$${LIFECYCLE_DESCRIPTOR}" > $(GOOS_DIR)/lifecycle.toml

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ clean:
 
 package: package-linux package-windows
 
+package-linux: export LIFECYCLE_DESCRIPTOR:=$(LIFECYCLE_DESCRIPTOR)
 package-linux: GOOS:=linux
 package-linux: GOOS_DIR:=$(BUILD_DIR)/$(GOOS)
 package-linux: ARCHIVE_NAME=lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64
@@ -135,6 +136,7 @@ package-linux:
 	@echo "> Packaging lifecycle for $(GOOS)..."
 	tar czf $(BUILD_DIR)/$(ARCHIVE_NAME).tgz -C $(GOOS_DIR) lifecycle.toml lifecycle
 
+package-windows: export LIFECYCLE_DESCRIPTOR:=$(LIFECYCLE_DESCRIPTOR)
 package-windows: GOOS:=windows
 package-windows: GOOS_DIR:=$(BUILD_DIR)/$(GOOS)
 package-windows: ARCHIVE_NAME=lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64
@@ -146,6 +148,7 @@ package-windows:
 	@echo "> Packaging lifecycle for $(GOOS)..."
 	tar czf $(BUILD_DIR)/$(ARCHIVE_NAME).tgz -C $(GOOS_DIR) lifecycle.toml lifecycle
 
+package-darwin: export LIFECYCLE_DESCRIPTOR:=$(LIFECYCLE_DESCRIPTOR)
 package-darwin: GOOS:=darwin
 package-darwin: GOOS_DIR:=$(BUILD_DIR)/$(GOOS)
 package-darwin: ARCHIVE_NAME=lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ make test
 
 ### Build
 
-Builds binaries to `out/lifecycle/`.
+Builds binaries to `out/linux/lifecycle/`.
 
 ```bash
 $ make build
@@ -65,7 +65,7 @@ $ make build
 ### Package
 
 Creates an archive at `out/lifecycle-<LIFECYCLE_VERSION>+linux.x86-64.tgz`, using the contents of the
-`out/lifecycle/` directory, for the given (or default) `LIFECYCLE_VERSION`.
+`out/linux/lifecycle/` directory, for the given (or default) `LIFECYCLE_VERSION`.
 
 ```bash
 $ make package

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -154,7 +154,7 @@ func testAcceptance(t *testing.T, when spec.G, it spec.S) {
 }
 
 func lifecycleCmd(binary string, args ...string) *exec.Cmd {
-	return exec.Command(filepath.Join(buildDir, "lifecycle", binary), args...)
+	return exec.Command(filepath.Join(buildDir, runtime.GOOS, "lifecycle", binary), args...)
 }
 
 func buildBinaries(t *testing.T, dir string) {

--- a/archive/tar.go
+++ b/archive/tar.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 func WriteFilesToTar(dest string, uid, gid int, files ...string) (string, map[string]struct{}, error) {
@@ -223,8 +221,8 @@ type PathMode struct {
 
 func Untar(r io.Reader, dest string) error {
 	// Avoid umask from changing the file permissions in the tar file.
-	umask := unix.Umask(0)
-	defer unix.Umask(umask)
+	umask := setUmask(0)
+	defer setUmask(umask)
 
 	buf := make([]byte, 32*32*1024)
 	dirsFound := make(map[string]bool)

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -1,0 +1,11 @@
+// +build linux darwin
+
+package archive
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func setUmask(newMask int) (oldMask int) {
+	return unix.Umask(newMask)
+}

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -1,9 +1,5 @@
-// +build windows
-
 package archive
 
 func setUmask(newMask int) (oldMask int) {
 	panic("Not implemented on Windows")
-
-	return -1
 }

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package archive
+
+func setUmask(newMask int) (oldMask int) {
+	panic("Not implemented on Windows")
+
+	return -1
+}


### PR DESCRIPTION
We made the minimal source changes to cross-compile on Windows.

Resolves #234

## Note:
This does not yet make any lifecycle functionality work on Windows but also does not change Linux functionality. This only allows `make build-windows package-windows` to create lifecycle tarballs containing actual `.exe` files.

Additional Issues will iteratively add Windows functionality to lifecycle. See upcoming issues: https://github.com/buildpacks/lifecycle/issues?q=is%3Aissue+is%3Aopen+label%3Aos%2Fwindows