### PR TITLE
Fixes anonymous auth when analyze/export run as root

### DIFF
--- a/auth/env_keychain_test.go
+++ b/auth/env_keychain_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -16,93 +17,126 @@ import (
 )
 
 func TestEnvKeychain(t *testing.T) {
-	spec.Run(t, "EnvKeychain", testEnvKeychain, spec.Sequential(), spec.Report(report.Terminal{}))
+	spec.Run(t, "NewKeychain", testEnvKeychain, spec.Sequential(), spec.Report(report.Terminal{}))
 }
 
 func testEnvKeychain(t *testing.T, when spec.G, it spec.S) {
-	when("EnvKeychain", func() {
-		var envKeyChain authn.Keychain
-
-		it.Before(func() {
-			envKeyChain = auth.EnvKeychain("CNB_REGISTRY_AUTH")
-		})
-
-		it.After(func() {
-			err := os.Unsetenv("CNB_REGISTRY_AUTH")
-			h.AssertNil(t, err)
-		})
-
-		when("#Resolve", func() {
-			when("valid auth env variable is set", func() {
-				it.Before(func() {
-					err := os.Setenv(
-						"CNB_REGISTRY_AUTH",
-						`{"basic-registry.com": "Basic asdf=", "bearer-registry.com": "Bearer qwerty="}`,
-					)
-					h.AssertNil(t, err)
-				})
-
-				it("loads the basic auth from the environment", func() {
-					registry, err := name.NewRegistry("basic-registry.com", name.WeakValidation)
-					h.AssertNil(t, err)
-
-					authenticator, err := envKeyChain.Resolve(registry)
-					h.AssertNil(t, err)
-
-					header, err := authenticator.Authorization()
-					h.AssertNil(t, err)
-
-					h.AssertEq(t, header, &authn.AuthConfig{Auth: "asdf="})
-				})
-
-				it("loads the bearer auth from the environment", func() {
-					registry, err := name.NewRegistry("bearer-registry.com", name.WeakValidation)
-					h.AssertNil(t, err)
-
-					authenticator, err := envKeyChain.Resolve(registry)
-					h.AssertNil(t, err)
-
-					header, err := authenticator.Authorization()
-					h.AssertNil(t, err)
-
-					h.AssertEq(t, header, &authn.AuthConfig{RegistryToken: "qwerty="})
-				})
-
-				it("returns an Anonymous authenticator when the environment does not have a auth header", func() {
-					registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
-					h.AssertNil(t, err)
-
-					authenticator, err := envKeyChain.Resolve(registry)
-					h.AssertNil(t, err)
-
-					h.AssertEq(t, authenticator, authn.Anonymous)
-				})
+	when("#NewKeychain", func() {
+		when("CNB_REGISTRY_AUTH is set", func() {
+			it.Before(func() {
+				err := os.Setenv(
+					"CNB_REGISTRY_AUTH",
+					`foo`,
+				)
+				h.AssertNil(t, err)
 			})
 
-			when("invalid env var is set", func() {
-				it.Before(func() {
-					err := os.Setenv("CNB_REGISTRY_AUTH", "NOT -- JSON")
-					h.AssertNil(t, err)
-				})
-
-				it("returns an error", func() {
-					registry, err := name.NewRegistry("some-registry.com", name.WeakValidation)
-					h.AssertNil(t, err)
-
-					_, err = envKeyChain.Resolve(registry)
-					h.AssertError(t, err, "failed to parse CNB_REGISTRY_AUTH value")
-				})
+			it.After(func() {
+				err := os.Unsetenv("CNB_REGISTRY_AUTH")
+				h.AssertNil(t, err)
 			})
 
-			when("env var is not set", func() {
-				it("returns an Anonymous authenticator", func() {
-					registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
-					h.AssertNil(t, err)
+			it("returns an EnvKeychain", func() {
+				envKeyChain := auth.NewKeychain("CNB_REGISTRY_AUTH")
+				_, ok := envKeyChain.(*auth.EnvKeychain)
+				if ok != true {
+					t.Fatalf("expected *auth.EnvKeychain, got %s", reflect.TypeOf(envKeyChain))
+				}
+			})
+		})
 
-					auth, err := envKeyChain.Resolve(registry)
-					h.AssertNil(t, err)
+		when("CNB_REGISTRY_AUTH is not set", func() {
+			it("returns the ggcr DefaultKeychain", func() {
+				envKeyChain := auth.NewKeychain("CNB_REGISTRY_AUTH")
+				h.AssertEq(t, envKeyChain, authn.DefaultKeychain)
+			})
+		})
 
-					h.AssertEq(t, auth, authn.Anonymous)
+		when("#EnvKeychain", func() {
+			var envKeyChain authn.Keychain
+
+			when("#Resolve", func() {
+				it.Before(func() {
+					envKeyChain = &auth.EnvKeychain{EnvVar: "CNB_REGISTRY_AUTH"}
+				})
+
+				it.After(func() {
+					err := os.Unsetenv("CNB_REGISTRY_AUTH")
+					h.AssertNil(t, err)
+				})
+
+				when("valid auth env variable is set", func() {
+					it.Before(func() {
+						err := os.Setenv(
+							"CNB_REGISTRY_AUTH",
+							`{"basic-registry.com": "Basic asdf=", "bearer-registry.com": "Bearer qwerty="}`,
+						)
+						h.AssertNil(t, err)
+					})
+
+					it("loads the basic auth from the environment", func() {
+						registry, err := name.NewRegistry("basic-registry.com", name.WeakValidation)
+						h.AssertNil(t, err)
+
+						authenticator, err := envKeyChain.Resolve(registry)
+						h.AssertNil(t, err)
+
+						header, err := authenticator.Authorization()
+						h.AssertNil(t, err)
+
+						h.AssertEq(t, header, &authn.AuthConfig{Auth: "asdf="})
+					})
+
+					it("loads the bearer auth from the environment", func() {
+						registry, err := name.NewRegistry("bearer-registry.com", name.WeakValidation)
+						h.AssertNil(t, err)
+
+						authenticator, err := envKeyChain.Resolve(registry)
+						h.AssertNil(t, err)
+
+						header, err := authenticator.Authorization()
+						h.AssertNil(t, err)
+
+						h.AssertEq(t, header, &authn.AuthConfig{RegistryToken: "qwerty="})
+					})
+
+					it("returns an Anonymous authenticator when the environment does not have a auth header", func() {
+						envKeyChain = auth.NewKeychain("CNB_REGISTRY_AUTH")
+						registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
+						h.AssertNil(t, err)
+
+						authenticator, err := envKeyChain.Resolve(registry)
+						h.AssertNil(t, err)
+
+						h.AssertEq(t, authenticator, authn.Anonymous)
+					})
+				})
+
+				when("invalid env var is set", func() {
+					it.Before(func() {
+						err := os.Setenv("CNB_REGISTRY_AUTH", "NOT -- JSON")
+						h.AssertNil(t, err)
+					})
+
+					it("returns an error", func() {
+						registry, err := name.NewRegistry("some-registry.com", name.WeakValidation)
+						h.AssertNil(t, err)
+
+						_, err = envKeyChain.Resolve(registry)
+						h.AssertError(t, err, "failed to parse CNB_REGISTRY_AUTH value")
+					})
+				})
+
+				when("env var is not set", func() {
+					it("returns an Anonymous authenticator", func() {
+						registry, err := name.NewRegistry("no-env-auth-registry.com", name.WeakValidation)
+						h.AssertNil(t, err)
+
+						auth, err := envKeyChain.Resolve(registry)
+						h.AssertNil(t, err)
+
+						h.AssertEq(t, auth, authn.Anonymous)
+					})
 				})
 			})
 		})

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -118,7 +118,7 @@ func (aa analyzeArgs) analyze(group lifecycle.BuildpackGroup, cacheStore lifecyc
 	} else {
 		img, err = remote.NewImage(
 			aa.imageName,
-			auth.EnvKeychain(cmd.EnvRegistryAuth),
+			auth.NewKeychain(cmd.EnvRegistryAuth),
 			remote.FromBaseImage(aa.imageName),
 		)
 	}

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -273,14 +273,14 @@ func initRemoteImage(imageName string, runImageRef string, analyzedMD lifecycle.
 
 	appImage, err := remote.NewImage(
 		imageName,
-		auth.EnvKeychain(cmd.EnvRegistryAuth),
+		auth.NewKeychain(cmd.EnvRegistryAuth),
 		opts...,
 	)
 	if err != nil {
 		return nil, "", cmd.FailErr(err, "new app image")
 	}
 
-	runImage, err := remote.NewImage(runImageRef, auth.EnvKeychain(cmd.EnvRegistryAuth), remote.FromBaseImage(runImageRef))
+	runImage, err := remote.NewImage(runImageRef, auth.NewKeychain(cmd.EnvRegistryAuth), remote.FromBaseImage(runImageRef))
 	if err != nil {
 		return nil, "", cmd.FailErr(err, "access run image")
 	}

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -69,7 +69,7 @@ func initCache(cacheImageTag, cacheDir string) (lifecycle.Cache, error) {
 		err        error
 	)
 	if cacheImageTag != "" {
-		cacheStore, err = cache.NewImageCacheFromName(cacheImageTag, auth.EnvKeychain(cmd.EnvRegistryAuth))
+		cacheStore, err = cache.NewImageCacheFromName(cacheImageTag, auth.NewKeychain(cmd.EnvRegistryAuth))
 		if err != nil {
 			return nil, cmd.FailErr(err, "create image cache")
 		}

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -86,7 +86,7 @@ func (r *rebaseCmd) Exec() error {
 	} else {
 		appImage, err = remote.NewImage(
 			r.imageNames[0],
-			auth.EnvKeychain(cmd.EnvRegistryAuth),
+			auth.NewKeychain(cmd.EnvRegistryAuth),
 			remote.FromBaseImage(r.imageNames[0]),
 		)
 	}
@@ -119,7 +119,7 @@ func (r *rebaseCmd) Exec() error {
 	} else {
 		newBaseImage, err = remote.NewImage(
 			r.imageNames[0],
-			auth.EnvKeychain(cmd.EnvRegistryAuth),
+			auth.NewKeychain(cmd.EnvRegistryAuth),
 			remote.FromBaseImage(r.runImageRef),
 		)
 	}


### PR DESCRIPTION
* Uses DefaultKeychain if CNB_REGISTRY_AUTH is not set
* Uses EnvKeychain if CNB_REGISTRY_AUTH is set
* Doesn't fallback on the default keychain if the EnvKeychain returns anonymous
* This fixes an error caused by the lifecycle attempting to read  in root's home dir after dropping privileges
* Generally platforms use either CNB_REGISTRY_AUTH or a docker config.json, not both

Signed-off-by: Natalie Arellano <narellano@pivotal.io>
Signed-off-by: Emily Casey <ecasey@pivotal.io>