### PR TITLE
Default process type flag

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -139,6 +139,10 @@ func FlagProjectMetadataPath(projectMetadataPath *string) {
 	flagSet.StringVar(projectMetadataPath, "project-metadata", envOrDefault(EnvProjectMetadataPath, DefaultProjectMetadataPath), "path to project-metadata.toml")
 }
 
+func FlagProcessType(processType *string) {
+	flagSet.StringVar(processType, "process-type", os.Getenv(EnvProcessType), "default process type")
+}
+
 func intEnv(k string) int {
 	v := os.Getenv(k)
 	d, err := strconv.Atoi(v)

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -37,6 +37,7 @@ type exportCmd struct {
 	cacheImageTag       string
 	cacheDir            string
 	projectMetadataPath string
+	processType         string
 }
 
 func (e *exportCmd) Init() {
@@ -55,6 +56,7 @@ func (e *exportCmd) Init() {
 	cmd.FlagCacheImage(&e.cacheImageTag)
 	cmd.FlagCacheDir(&e.cacheDir)
 	cmd.FlagProjectMetadataPath(&e.projectMetadataPath)
+	cmd.FlagProcessType(&e.processType)
 }
 
 func (e *exportCmd) Args(nargs int, args []string) error {
@@ -227,15 +229,16 @@ func (e *exportCmd) Exec() error {
 	}
 
 	if err := exporter.Export(lifecycle.ExportOptions{
-		LayersDir:       e.layersDir,
-		AppDir:          e.appDir,
-		WorkingImage:    appImage,
-		RunImageRef:     runImageID.String(),
-		OrigMetadata:    analyzedMD.Metadata,
-		AdditionalNames: e.imageNames,
-		LauncherConfig:  launcherConfig,
-		Stack:           stackMD,
-		Project:         projectMD,
+		LayersDir:          e.layersDir,
+		AppDir:             e.appDir,
+		WorkingImage:       appImage,
+		RunImageRef:        runImageID.String(),
+		OrigMetadata:       analyzedMD.Metadata,
+		AdditionalNames:    e.imageNames,
+		LauncherConfig:     launcherConfig,
+		Stack:              stackMD,
+		Project:            projectMD,
+		DefaultProcessType: e.processType,
 	}); err != nil {
 		if _, isSaveError := err.(*imgutil.SaveError); isSaveError {
 			return cmd.FailErrCode(err, cmd.CodeFailedSave, "export")

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -226,7 +226,17 @@ func (e *exportCmd) Exec() error {
 		},
 	}
 
-	if err := exporter.Export(e.layersDir, e.appDir, appImage, runImageID.String(), analyzedMD.Metadata, e.imageNames[1:], launcherConfig, stackMD, projectMD); err != nil {
+	if err := exporter.Export(lifecycle.ExportOptions{
+		LayersDir:       e.layersDir,
+		AppDir:          e.appDir,
+		WorkingImage:    appImage,
+		RunImageRef:     runImageID.String(),
+		OrigMetadata:    analyzedMD.Metadata,
+		AdditionalNames: e.imageNames,
+		LauncherConfig:  launcherConfig,
+		Stack:           stackMD,
+		Project:         projectMD,
+	}); err != nil {
 		if _, isSaveError := err.(*imgutil.SaveError); isSaveError {
 			return cmd.FailErrCode(err, cmd.CodeFailedSave, "export")
 		}

--- a/exporter.go
+++ b/exporter.go
@@ -46,58 +46,60 @@ type SliceLayer struct {
 	SHA     string
 }
 
-func (e *Exporter) Export(
-	layersDir,
-	appDir string,
-	workingImage imgutil.Image,
-	runImageRef string,
-	origMetadata LayersMetadata,
-	additionalNames []string,
-	launcherConfig LauncherConfig,
-	stack StackMetadata,
-	project ProjectMetadata,
-) error {
+type ExportOptions struct {
+	LayersDir       string
+	AppDir          string
+	WorkingImage    imgutil.Image
+	RunImageRef     string
+	OrigMetadata    LayersMetadata
+	AdditionalNames []string
+	LauncherConfig  LauncherConfig
+	Stack           StackMetadata
+	Project         ProjectMetadata
+}
+
+func (e *Exporter) Export(opts ExportOptions) error {
 	var err error
 
-	layersDir, err = filepath.Abs(layersDir)
+	opts.LayersDir, err = filepath.Abs(opts.LayersDir)
 	if err != nil {
 		return errors.Wrapf(err, "layers dir absolute path")
 	}
 
-	appDir, err = filepath.Abs(appDir)
+	opts.AppDir, err = filepath.Abs(opts.AppDir)
 	if err != nil {
 		return errors.Wrapf(err, "app dir absolute path")
 	}
 
 	meta := LayersMetadata{}
-	meta.RunImage.TopLayer, err = workingImage.TopLayer()
+	meta.RunImage.TopLayer, err = opts.WorkingImage.TopLayer()
 	if err != nil {
 		return errors.Wrap(err, "get run image top layer SHA")
 	}
 
-	meta.RunImage.Reference = runImageRef
-	meta.Stack = stack
+	meta.RunImage.Reference = opts.RunImageRef
+	meta.Stack = opts.Stack
 
 	buildMD := &BuildMetadata{}
-	if _, err := toml.DecodeFile(MetadataFilePath(layersDir), buildMD); err != nil {
+	if _, err := toml.DecodeFile(MetadataFilePath(opts.LayersDir), buildMD); err != nil {
 		return errors.Wrap(err, "read build metadata")
 	}
 
 	// creating app layers (slices + app dir)
-	appSlices, err := e.createAppSliceLayers(appDir, buildMD.Slices)
+	appSlices, err := e.createAppSliceLayers(opts.AppDir, buildMD.Slices)
 	if err != nil {
 		return errors.Wrap(err, "creating app layers")
 	}
 
 	// launcher
-	meta.Launcher.SHA, err = e.addOrReuseLayer(workingImage, &layer{path: launcherConfig.Path, identifier: "launcher"}, origMetadata.Launcher.SHA)
+	meta.Launcher.SHA, err = e.addOrReuseLayer(opts.WorkingImage, &layer{path: opts.LauncherConfig.Path, identifier: "launcher"}, opts.OrigMetadata.Launcher.SHA)
 	if err != nil {
 		return errors.Wrap(err, "exporting launcher layer")
 	}
 
 	// layers
 	for _, bp := range e.Buildpacks {
-		bpDir, err := readBuildpackLayersDir(layersDir, bp)
+		bpDir, err := readBuildpackLayersDir(opts.LayersDir, bp)
 		if err != nil {
 			return errors.Wrapf(err, "reading layers for buildpack '%s'", bp.ID)
 		}
@@ -115,8 +117,8 @@ func (e *Exporter) Export(
 			}
 
 			if layer.hasLocalContents() {
-				origLayerMetadata := origMetadata.MetadataForBuildpack(bp.ID).Layers[layer.name()]
-				lmd.SHA, err = e.addOrReuseLayer(workingImage, &layer, origLayerMetadata.SHA)
+				origLayerMetadata := opts.OrigMetadata.MetadataForBuildpack(bp.ID).Layers[layer.name()]
+				lmd.SHA, err = e.addOrReuseLayer(opts.WorkingImage, &layer, origLayerMetadata.SHA)
 				if err != nil {
 					return err
 				}
@@ -124,14 +126,14 @@ func (e *Exporter) Export(
 				if lmd.Cache {
 					return fmt.Errorf("layer '%s' is cache=true but has no contents", layer.Identifier())
 				}
-				origLayerMetadata, ok := origMetadata.MetadataForBuildpack(bp.ID).Layers[layer.name()]
+				origLayerMetadata, ok := opts.OrigMetadata.MetadataForBuildpack(bp.ID).Layers[layer.name()]
 				if !ok {
 					return fmt.Errorf("cannot reuse '%s', previous image has no metadata for layer '%s'", layer.Identifier(), layer.Identifier())
 				}
 
 				e.Logger.Infof("Reusing layer '%s'\n", layer.Identifier())
 				e.Logger.Debugf("Layer '%s' SHA: %s\n", layer.Identifier(), origLayerMetadata.SHA)
-				if err := workingImage.ReuseLayer(origLayerMetadata.SHA); err != nil {
+				if err := opts.WorkingImage.ReuseLayer(origLayerMetadata.SHA); err != nil {
 					return errors.Wrapf(err, "reusing layer: '%s'", layer.Identifier())
 				}
 				lmd.SHA = origLayerMetadata.SHA
@@ -150,13 +152,13 @@ func (e *Exporter) Export(
 	}
 
 	// app
-	meta.App, err = e.addSliceLayers(workingImage, appSlices, origMetadata.App)
+	meta.App, err = e.addSliceLayers(opts.WorkingImage, appSlices, opts.OrigMetadata.App)
 	if err != nil {
 		return errors.Wrap(err, "exporting slice layers")
 	}
 
 	// config
-	meta.Config.SHA, err = e.addOrReuseLayer(workingImage, &layer{path: filepath.Join(layersDir, "config"), identifier: "config"}, origMetadata.Config.SHA)
+	meta.Config.SHA, err = e.addOrReuseLayer(opts.WorkingImage, &layer{path: filepath.Join(opts.LayersDir, "config"), identifier: "config"}, opts.OrigMetadata.Config.SHA)
 	if err != nil {
 		return errors.Wrap(err, "exporting config layer")
 	}
@@ -166,44 +168,44 @@ func (e *Exporter) Export(
 		return errors.Wrap(err, "marshall metadata")
 	}
 
-	if err = workingImage.SetLabel(LayerMetadataLabel, string(data)); err != nil {
+	if err = opts.WorkingImage.SetLabel(LayerMetadataLabel, string(data)); err != nil {
 		return errors.Wrap(err, "set app image metadata label")
 	}
 
-	buildMD.Launcher = launcherConfig.Metadata
+	buildMD.Launcher = opts.LauncherConfig.Metadata
 	buildJSON, err := json.Marshal(buildMD)
 	if err != nil {
 		return errors.Wrap(err, "parse build metadata")
 	}
-	if err := workingImage.SetLabel(BuildMetadataLabel, string(buildJSON)); err != nil {
+	if err := opts.WorkingImage.SetLabel(BuildMetadataLabel, string(buildJSON)); err != nil {
 		return errors.Wrap(err, "set build image metadata label")
 	}
 
-	projectJSON, err := json.Marshal(project)
+	projectJSON, err := json.Marshal(opts.Project)
 	if err != nil {
 		return errors.Wrap(err, "parse project metadata")
 	}
-	if err := workingImage.SetLabel(ProjectMetadataLabel, string(projectJSON)); err != nil {
+	if err := opts.WorkingImage.SetLabel(ProjectMetadataLabel, string(projectJSON)); err != nil {
 		return errors.Wrap(err, "set project metadata label")
 	}
 
-	if err = workingImage.SetEnv(cmd.EnvLayersDir, layersDir); err != nil {
+	if err = opts.WorkingImage.SetEnv(cmd.EnvLayersDir, opts.LayersDir); err != nil {
 		return errors.Wrapf(err, "set app image env %s", cmd.EnvLayersDir)
 	}
 
-	if err = workingImage.SetEnv(cmd.EnvAppDir, appDir); err != nil {
+	if err = opts.WorkingImage.SetEnv(cmd.EnvAppDir, opts.AppDir); err != nil {
 		return errors.Wrapf(err, "set app image env %s", cmd.EnvAppDir)
 	}
 
-	if err = workingImage.SetEntrypoint(launcherConfig.Path); err != nil {
+	if err = opts.WorkingImage.SetEntrypoint(opts.LauncherConfig.Path); err != nil {
 		return errors.Wrap(err, "setting entrypoint")
 	}
 
-	if err = workingImage.SetCmd(); err != nil { // Note: Command intentionally empty
+	if err = opts.WorkingImage.SetCmd(); err != nil { // Note: Command intentionally empty
 		return errors.Wrap(err, "setting cmd")
 	}
 
-	return saveImage(workingImage, additionalNames, e.Logger)
+	return saveImage(opts.WorkingImage, opts.AdditionalNames, e.Logger)
 }
 
 func (e *Exporter) Cache(layersDir string, cacheStore Cache) error {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -35,19 +35,16 @@ func TestExporter(t *testing.T) {
 
 func testExporter(t *testing.T, when spec.G, it spec.S) {
 	var (
-		exporter        *lifecycle.Exporter
-		fakeAppImage    *fakes.Image
-		layersDir       string
-		tmpDir          string
-		appDir          string
-		launcherConfig  lifecycle.LauncherConfig
-		uid             = 1234
-		gid             = 4321
-		stack           = lifecycle.StackMetadata{}
-		project         = lifecycle.ProjectMetadata{}
-		additionalNames []string
-		runImageRef     = "run-image-reference"
-		logHandler      = memory.New()
+		exporter     *lifecycle.Exporter
+		tmpDir       string
+		fakeAppImage *fakes.Image
+		uid          = 1234
+		gid          = 4321
+		logHandler   = memory.New()
+		opts         = lifecycle.ExportOptions{
+			RunImageRef:     "run-image-reference",
+			AdditionalNames: []string{},
+		}
 	)
 
 	it.Before(func() {
@@ -57,7 +54,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 		launcherPath, err := filepath.Abs(filepath.Join("testdata", "exporter", "launcher"))
 		h.AssertNil(t, err)
 
-		launcherConfig = lifecycle.LauncherConfig{
+		opts.LauncherConfig = lifecycle.LauncherConfig{
 			Path: launcherPath,
 			Metadata: lifecycle.LauncherMetadata{
 				Version: "1.2.3",
@@ -70,8 +67,8 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 			},
 		}
 
-		layersDir = filepath.Join(tmpDir, "layers")
-		h.AssertNil(t, os.Mkdir(layersDir, 0777))
+		opts.LayersDir = filepath.Join(tmpDir, "layers")
+		h.AssertNil(t, os.Mkdir(opts.LayersDir, 0777))
 		h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "launcher"), []byte("some-launcher"), 0777))
 
 		fakeAppImage = fakes.NewImage(
@@ -81,8 +78,9 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				ImageID: "some-image-id",
 			},
 		)
+		opts.WorkingImage = fakeAppImage
 
-		additionalNames = []string{"some-repo/app-image:foo", "some-repo/app-image:bar"}
+		opts.AdditionalNames = []string{"some-repo/app-image:foo", "some-repo/app-image:bar"}
 
 		exporter = &lifecycle.Exporter{
 			ArtifactsDir: tmpDir,
@@ -104,31 +102,30 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 	when("#Export", func() {
 		when("previous slice image exists", func() {
 			var (
-				fakeOriginalImage *fakes.Image
-				fakeImageMetadata lifecycle.LayersMetadata
-				sliceSHA          string
+				sliceSHA string
 			)
 
 			it.Before(func() {
 				var err error
 
 				// LayersDir is a tmp directory
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "app-slices", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "app-slices", "layers"), opts.LayersDir)
 
-				appDir, err = filepath.Abs(filepath.Join(layersDir, "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join(opts.LayersDir, "app"))
 				h.AssertNil(t, err)
 
-				sliceConfigFilePath := filepath.Join(appDir, "static", "assets", "config.txt")
-				sliceSvgFilePath := filepath.Join(appDir, "static", "assets", "logo.svg")
+				sliceConfigFilePath := filepath.Join(opts.AppDir, "static", "assets", "config.txt")
+				sliceSvgFilePath := filepath.Join(opts.AppDir, "static", "assets", "logo.svg")
 
-				localReusableLayerPath := filepath.Join(layersDir, "other.buildpack.id/local-reusable-layer")
+				localReusableLayerPath := filepath.Join(opts.LayersDir, "other.buildpack.id/local-reusable-layer")
 				localReusableLayerSha := h.ComputeSHA256ForPath(t, localReusableLayerPath, uid, gid)
-				launcherSHA := h.ComputeSHA256ForPath(t, launcherConfig.Path, uid, gid)
-				sliceSHA = h.ComputeSHA256ForFiles(t, filepath.Join(layersDir, "slice-test.tar"), uid, gid, sliceConfigFilePath, sliceSvgFilePath)
+				launcherSHA := h.ComputeSHA256ForPath(t, opts.LauncherConfig.Path, uid, gid)
+				sliceSHA = h.ComputeSHA256ForFiles(t, filepath.Join(opts.LayersDir, "slice-test.tar"), uid, gid, sliceConfigFilePath, sliceSvgFilePath)
 
-				fakeOriginalImage = fakes.NewImage("app/original-image", "original-top-layer-sha",
+				fakeOriginalImage := fakes.NewImage("app/original-image", "original-top-layer-sha",
 					local.IDIdentifier{ImageID: "some-original-run-image-digest"},
 				)
+				defer fakeOriginalImage.Cleanup()
 				fakeAppImage.AddPreviousLayer("sha256:"+localReusableLayerSha, "")
 				fakeAppImage.AddPreviousLayer("sha256:"+launcherSHA, "")
 				fakeAppImage.AddPreviousLayer("sha256:orig-launch-layer-no-local-dir-sha", "")
@@ -174,26 +171,22 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
    }
 }`, sliceSHA, localReusableLayerSha, launcherSHA)))
 
-				h.AssertNil(t, lifecycle.DecodeLabel(fakeOriginalImage, lifecycle.LayerMetadataLabel, &fakeImageMetadata))
-			})
-
-			it.After(func() {
-				fakeOriginalImage.Cleanup()
+				h.AssertNil(t, lifecycle.DecodeLabel(fakeOriginalImage, lifecycle.LayerMetadataLabel, &opts.OrigMetadata))
 			})
 
 			it("reuses slice layer if the sha matches the sha in the archive metadata", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				sliceLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, "static", "misc", "resources", "reports", "report.tps"))
+				sliceLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, "static", "misc", "resources", "reports", "report.tps"))
 				h.AssertNil(t, err)
 
-				assertTarFileExists(t, sliceLayerPath, filepath.Join(appDir, "static", "misc", "resources", "reports", "numbers.csv"), true)
-				assertTarFileExists(t, sliceLayerPath, filepath.Join(appDir, "static", "misc", "resources", "reports", "report.tps"), true)
+				assertTarFileExists(t, sliceLayerPath, filepath.Join(opts.AppDir, "static", "misc", "resources", "reports", "numbers.csv"), true)
+				assertTarFileExists(t, sliceLayerPath, filepath.Join(opts.AppDir, "static", "misc", "resources", "reports", "report.tps"), true)
 
-				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, ".hidden.txt"))
 				h.AssertNil(t, err)
 
-				assertTarFileExists(t, appLayerPath, filepath.Join(appDir, "static", "misc", "resources"), false)
+				assertTarFileExists(t, appLayerPath, filepath.Join(opts.AppDir, "static", "misc", "resources"), false)
 
 				h.AssertContains(t, fakeAppImage.ReusedLayers(), "sha256:"+sliceSHA)
 				assertLogEntry(t, logHandler, "Reusing 1/4 app layer(s)")
@@ -202,25 +195,21 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("previous image exists", func() {
-			var (
-				fakeOriginalImage *fakes.Image
-				fakeImageMetadata lifecycle.LayersMetadata
-			)
-
 			it.Before(func() {
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "previous-image-exists", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "previous-image-exists", "layers"), opts.LayersDir)
 
 				var err error
-				appDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "previous-image-exists", "layers", "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "previous-image-exists", "layers", "app"))
 				h.AssertNil(t, err)
 
-				localReusableLayerPath := filepath.Join(layersDir, "other.buildpack.id/local-reusable-layer")
+				localReusableLayerPath := filepath.Join(opts.LayersDir, "other.buildpack.id/local-reusable-layer")
 				localReusableLayerSha := h.ComputeSHA256ForPath(t, localReusableLayerPath, uid, gid)
-				launcherSHA := h.ComputeSHA256ForPath(t, launcherConfig.Path, uid, gid)
+				launcherSHA := h.ComputeSHA256ForPath(t, opts.LauncherConfig.Path, uid, gid)
 
-				fakeOriginalImage = fakes.NewImage("app/original-image", "original-top-layer-sha",
+				fakeOriginalImage := fakes.NewImage("app/original-image", "original-top-layer-sha",
 					local.IDIdentifier{ImageID: "some-original-run-image-digest"},
 				)
+				defer fakeOriginalImage.Cleanup()
 				fakeAppImage.AddPreviousLayer("sha256:"+localReusableLayerSha, "")
 				fakeAppImage.AddPreviousLayer("sha256:"+launcherSHA, "")
 				fakeAppImage.AddPreviousLayer("sha256:orig-launch-layer-no-local-dir-sha", "")
@@ -260,120 +249,116 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
    }
 }`, localReusableLayerSha, launcherSHA)))
 
-				h.AssertNil(t, lifecycle.DecodeLabel(fakeOriginalImage, lifecycle.LayerMetadataLabel, &fakeImageMetadata))
-			})
-
-			it.After(func() {
-				fakeOriginalImage.Cleanup()
+				h.AssertNil(t, lifecycle.DecodeLabel(fakeOriginalImage, lifecycle.LayerMetadataLabel, &opts.OrigMetadata))
 			})
 
 			it("creates app layer on Run image", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, ".hidden.txt"))
 				h.AssertNil(t, err)
 
-				assertTarFileContents(t, appLayerPath, filepath.Join(appDir, ".hidden.txt"), "some-hidden-text\n")
-				assertTarFileOwner(t, appLayerPath, appDir, uid, gid)
+				assertTarFileContents(t, appLayerPath, filepath.Join(opts.AppDir, ".hidden.txt"), "some-hidden-text\n")
+				assertTarFileOwner(t, appLayerPath, opts.AppDir, uid, gid)
 				assertLogEntry(t, logHandler, "Adding 1/1 app layer(s)")
 			})
 
 			it("creates config layer on Run image", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "config", "metadata.toml"))
+				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "config", "metadata.toml"))
 				h.AssertNil(t, err)
 
 				assertTarFileContents(t,
 					configLayerPath,
-					filepath.Join(layersDir, "config", "metadata.toml"),
+					filepath.Join(opts.LayersDir, "config", "metadata.toml"),
 					"[[processes]]\n  type = \"web\"\n  command = \"npm start\"\n",
 				)
-				assertTarFileOwner(t, configLayerPath, filepath.Join(layersDir, "config"), uid, gid)
+				assertTarFileOwner(t, configLayerPath, filepath.Join(opts.LayersDir, "config"), uid, gid)
 				assertAddLayerLog(t, logHandler, "config", configLayerPath)
 			})
 
 			it("reuses launcher layer if the sha matches the sha in the metadata", func() {
-				launcherLayerSHA := h.ComputeSHA256ForPath(t, launcherConfig.Path, uid, gid)
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				launcherLayerSHA := h.ComputeSHA256ForPath(t, opts.LauncherConfig.Path, uid, gid)
+				h.AssertNil(t, exporter.Export(opts))
 				h.AssertContains(t, fakeAppImage.ReusedLayers(), "sha256:"+launcherLayerSHA)
 				assertReuseLayerLog(t, logHandler, "launcher", launcherLayerSHA)
 			})
 
 			it("reuses launch layers when only layer.toml is present", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				h.AssertContains(t, fakeAppImage.ReusedLayers(), "sha256:orig-launch-layer-no-local-dir-sha")
 				assertReuseLayerLog(t, logHandler, "buildpack.id:launch-layer-no-local-dir", "orig-launch-layer-no-local-dir-sha")
 			})
 
 			it("reuses cached launch layers if the local sha matches the sha in the metadata", func() {
-				layer5sha := h.ComputeSHA256ForPath(t, filepath.Join(layersDir, "other.buildpack.id/local-reusable-layer"), uid, gid)
+				layer5sha := h.ComputeSHA256ForPath(t, filepath.Join(opts.LayersDir, "other.buildpack.id/local-reusable-layer"), uid, gid)
 
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				h.AssertContains(t, fakeAppImage.ReusedLayers(), "sha256:"+layer5sha)
 				assertReuseLayerLog(t, logHandler, "other.buildpack.id:local-reusable-layer", layer5sha)
 			})
 
 			it("adds new launch layers", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				layer2Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/new-launch-layer"))
+				layer2Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "buildpack.id/new-launch-layer"))
 				h.AssertNil(t, err)
 
 				assertTarFileContents(t,
 					layer2Path,
-					filepath.Join(layersDir, "buildpack.id/new-launch-layer/file-from-new-launch-layer"),
+					filepath.Join(opts.LayersDir, "buildpack.id/new-launch-layer/file-from-new-launch-layer"),
 					"echo text from layer 2\n")
-				assertTarFileOwner(t, layer2Path, filepath.Join(layersDir, "buildpack.id/new-launch-layer"), uid, gid)
+				assertTarFileOwner(t, layer2Path, filepath.Join(opts.LayersDir, "buildpack.id/new-launch-layer"), uid, gid)
 				assertAddLayerLog(t, logHandler, "buildpack.id:new-launch-layer", layer2Path)
 			})
 
 			it("adds new launch layers from a second buildpack", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				layer3Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "other.buildpack.id/new-launch-layer"))
+				layer3Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "other.buildpack.id/new-launch-layer"))
 				h.AssertNil(t, err)
 
 				assertTarFileContents(t,
 					layer3Path,
-					filepath.Join(layersDir, "other.buildpack.id/new-launch-layer/new-launch-layer-file"),
+					filepath.Join(opts.LayersDir, "other.buildpack.id/new-launch-layer/new-launch-layer-file"),
 					"echo text from new layer\n")
-				assertTarFileOwner(t, layer3Path, filepath.Join(layersDir, "other.buildpack.id/new-launch-layer"), uid, gid)
+				assertTarFileOwner(t, layer3Path, filepath.Join(opts.LayersDir, "other.buildpack.id/new-launch-layer"), uid, gid)
 				assertAddLayerLog(t, logHandler, "other.buildpack.id:new-launch-layer", layer3Path)
 			})
 
 			it("only creates expected layers", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				var applayer, configLayer, layer2, layer3 = 1, 1, 1, 1
 				h.AssertEq(t, fakeAppImage.NumberOfAddedLayers(), applayer+configLayer+layer2+layer3)
 			})
 
 			it("only reuses expected layers", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				var launcherLayer, layer1, layer5 = 1, 1, 1
 				h.AssertEq(t, len(fakeAppImage.ReusedLayers()), launcherLayer+layer1+layer5)
 			})
 
 			it("saves lifecycle metadata with layer info", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, ".hidden.txt"))
 				h.AssertNil(t, err)
 				appLayerSHA := h.ComputeSHA256ForFile(t, appLayerPath)
 
-				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "config", "metadata.toml"))
+				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "config", "metadata.toml"))
 				h.AssertNil(t, err)
 				configLayerSHA := h.ComputeSHA256ForFile(t, configLayerPath)
 
