### PR TITLE
Better error message when an image reference fails to parse

### DIFF
--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -77,8 +77,8 @@ func (c *createCmd) Args(nargs int, args []string) error {
 		c.previousImage = c.imageName
 	}
 
-	if err := image.EnsureSingleRegistry(append(c.additionalTags, c.imageName)...); err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "all tags must have the same registry as the exported image")
+	if err := image.ValidateDestinationTags(c.useDaemon, append(c.additionalTags, c.imageName)...); err != nil {
+		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "failed to validate image tag(s)")
 	}
 
 	return nil

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -78,7 +78,7 @@ func (c *createCmd) Args(nargs int, args []string) error {
 	}
 
 	if err := image.ValidateDestinationTags(c.useDaemon, append(c.additionalTags, c.imageName)...); err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "failed to validate image tag(s)")
+		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate image tag(s)")
 	}
 
 	return nil

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -86,7 +86,7 @@ func (e *exportCmd) Args(nargs int, args []string) error {
 	}
 
 	if err := image.ValidateDestinationTags(e.useDaemon, e.imageNames...); err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "failed to validate image tag(s)")
+		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate image tag(s)")
 	}
 
 	if e.deprecatedRunImageRef != "" && e.runImageRef != os.Getenv(cmd.EnvRunImage) {

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -85,8 +85,8 @@ func (e *exportCmd) Args(nargs int, args []string) error {
 		cmd.Logger.Warn("Will not cache data, no cache flag specified.")
 	}
 
-	if err := image.EnsureSingleRegistry(e.imageNames...); err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "cannot export to multiple registries")
+	if err := image.ValidateDestinationTags(e.useDaemon, e.imageNames...); err != nil {
+		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "failed to validate image tag(s)")
 	}
 
 	if e.deprecatedRunImageRef != "" && e.runImageRef != os.Getenv(cmd.EnvRunImage) {

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -42,8 +42,8 @@ func (r *rebaseCmd) Args(nargs int, args []string) error {
 		return cmd.FailErrCode(errors.New("at least one image argument is required"), cmd.CodeInvalidArgs, "parse arguments")
 	}
 	r.imageNames = args
-	if err := image.EnsureSingleRegistry(r.imageNames...); err != nil {
-		return cmd.FailErrCode(image.EnsureSingleRegistry(r.imageNames...), cmd.CodeInvalidArgs, "images tags must all have the same registry")
+	if err := image.ValidateDestinationTags(r.useDaemon, r.imageNames...); err != nil {
+		return cmd.FailErrCode(image.ValidateDestinationTags(false, r.imageNames...), cmd.CodeInvalidArgs, "failed to validate image tag(s)")
 	}
 
 	if r.deprecatedRunImageRef != "" && r.runImageRef != "" {

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -43,7 +43,7 @@ func (r *rebaseCmd) Args(nargs int, args []string) error {
 	}
 	r.imageNames = args
 	if err := image.ValidateDestinationTags(r.useDaemon, r.imageNames...); err != nil {
-		return cmd.FailErrCode(image.ValidateDestinationTags(false, r.imageNames...), cmd.CodeInvalidArgs, "failed to validate image tag(s)")
+		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate image tag(s)")
 	}
 
 	if r.deprecatedRunImageRef != "" && r.runImageRef != "" {

--- a/image/image.go
+++ b/image/image.go
@@ -5,7 +5,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func EnsureSingleRegistry(repoNames ...string) error {
+// ValidateDestinationTags ensures all tags are valid
+// daemon - when false (exporting to a registry), ensures all tags are on the same registry
+func ValidateDestinationTags(daemon bool, repoNames ...string) error {
 	var (
 		reg        string
 		registries = map[string]struct{}{}
@@ -20,8 +22,8 @@ func EnsureSingleRegistry(repoNames ...string) error {
 		registries[reg] = struct{}{}
 	}
 
-	if len(registries) != 1 {
-		return errors.New("exporting to multiple registries is unsupported")
+	if !daemon && len(registries) != 1 {
+		return errors.New("writing to multiple registries is unsupported")
 	}
 
 	return nil

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -14,18 +14,33 @@ func TestImage(t *testing.T) {
 }
 
 func testImage(t *testing.T, when spec.G, it spec.S) {
-	when("#EnsureSingleRegistry", func() {
+	when("#ValidateDestinationTags", func() {
 		when("multiple registries are provided", func() {
-			it("errors as unsupported", func() {
-				err := image.EnsureSingleRegistry("some/repo", "gcr.io/other-repo:latest", "example.com/final-repo")
-				h.AssertError(t, err, "exporting to multiple registries is unsupported")
+			when("daemon", func() {
+				it("does not return an error", func() {
+					err := image.ValidateDestinationTags(true, "some/repo", "gcr.io/other-repo:latest", "example.com/final-repo")
+					h.AssertNil(t, err)
+				})
+			})
+			when("registry", func() {
+				it("errors as unsupported", func() {
+					err := image.ValidateDestinationTags(false, "some/repo", "gcr.io/other-repo:latest", "example.com/final-repo")
+					h.AssertError(t, err, "writing to multiple registries is unsupported")
+				})
 			})
 		})
 
 		when("a single registry is provided", func() {
 			it("does not return an error", func() {
-				err := image.EnsureSingleRegistry("gcr.io/some/repo", "gcr.io/other-repo:latest", "gcr.io/final-repo")
+				err := image.ValidateDestinationTags(false, "gcr.io/some/repo", "gcr.io/other-repo:latest", "gcr.io/final-repo")
 				h.AssertNil(t, err)
+			})
+		})
+
+		when("the tag reference is invalid", func() {
+			it("error", func() {
+				err := image.ValidateDestinationTags(false, "some/Repo")
+				h.AssertError(t, err, "could not parse reference: some/Repo")
 			})
 		})
 	})

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -38,7 +38,7 @@ func testImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("the tag reference is invalid", func() {
-			it("error", func() {
+			it("errors", func() {
 				err := image.ValidateDestinationTags(false, "some/Repo")
 				h.AssertError(t, err, "could not parse reference: some/Repo")
 			})


### PR DESCRIPTION
* Fixes: #295

Doesn't validate that all destination tags have a matching registry when
exporting to the daemon (this is unnecessary in the daemon case)