### PR TITLE
Don't lock os thread

### DIFF
--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"syscall"
 )
@@ -106,16 +105,12 @@ func RunAs(uid, gid int) error {
 		return nil
 	}
 
-	// temporarily reduce to one thread b/c setres{gid,uid} works per thread on linux
-	mxp := runtime.GOMAXPROCS(1)
-	runtime.LockOSThread()
 	if err := setresgid(gid, gid, gid); err != nil {
 		return err
 	}
 	if err := setresuid(uid, uid, uid); err != nil {
 		return err
 	}
-	_ = runtime.GOMAXPROCS(mxp)
 
 	return nil
 }


### PR DESCRIPTION
runtime.LockOSThread() slows down the exporter and is unecessary now that we use the musllibc implementation of setres{g,u}id. It was originally added when we attempted to use the go runtime implementation of SetRes{G,U}ID, which only works on a single thread.

Signed-off-by: Emily Casey <ecasey@pivotal.io>