-				newLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/new-launch-layer"))
+				newLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "buildpack.id/new-launch-layer"))
 				h.AssertNil(t, err)
 				newLayerSHA := h.ComputeSHA256ForFile(t, newLayerPath)
 
-				secondBPLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "other.buildpack.id/new-launch-layer"))
+				secondBPLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "other.buildpack.id/new-launch-layer"))
 				h.AssertNil(t, err)
 				secondBPLayerPathSHA := h.ComputeSHA256ForFile(t, secondBPLayerPath)
 
@@ -413,13 +398,13 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("saves run image metadata to the resulting image", func() {
-				stack = lifecycle.StackMetadata{
+				opts.Stack = lifecycle.StackMetadata{
 					RunImage: lifecycle.StackRunImageMetadata{
 						Image:   "some/run",
 						Mirrors: []string{"registry.example.com/some/run", "other.example.com/some/run"},
 					},
 				}
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				metadataJSON, err := fakeAppImage.Label("io.buildpacks.lifecycle.metadata")
 				h.AssertNil(t, err)
@@ -441,7 +426,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 
 			when("metadata.toml is missing bom and has empty process list", func() {
 				it.Before(func() {
-					err := ioutil.WriteFile(filepath.Join(layersDir, "config", "metadata.toml"), []byte(`
+					err := ioutil.WriteFile(filepath.Join(opts.LayersDir, "config", "metadata.toml"), []byte(`
 processes = []
 
 [[buildpacks]]
@@ -458,7 +443,7 @@ version = "4.5.6"
 				})
 
 				it("BOM is null and processes is an empty array in the label", func() {
-					h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+					h.AssertNil(t, exporter.Export(opts))
 
 					metadataJSON, err := fakeAppImage.Label("io.buildpacks.build.metadata")
 					h.AssertNil(t, err)
@@ -494,7 +479,7 @@ version = "4.5.6"
 
 			when("there is a complete metadata.toml", func() {
 				it.Before(func() {
-					err := ioutil.WriteFile(filepath.Join(layersDir, "config", "metadata.toml"), []byte(`
+					err := ioutil.WriteFile(filepath.Join(opts.LayersDir, "config", "metadata.toml"), []byte(`
 [[processes]]
 type = "web"
 direct = true
@@ -535,7 +520,7 @@ type = "Apache-2.0"
 				})
 
 				it("combines metadata.toml with launcher config to create build label", func() {
-					h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+					h.AssertNil(t, exporter.Export(opts))
 
 					metadataJSON, err := fakeAppImage.Label("io.buildpacks.build.metadata")
 					h.AssertNil(t, err)
@@ -605,7 +590,7 @@ type = "Apache-2.0"
 
 			when("there is project metadata", func() {
 				it("saves metadata with project info", func() {
-					fakeProjectMetadata := lifecycle.ProjectMetadata{
+					opts.Project = lifecycle.ProjectMetadata{
 						Source: lifecycle.ProjectSource{
 							Type: "git",
 							Version: map[string]interface{}{
@@ -616,7 +601,7 @@ type = "Apache-2.0"
 								"branch":     "master",
 							},
 						}}
-					h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, fakeProjectMetadata))
+					h.AssertNil(t, exporter.Export(opts))
 
 					projectJSON, err := fakeAppImage.Label("io.buildpacks.project.metadata")
 					h.AssertNil(t, err)
@@ -627,36 +612,36 @@ type = "Apache-2.0"
 					}
 
 					t.Log("adds project metadata to label")
-					h.AssertEq(t, projectMD, fakeProjectMetadata)
+					h.AssertEq(t, projectMD, opts.Project)
 				})
 			})
 
 			it("sets CNB_LAYERS_DIR", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Env("CNB_LAYERS_DIR")
 				h.AssertNil(t, err)
-				h.AssertEq(t, val, layersDir)
+				h.AssertEq(t, val, opts.LayersDir)
 			})
 
 			it("sets CNB_APP_DIR", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				val, err := fakeAppImage.Env("CNB_APP_DIR")
+				val, err := opts.WorkingImage.Env("CNB_APP_DIR")
 				h.AssertNil(t, err)
-				h.AssertEq(t, val, appDir)
+				h.AssertEq(t, val, opts.AppDir)
 			})
 
 			it("sets ENTRYPOINT to launcher", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Entrypoint()
 				h.AssertNil(t, err)
-				h.AssertEq(t, val, []string{launcherConfig.Path})
+				h.AssertEq(t, val, []string{opts.LauncherConfig.Path})
 			})
 
 			it("sets empty CMD", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Cmd()
 				h.AssertNil(t, err)
@@ -664,7 +649,7 @@ type = "Apache-2.0"
 			})
 
 			it("saves run image", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				h.AssertEq(t, fakeAppImage.IsSaved(), true)
 			})
@@ -681,7 +666,7 @@ type = "Apache-2.0"
 				})
 
 				it("outputs the digest", func() {
-					h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+					h.AssertNil(t, exporter.Export(opts))
 
 					assertLogEntry(t, logHandler, `*** Digest: `+fakeRemoteDigest)
 				})
@@ -689,87 +674,76 @@ type = "Apache-2.0"
 
 			when("image has an ID identifier", func() {
 				it("outputs the image ID", func() {
-					h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+					h.AssertNil(t, exporter.Export(opts))
 
 					assertLogEntry(t, logHandler, `*** Image ID: some-image-id`)
 				})
 			})
 
 			it("outputs image names", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				assertLogEntry(t, logHandler, `*** Images (some-image-i):`)
 				assertLogEntry(t, logHandler, fakeAppImage.Name())
-				assertLogEntry(t, logHandler, additionalNames[0])
-				assertLogEntry(t, logHandler, additionalNames[1])
+				assertLogEntry(t, logHandler, opts.AdditionalNames[0])
+				assertLogEntry(t, logHandler, opts.AdditionalNames[1])
 			})
 
 			when("one of the additional names fails", func() {
 				it("outputs identifier and image name with error", func() {
 					failingName := "not.a.tag@reference"
+					opts.AdditionalNames = append(opts.AdditionalNames, failingName)
 
-					err := exporter.Export(
-						layersDir,
-						appDir,
-						fakeAppImage,
-						runImageRef,
-						fakeImageMetadata,
-						append(additionalNames, failingName),
-						launcherConfig,
-						stack,
-						project,
-					)
+					err := exporter.Export(opts)
 
 					h.AssertError(t, err, fmt.Sprintf("failed to write image to the following tags: [%s:", failingName))
 
 					assertLogEntry(t, logHandler, `*** Images (some-image-i):`)
 					assertLogEntry(t, logHandler, fakeAppImage.Name())
-					assertLogEntry(t, logHandler, additionalNames[0])
-					assertLogEntry(t, logHandler, additionalNames[1])
+					assertLogEntry(t, logHandler, opts.AdditionalNames[0])
+					assertLogEntry(t, logHandler, opts.AdditionalNames[1])
 					assertLogEntry(t, logHandler, fmt.Sprintf("%s - could not parse reference", failingName))
 				})
 			})
 
 			when("previous image metadata is missing buildpack for reused layer", func() {
-				var incompleteMetadata lifecycle.LayersMetadata
-
 				it.Before(func() {
-					h.AssertNil(t, fakeOriginalImage.SetLabel("io.buildpacks.lifecycle.metadata", `{"buildpacks":[{}]}`))
-					h.AssertNil(t, lifecycle.DecodeLabel(fakeOriginalImage, lifecycle.LayerMetadataLabel, &incompleteMetadata))
+					opts.OrigMetadata = lifecycle.LayersMetadata{
+						Buildpacks: []lifecycle.BuildpackLayersMetadata{{}},
+					}
 				})
 
 				it("returns an error", func() {
 					h.AssertError(
 						t,
-						exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, incompleteMetadata, additionalNames, launcherConfig, stack, project),
+						exporter.Export(opts),
 						"cannot reuse 'buildpack.id:launch-layer-no-local-dir', previous image has no metadata for layer 'buildpack.id:launch-layer-no-local-dir'",
 					)
 				})
 			})
 
 			when("previous image metadata is missing reused layer", func() {
-				var incompleteMetadata lifecycle.LayersMetadata
-
 				it.Before(func() {
-					_ = fakeOriginalImage.SetLabel(
-						"io.buildpacks.lifecycle.metadata",
-						`{"buildpacks":[{"key": "buildpack.id", "layers": {}}]}`)
-
-					h.AssertNil(t, lifecycle.DecodeLabel(fakeOriginalImage, lifecycle.LayerMetadataLabel, &incompleteMetadata))
+					opts.OrigMetadata = lifecycle.LayersMetadata{
+						Buildpacks: []lifecycle.BuildpackLayersMetadata{{
+							ID:     "buildpack.id",
+							Layers: map[string]lifecycle.BuildpackLayerMetadata{},
+						}},
+					}
 				})
 
 				it("returns an error", func() {
 					h.AssertError(
 						t,
-						exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, incompleteMetadata, additionalNames, launcherConfig, stack, project),
+						exporter.Export(opts),
 						"cannot reuse 'buildpack.id:launch-layer-no-local-dir', previous image has no metadata for layer 'buildpack.id:launch-layer-no-local-dir'",
 					)
 				})
 			})
 
-			it("saves the image for all provided additionalNames", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
-				h.AssertContains(t, fakeAppImage.SavedNames(), append(additionalNames, fakeAppImage.Name())...)
+			it("saves the image for all provided AdditionalNames", func() {
+				h.AssertNil(t, exporter.Export(opts))
+				h.AssertContains(t, fakeAppImage.SavedNames(), append(opts.AdditionalNames, fakeAppImage.Name())...)
 			})
 		})
 
@@ -779,9 +753,9 @@ type = "Apache-2.0"
 			)
 
 			it.Before(func() {
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "app-slices", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "app-slices", "layers"), opts.LayersDir)
 				var err error
-				appDir, err = filepath.Abs(filepath.Join(layersDir, "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join(opts.LayersDir, "app"))
 				h.AssertNil(t, err)
 
 				// TODO : this is an hacky way to create a non-existing image and should be improved in imgutil
@@ -794,22 +768,22 @@ type = "Apache-2.0"
 			})
 
 			it("create a slice layer on the Run image", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				sliceLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, "static", "assets", "config.txt"))
