### PR TITLE
Add omitempty to project metadata types

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -574,7 +574,7 @@ type = "Apache-2.0"
 			when("there is project metadata", func() {
 				it("saves metadata with project info", func() {
 					opts.Project = lifecycle.ProjectMetadata{
-						Source: lifecycle.ProjectSource{
+						Source: &lifecycle.ProjectSource{
 							Type: "git",
 							Version: map[string]interface{}{
 								"commit": "abcd1234",
@@ -958,7 +958,7 @@ type = "Apache-2.0"
 			when("there is project metadata", func() {
 				it("saves metadata with project info", func() {
 					opts.Project = lifecycle.ProjectMetadata{
-						Source: lifecycle.ProjectSource{
+						Source: &lifecycle.ProjectSource{
 							Type: "git",
 							Version: map[string]interface{}{
 								"commit": "abcd1234",

--- a/project_metadata.go
+++ b/project_metadata.go
@@ -5,11 +5,11 @@ const (
 )
 
 type ProjectMetadata struct {
-	Source ProjectSource `toml:"source" json:"source"`
+	Source *ProjectSource `toml:"source" json:"source,omitempty"`
 }
 
 type ProjectSource struct {
-	Type     string                 `toml:"type" json:"type"`
-	Version  map[string]interface{} `toml:"version" json:"version"`
-	Metadata map[string]interface{} `toml:"metadata" json:"metadata"`
+	Type     string                 `toml:"type" json:"type,omitempty"`
+	Version  map[string]interface{} `toml:"version" json:"version,omitempty"`
+	Metadata map[string]interface{} `toml:"metadata" json:"metadata,omitempty"`
 }


### PR DESCRIPTION
This will prevent missing project metadata from writing a noisy project metadata value: `{\"source\":{\"type\":\"\",\"version\":null,\"metadata\":null}}`

This will instead produce an empty json document `{}`

Signed-off-by: Matthew McNew <mmcnew@pivotal.io>