### PR TITLE
Do not delete cache image when exporting cache if it is the same as before

### DIFF
--- a/cache/image_cache.go
+++ b/cache/image_cache.go
@@ -119,7 +119,7 @@ func (c *ImageCache) DeleteOrigImage() error {
 	if err != nil {
 		return errors.Wrap(err, "getting identifier for new image")
 	}
-	if origIdentifier == newIdentifier {
+	if origIdentifier.String() == newIdentifier.String() {
 		return nil
 	}
 	return c.origImage.Delete()

--- a/cache/image_cache.go
+++ b/cache/image_cache.go
@@ -102,10 +102,25 @@ func (c *ImageCache) Commit() error {
 
 	if c.origImage.Found() {
 		// Deleting the original image is for cleanup only and should not fail the commit.
-		if err := c.origImage.Delete(); err != nil {
+		if err := c.DeleteOrigImage(); err != nil {
 			fmt.Printf("Unable to delete previous cache image: %v", err)
 		}
 	}
 	c.origImage = c.newImage
 	return nil
+}
+
+func (c *ImageCache) DeleteOrigImage() error {
+	origIdentifier, err := c.origImage.Identifier()
+	if err != nil {
+		return errors.Wrap(err, "getting identifier for original image")
+	}
+	newIdentifier, err := c.newImage.Identifier()
+	if err != nil {
+		return errors.Wrap(err, "getting identifier for new image")
+	}
+	if origIdentifier == newIdentifier {
+		return nil
+	}
+	return c.origImage.Delete()
 }

--- a/cache/image_cache_test.go
+++ b/cache/image_cache_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/buildpacks/imgutil/fakes"
+	"github.com/buildpacks/imgutil/local"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -283,6 +284,34 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 				err = subject.Commit()
 				h.AssertError(t, err, "cache cannot be modified after commit")
+			})
+		})
+
+		when("with #DeleteOrigImage", func() {
+			when("original and new image are different", func() {
+				it.Before(func() {
+					fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOrigImage"})
+					fakeNewImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeNewImage"})
+					subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
+				})
+				it("should delete original image", func() {
+					err := subject.DeleteOrigImage()
+					h.AssertNil(t, err)
+					h.AssertEq(t, fakeOriginalImage.Found(), false)
+				})
+			})
+
+			when("original and new image are the same", func() {
+				it.Before(func() {
+					fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOrigImage"})
+					fakeNewImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOrigImage"})
+					subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
+				})
+				it("should not delete original image", func() {
+					err := subject.DeleteOrigImage()
+					h.AssertNil(t, err)
+					h.AssertEq(t, fakeOriginalImage.Found(), true)
+				})
 			})
 		})
 	})

--- a/cache/image_cache_test.go
+++ b/cache/image_cache_test.go
@@ -40,8 +40,8 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 		tmpDir, err = ioutil.TempDir("", "")
 		h.AssertNil(t, err)
 
-		fakeOriginalImage = fakes.NewImage("fake-image", "", nil)
-		fakeNewImage = fakes.NewImage("fake-image", "", nil)
+		fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOriginalImage"})
+		fakeNewImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeImage"})
 
 		subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
 


### PR DESCRIPTION
With the reproducibility improvements, it often happens that the old and
new cache images are the same. The original image should not be
deleted in this case.

This is an issue with remote images, where the image is deleted by
digest and both the old and new images share the same digest.

Signed-off-by: Lukas Berger <bergerl@google.com>