+				sliceLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, "static", "assets", "config.txt"))
 				h.AssertNil(t, err)
 
-				assertTarFileExists(t, sliceLayerPath, filepath.Join(appDir, "static", "assets", "config.txt"), true)
-				assertTarFileExists(t, sliceLayerPath, filepath.Join(appDir, "static", "assets", "logo.svg"), true)
+				assertTarFileExists(t, sliceLayerPath, filepath.Join(opts.AppDir, "static", "assets", "config.txt"), true)
+				assertTarFileExists(t, sliceLayerPath, filepath.Join(opts.AppDir, "static", "assets", "logo.svg"), true)
 
-				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, ".hidden.txt"))
 				h.AssertNil(t, err)
 
-				assertTarFileExists(t, appLayerPath, filepath.Join(appDir, "static", "assets", "config.txt"), false)
-				assertTarFileExists(t, appLayerPath, filepath.Join(appDir, "static", "assets", "logo.svg"), false)
-				assertTarFileExists(t, appLayerPath, filepath.Join(appDir, "static", "misc", "resources"), false)
-				assertTarFileExists(t, appLayerPath, filepath.Join(appDir, "test_app.sh"), true)
-				assertTarFileExists(t, appLayerPath, filepath.Join(appDir, ".hidden.txt"), true)
+				assertTarFileExists(t, appLayerPath, filepath.Join(opts.AppDir, "static", "assets", "config.txt"), false)
+				assertTarFileExists(t, appLayerPath, filepath.Join(opts.AppDir, "static", "assets", "logo.svg"), false)
+				assertTarFileExists(t, appLayerPath, filepath.Join(opts.AppDir, "static", "misc", "resources"), false)
+				assertTarFileExists(t, appLayerPath, filepath.Join(opts.AppDir, "test_app.sh"), true)
+				assertTarFileExists(t, appLayerPath, filepath.Join(opts.AppDir, ".hidden.txt"), true)
 
 				assertLogEntry(t, logHandler, "Adding 4/4 app layer(s)")
 			})
