### PR TITLE
Build linux artifact in a Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up go
+        uses: actions/setup-go@v2-beta
+        with:
+          go-version: '1.13'
+      - name: Set up go env
+        run: |
+          echo "::set-env name=GOPATH::$(go env GOPATH)"
+          echo "::add-path::$(go env GOPATH)/bin"
+        shell: bash
+      - name: Install jq
+        run: |
+          mkdir -p deps/bin
+          curl -s -L -o deps/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+          chmod +x deps/bin/jq
+          echo "::add-path::${PWD}/deps/bin"
+      - name: Test
+        run: make test
+      - name: Build
+        run: |
+          make build-linux
+          make package-linux
+      - uses: actions/upload-artifact@v1
+        with:
+          name: lifecycle
+          path: out/lifecycle-v0.0.0+linux.x86-64.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
+    env:
+      LIFECYCLE_VERSION: 0.7.0
     steps:
       - uses: actions/checkout@v2
       - name: Set up go
@@ -36,5 +38,5 @@ jobs:
           make package-linux
       - uses: actions/upload-artifact@v1
         with:
-          name: lifecycle
-          path: out/lifecycle-v0.0.0+linux.x86-64.tgz
+          name: lifecycle-linux-x86-64
+          path: out/lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
         run: make test
       - name: Build
         run: |
-          make build-linux
-          make package-linux
+          make build
+          make package
       - uses: actions/upload-artifact@v1
         with:
           name: lifecycle-linux-x86-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: go
-go:
-- 1.13.x
-script:
-- make test
-branches:
-  only:
-  - master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Lifecycle
 
+![Build Status](https://github.com/buildpacks/lifecycle/workflows/build/badge.svg)
 [![Build Status](https://travis-ci.org/buildpacks/lifecycle.svg?branch=master)](https://travis-ci.org/buildpack/lifecycle)
 [![GoDoc](https://godoc.org/github.com/buildpacks/lifecycle?status.svg)](https://godoc.org/github.com/buildpacks/lifecycle)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Lifecycle
 
 ![Build Status](https://github.com/buildpacks/lifecycle/workflows/build/badge.svg)
-[![Build Status](https://travis-ci.org/buildpacks/lifecycle.svg?branch=master)](https://travis-ci.org/buildpack/lifecycle)
 [![GoDoc](https://godoc.org/github.com/buildpacks/lifecycle?status.svg)](https://godoc.org/github.com/buildpacks/lifecycle)
 
 A reference implementation of the [Cloud Native Buildpacks specification](https://github.com/buildpacks/spec).


### PR DESCRIPTION
Signed-off-by: Simon Jones <simonjones@vmware.com>

This PR adds a Github actions for new PRs and pushes to master which triggers unit testing, building and packaging of the lifecycle artifact for Linux.

I do have an outstanding concern that this defaults to version `0.0.0`, however this is not intended to immediately replace the current build process, so versioned artifacts will continue to be created and uploaded to our GCS bucket with the correct version number.