### PR TITLE
support world writable pvcs on k8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   test-and-build:
     runs-on: ubuntu-latest
     env:
-      LIFECYCLE_VERSION: 0.7.0
+      LIFECYCLE_VERSION: 0.7.1
     steps:
       - uses: actions/checkout@v2
       - name: Set up go

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -33,7 +33,7 @@ csetresgid(gid_t rgid, gid_t egid, gid_t sgid) {
 */
 import "C"
 
-// EnsureOwner recursively chowns a dir if it isn't owned by the given group
+// EnsureOwner recursively chowns a dir if it isn't writable
 func EnsureOwner(uid, gid int, paths ...string) error {
 	for _, p := range paths {
 		fi, err := os.Stat(p)
@@ -43,7 +43,7 @@ func EnsureOwner(uid, gid int, paths ...string) error {
 		if err != nil {
 			return err
 		}
-		if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Gid == uint32(gid) {
+		if stat, ok := fi.Sys().(*syscall.Stat_t); ok && canWrite(uid, gid, stat) {
 			// if a dir has correct ownership, assume it's children do, for performance
 			continue
 		}
@@ -52,6 +52,25 @@ func EnsureOwner(uid, gid int, paths ...string) error {
 		}
 	}
 	return nil
+}
+
+var (
+	worldWrite uint32 = 0002
+	groupWrite uint32 = 0020
+)
+
+func canWrite(uid, gid int, stat *syscall.Stat_t) bool {
+	if stat.Uid == uint32(uid) {
+		// assume owner has write permission
+		return true
+	}
+	if stat.Gid == uint32(gid) && stat.Mode&groupWrite != 0 {
+		return true
+	}
+	if stat.Mode&worldWrite != 0 {
+		return true
+	}
+	return false
 }
 
 func IsPrivileged() bool {

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -54,7 +54,7 @@ func EnsureOwner(uid, gid int, paths ...string) error {
 	return nil
 }
 
-var (
+const (
 	worldWrite uint32 = 0002
 	groupWrite uint32 = 0020
 )

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -33,6 +33,7 @@ csetresgid(gid_t rgid, gid_t egid, gid_t sgid) {
 */
 import "C"
 
+// EnsureOwner recursively chowns a dir if it isn't owned by the given group
 func EnsureOwner(uid, gid int, paths ...string) error {
 	for _, p := range paths {
 		fi, err := os.Stat(p)
@@ -42,7 +43,7 @@ func EnsureOwner(uid, gid int, paths ...string) error {
 		if err != nil {
 			return err
 		}
-		if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Uid == uint32(uid) && stat.Gid == uint32(gid) {
+		if stat, ok := fi.Sys().(*syscall.Stat_t); ok && stat.Gid == uint32(gid) {
 			// if a dir has correct ownership, assume it's children do, for performance
 			continue
 		}


### PR DESCRIPTION
If user does not own volume, check thoroughly for write permissions before attempting to chown.

context: https://github.com/buildpacks/lifecycle/issues/271#issuecomment-598926266