@@ -821,9 +795,9 @@ type = "Apache-2.0"
 			)
 
 			it.Before(func() {
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "previous-image-not-exist", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "previous-image-not-exist", "layers"), opts.LayersDir)
 				var err error
-				appDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "previous-image-not-exist", "layers", "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "previous-image-not-exist", "layers", "app"))
 				h.AssertNil(t, err)
 
 				// TODO : this is an hacky way to create a non-existing image and should be improved in imgutil
@@ -836,13 +810,13 @@ type = "Apache-2.0"
 			})
 
 			it("creates app layer on Run image", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, ".hidden.txt"))
 				h.AssertNil(t, err)
 
-				assertTarFileContents(t, appLayerPath, filepath.Join(appDir, ".hidden.txt"), "some-hidden-text\n")
-				assertTarFileOwner(t, appLayerPath, appDir, uid, gid)
+				assertTarFileContents(t, appLayerPath, filepath.Join(opts.AppDir, ".hidden.txt"), "some-hidden-text\n")
+				assertTarFileOwner(t, appLayerPath, opts.AppDir, uid, gid)
 				assertLogEntry(t, logHandler, "Adding 1/1 app layer(s)")
 			})
 
@@ -851,97 +825,98 @@ type = "Apache-2.0"
 					cwd, err := os.Getwd()
 					h.AssertNil(t, err)
 
