### PR TITLE
play nice with k8s PodSecurityContext fsGroup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     env:
-      LIFECYCLE_VERSION: 0.7.0
+      LIFECYCLE_VERSION: 0.7.1
     steps:
       - uses: actions/checkout@v2
       - name: Set up go

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -33,6 +33,7 @@ csetresgid(gid_t rgid, gid_t egid, gid_t sgid) {
 */
 import "C"
 
+// EnsureOwner recursively chowns a dir if it isn't owned by the given group
 func EnsureOwner(uid, gid int, paths ...string) error {
 	for _, p := range paths {
 		fi, err := os.Stat(p)
@@ -42,7 +43,7 @@ func EnsureOwner(uid, gid int, paths ...string) error {
 		if err != nil {
 			return err
 		}
-		if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Uid == uint32(uid) && stat.Gid == uint32(gid) {
+		if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Gid == uint32(gid) {
 			// if a dir has correct ownership, assume it's children do, for performance
 			continue
 		}


### PR DESCRIPTION
Correct `gid` is good enough to satisfy `EnsureOwner` that permissions are correct

Fixes: #271