### PR TITLE
fixes error setting run-image with CNB_RUN_IMAGE env var

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -102,7 +102,7 @@ func FlagPlatformDir(dir *string) {
 }
 
 func DeprecatedFlagRunImage(image *string) {
-	flagSet.StringVar(image, "image", os.Getenv(EnvRunImage), "reference to run image")
+	flagSet.StringVar(image, "image", "", "reference to run image")
 }
 
 func FlagRunImage(image *string) {

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -89,7 +89,7 @@ func (e *exportCmd) Args(nargs int, args []string) error {
 		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "cannot export to multiple registries")
 	}
 
-	if e.deprecatedRunImageRef != "" && e.runImageRef != "" {
+	if e.deprecatedRunImageRef != "" && e.runImageRef != os.Getenv(cmd.EnvRunImage) {
 		return cmd.FailErrCode(errors.New("supply only one of -run-image or (deprecated) -image"), cmd.CodeInvalidArgs, "parse arguments")
 	}
 


### PR DESCRIPTION
* no default for deprecated -image flag
* when decided whether -run-image flag is passed, compare to the default
* Fixes #274 