-					relAppDir, err := filepath.Rel(cwd, appDir)
+					fullAppDir := opts.AppDir
+					opts.AppDir, err = filepath.Rel(cwd, opts.AppDir)
 					h.AssertNil(t, err)
 
-					h.AssertNil(t, exporter.Export(layersDir, relAppDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+					h.AssertNil(t, exporter.Export(opts))
 
-					appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+					appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(fullAppDir, ".hidden.txt"))
 					h.AssertNil(t, err)
 
-					assertTarFileContents(t, appLayerPath, filepath.Join(appDir, ".hidden.txt"), "some-hidden-text\n")
-					assertTarFileOwner(t, appLayerPath, appDir, uid, gid)
+					assertTarFileContents(t, appLayerPath, filepath.Join(fullAppDir, ".hidden.txt"), "some-hidden-text\n")
+					assertTarFileOwner(t, appLayerPath, fullAppDir, uid, gid)
 					assertLogEntry(t, logHandler, "Adding 1/1 app layer(s)")
 				})
 			})
 
 			it("creates config layer on Run image", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "config", "metadata.toml"))
+				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "config", "metadata.toml"))
 				h.AssertNil(t, err)
 
 				assertTarFileContents(t,
 					configLayerPath,
-					filepath.Join(layersDir, "config/metadata.toml"),
+					filepath.Join(opts.LayersDir, "config/metadata.toml"),
 					"[[processes]]\n  type = \"web\"\n  command = \"npm start\"\n",
 				)
-				assertTarFileOwner(t, configLayerPath, filepath.Join(layersDir, "config"), uid, gid)
+				assertTarFileOwner(t, configLayerPath, filepath.Join(opts.LayersDir, "config"), uid, gid)
 				assertAddLayerLog(t, logHandler, "config", configLayerPath)
 			})
 
 			it("creates a launcher layer", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				launcherLayerPath, err := fakeAppImage.FindLayerWithPath(launcherConfig.Path)
+				launcherLayerPath, err := fakeAppImage.FindLayerWithPath(opts.LauncherConfig.Path)
 				h.AssertNil(t, err)
 				assertTarFileContents(t,
 					launcherLayerPath,
-					launcherConfig.Path,
+					opts.LauncherConfig.Path,
 					"some-launcher")
-				assertTarFileOwner(t, launcherLayerPath, launcherConfig.Path, uid, gid)
+				assertTarFileOwner(t, launcherLayerPath, opts.LauncherConfig.Path, uid, gid)
 				assertAddLayerLog(t, logHandler, "launcher", launcherLayerPath)
 			})
 
 			it("adds launch layers", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				layer1Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/layer1"))
+				layer1Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "buildpack.id/layer1"))
 				h.AssertNil(t, err)
 				assertTarFileContents(t,
 					layer1Path,
-					filepath.Join(layersDir, "buildpack.id/layer1/file-from-layer-1"),
+					filepath.Join(opts.LayersDir, "buildpack.id/layer1/file-from-layer-1"),
 					"echo text from layer 1\n")
-				assertTarFileOwner(t, layer1Path, filepath.Join(layersDir, "buildpack.id/layer1"), uid, gid)
+				assertTarFileOwner(t, layer1Path, filepath.Join(opts.LayersDir, "buildpack.id/layer1"), uid, gid)
 				assertAddLayerLog(t, logHandler, "buildpack.id:layer1", layer1Path)
 
-				layer2Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/layer2"))
+				layer2Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "buildpack.id/layer2"))
 				h.AssertNil(t, err)
 				assertTarFileContents(t,
 					layer2Path,
-					filepath.Join(layersDir, "buildpack.id/layer2/file-from-layer-2"),
+					filepath.Join(opts.LayersDir, "buildpack.id/layer2/file-from-layer-2"),
 					"echo text from layer 2\n")
-				assertTarFileOwner(t, layer2Path, filepath.Join(layersDir, "buildpack.id/layer2"), uid, gid)
+				assertTarFileOwner(t, layer2Path, filepath.Join(opts.LayersDir, "buildpack.id/layer2"), uid, gid)
 				assertAddLayerLog(t, logHandler, "buildpack.id:layer2", layer2Path)
 			})
 
 			it("only creates expected layers", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				var applayer, configLayer, launcherLayer, layer1, layer2 = 1, 1, 1, 1, 1
 				h.AssertEq(t, fakeAppImage.NumberOfAddedLayers(), applayer+configLayer+launcherLayer+layer1+layer2)
 			})
 
 			it("saves metadata with layer info", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(appDir, ".hidden.txt"))
+				appLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.AppDir, ".hidden.txt"))
 				h.AssertNil(t, err)
 				appLayerSHA := h.ComputeSHA256ForFile(t, appLayerPath)
 
-				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "config", "metadata.toml"))
+				configLayerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "config", "metadata.toml"))
 				h.AssertNil(t, err)
 				configLayerSHA := h.ComputeSHA256ForFile(t, configLayerPath)
 
-				launcherLayerPath, err := fakeAppImage.FindLayerWithPath(launcherConfig.Path)
+				launcherLayerPath, err := fakeAppImage.FindLayerWithPath(opts.LauncherConfig.Path)
 				h.AssertNil(t, err)
 				launcherLayerSHA := h.ComputeSHA256ForFile(t, launcherLayerPath)
 
-				layer1Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/layer1"))
+				layer1Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "buildpack.id/layer1"))
 				h.AssertNil(t, err)
 				buildpackLayer1SHA := h.ComputeSHA256ForFile(t, layer1Path)
 
-				layer2Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "buildpack.id/layer2"))
+				layer2Path, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "buildpack.id/layer2"))
 				h.AssertNil(t, err)
 				buildpackLayer2SHA := h.ComputeSHA256ForFile(t, layer2Path)
 
@@ -999,7 +974,7 @@ type = "Apache-2.0"
 
 			when("there is project metadata", func() {
 				it("saves metadata with project info", func() {
-					fakeProjectMetadata := lifecycle.ProjectMetadata{
+					opts.Project = lifecycle.ProjectMetadata{
 						Source: lifecycle.ProjectSource{
 							Type: "git",
 							Version: map[string]interface{}{
@@ -1010,7 +985,7 @@ type = "Apache-2.0"
 								"branch":     "master",
 							},
 						}}
-					h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, fakeProjectMetadata))
+					h.AssertNil(t, exporter.Export(opts))
 
 					projectJSON, err := fakeAppImage.Label("io.buildpacks.project.metadata")
 					h.AssertNil(t, err)
@@ -1021,45 +996,45 @@ type = "Apache-2.0"
 					}
 
 					t.Log("adds project metadata to label")
-					h.AssertEq(t, projectMD, fakeProjectMetadata)
+					h.AssertEq(t, projectMD, opts.Project)
 				})
 			})
 
 			it("sets CNB_LAYERS_DIR", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Env("CNB_LAYERS_DIR")
 				h.AssertNil(t, err)
-				h.AssertEq(t, val, layersDir)
+				h.AssertEq(t, val, opts.LayersDir)
 			})
 
 			it("sets CNB_APP_DIR", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Env("CNB_APP_DIR")
 				h.AssertNil(t, err)
-				h.AssertEq(t, val, appDir)
+				h.AssertEq(t, val, opts.AppDir)
 			})
 
 			it("sets ENTRYPOINT to launcher", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Entrypoint()
 				h.AssertNil(t, err)
-				h.AssertEq(t, val, []string{launcherConfig.Path})
+				h.AssertEq(t, val, []string{opts.LauncherConfig.Path})
 			})
 
 			it("sets empty CMD", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				val, err := fakeAppImage.Cmd()
 				h.AssertNil(t, err)
 				h.AssertEq(t, val, []string(nil))
 			})
 
-			it("saves the image for all provided additionalNames", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project))
-				h.AssertContains(t, fakeAppImage.SavedNames(), append(additionalNames, fakeAppImage.Name())...)
+			it("saves the image for all provided AdditionalNames", func() {
+				h.AssertNil(t, exporter.Export(opts))
+				h.AssertContains(t, fakeAppImage.SavedNames(), append(opts.AdditionalNames, fakeAppImage.Name())...)
 			})
 		})
 
@@ -1072,10 +1047,10 @@ type = "Apache-2.0"
 			it.Before(func() {
 				exporter.Buildpacks = []lifecycle.Buildpack{{ID: "some/escaped/bp/id"}}
 
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "escaped-bpid", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "escaped-bpid", "layers"), opts.LayersDir)
 
 				var err error
-				appDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "escaped-bpid", "layers", "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "escaped-bpid", "layers", "app"))
 				h.AssertNil(t, err)
 
 				fakeOriginalImage = fakes.NewImage("app/original", "original-top-sha", local.IDIdentifier{ImageID: "run-digest"})
@@ -1088,25 +1063,25 @@ type = "Apache-2.0"
 			})
 
 			it.After(func() {
-				fakeOriginalImage.Cleanup()
+				h.AssertNil(t, fakeOriginalImage.Cleanup())
 			})
 
 			it("exports layers from the escaped id path", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
-				layerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(layersDir, "some_escaped_bp_id/some-layer"))
+				layerPath, err := fakeAppImage.FindLayerWithPath(filepath.Join(opts.LayersDir, "some_escaped_bp_id/some-layer"))
 				h.AssertNil(t, err)
 
 				assertTarFileContents(t,
 					layerPath,
-					filepath.Join(layersDir, "some_escaped_bp_id/some-layer/some-file"),
+					filepath.Join(opts.LayersDir, "some_escaped_bp_id/some-layer/some-file"),
 					"some-file-contents\n")
-				assertTarFileOwner(t, layerPath, filepath.Join(layersDir, "some_escaped_bp_id/some-layer/some-file"), uid, gid)
+				assertTarFileOwner(t, layerPath, filepath.Join(opts.LayersDir, "some_escaped_bp_id/some-layer/some-file"), uid, gid)
 				assertAddLayerLog(t, logHandler, "some/escaped/bp/id:some-layer", layerPath)
 			})
 
 			it("exports buildpack metadata with unescaped id", func() {
-				h.AssertNil(t, exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project))
+				h.AssertNil(t, exporter.Export(opts))
 
 				metadataJSON, err := fakeAppImage.Label("io.buildpacks.lifecycle.metadata")
 				h.AssertNil(t, err)
@@ -1127,25 +1102,25 @@ type = "Apache-2.0"
 			)
 
 			it.Before(func() {
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "bad-layer", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "bad-layer", "layers"), opts.LayersDir)
 
 				var err error
-				appDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "bad-layer", "layers", "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "bad-layer", "layers", "app"))
 				h.AssertNil(t, err)
 
 				// TODO : this is an hacky way to create a non-existing image and should be improved in imgutil
 				nonExistingOriginalImage = fakes.NewImage("app/original-image", "", nil)
-				nonExistingOriginalImage.Delete()
+				h.AssertNil(t, nonExistingOriginalImage.Delete())
 			})
 
 			it.After(func() {
-				nonExistingOriginalImage.Cleanup()
+				h.AssertNil(t, nonExistingOriginalImage.Cleanup())
 			})
 
 			it("returns an error", func() {
 				h.AssertError(
 					t,
-					exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, lifecycle.LayersMetadata{}, additionalNames, launcherConfig, stack, project),
+					exporter.Export(opts),
 					"failed to parse metadata for layers '[buildpack.id:bad-layer]'",
 				)
 			})
@@ -1158,9 +1133,9 @@ type = "Apache-2.0"
 			)
 
 			it.Before(func() {
-				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "cache-layer-no-contents", "layers"), layersDir)
+				h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "cache-layer-no-contents", "layers"), opts.LayersDir)
 				var err error
-				appDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "cache-layer-no-contents", "layers", "app"))
+				opts.AppDir, err = filepath.Abs(filepath.Join("testdata", "exporter", "cache-layer-no-contents", "layers", "app"))
 				h.AssertNil(t, err)
 
 				fakeOriginalImage = fakes.NewImage(
@@ -1186,13 +1161,13 @@ type = "Apache-2.0"
 			})
 
 			it.After(func() {
-				fakeOriginalImage.Cleanup()
+				h.AssertNil(t, fakeOriginalImage.Cleanup())
 			})
 
 			it("returns an error", func() {
 				h.AssertError(
 					t,
-					exporter.Export(layersDir, appDir, fakeAppImage, runImageRef, fakeImageMetadata, additionalNames, launcherConfig, stack, project),
+					exporter.Export(opts),
 					"layer 'buildpack.id:cache-layer-no-contents' is cache=true but has no contents",
 				)
 			})
@@ -1507,7 +1482,7 @@ func tarFileContext(t *testing.T, tarfile, path string) (exist bool, contents st
 	t.Helper()
 	r, err := os.Open(tarfile)
 	h.AssertNil(t, err)
-	defer r.Close()
+	defer func() { h.AssertNil(t, r.Close()) }()
 
 	tr := tar.NewReader(r)
 	for {
@@ -1531,7 +1506,7 @@ func assertTarFileOwner(t *testing.T, tarfile, path string, expectedUID, expecte
 	var foundPath bool
 	r, err := os.Open(tarfile)
 	h.AssertNil(t, err)
-	defer r.Close()
+	defer func() { r.Close() }()
 
 	tr := tar.NewReader(r)
 	for {

--- a/metadata.go
+++ b/metadata.go
@@ -39,6 +39,15 @@ func MetadataFilePath(layersDir string) string {
 	return path.Join(layersDir, "config", "metadata.toml")
 }
 
+func (md BuildMetadata) hasProcess(processType string) bool {
+	for _, p := range md.Processes {
+		if p.Type == processType {
+			return true
+		}
+	}
+	return false
+}
+
 type CacheMetadata struct {
 	Buildpacks []BuildpackLayersMetadata `json:"buildpacks"`
 }

--- a/testdata/exporter/cache-layer-no-contents/layers/config/metadata.toml
+++ b/testdata/exporter/cache-layer-no-contents/layers/config/metadata.toml
@@ -1,3 +1,3 @@
 [[processes]]
-  type = "web"
-  command = "npm start"
+  type = "some-process-type"
+  command = "/some/command"

--- a/testdata/exporter/escaped-bpid/layers/config/metadata.toml
+++ b/testdata/exporter/escaped-bpid/layers/config/metadata.toml
@@ -1,3 +1,3 @@
 [[processes]]
-  type = "web"
-  command = "npm start"
+  type = "some-process-type"
+  command = "/some/command"

--- a/testdata/exporter/previous-image-exists/layers/config/metadata.toml
+++ b/testdata/exporter/previous-image-exists/layers/config/metadata.toml
@@ -1,3 +1,3 @@
 [[processes]]
-  type = "web"
-  command = "npm start"
+  type = "some-process-type"
+  command = "/some/command"

--- a/testdata/exporter/previous-image-not-exist/layers/config/metadata.toml
+++ b/testdata/exporter/previous-image-not-exist/layers/config/metadata.toml
@@ -1,3 +1,3 @@
 [[processes]]
-  type = "web"
-  command = "npm start"
+  type = "some-process-type"
+  command = "/some/command"


### PR DESCRIPTION
Implements https://github.com/buildpacks/rfcs/blob/master/text/0017-pack-build-default-process-flag.md (buildpacks/rfcs#28)

`exporter` accepts `-process-type` flag
* defaults to `CNB_PROCESS_TYPE` env var, if set
* no default if `CNB_PROCESS_TYPE` is not set

If provided, it sets `CNB_PROCESS_TYPE` on the exported image.