### PR TITLE
Implement process type specific env vars

### DIFF
--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -72,6 +72,12 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			expected := "worker-process-val"
 			assertOutput(t, cmd, expected)
 		})
+
+		it("sources scripts from process specific directories", func() {
+			cmd := exec.Command("docker", "run", "--rm", launchImage, "worker")
+			expected := "sourced bp profile\nsourced bp worker profile\nsourced app profile"
+			assertOutput(t, cmd, expected)
+		})
 	})
 
 	it("respects CNB_APP_DIR and CNB_LAYERS_DIR environment variables", func() {

--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -66,6 +66,12 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			}
 			assertOutput(t, cmd, expected)
 		})
+
+		it("sets env vars from process specific directories", func() {
+			cmd := exec.Command("docker", "run", "--rm", launchImage, "worker")
+			expected := "worker-process-val"
+			assertOutput(t, cmd, expected)
+		})
 	})
 
 	it("respects CNB_APP_DIR and CNB_LAYERS_DIR environment variables", func() {
@@ -83,11 +89,11 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("sets env vars from layers", func() {
-			cmd := exec.Command("docker", "run", "--rm", launchImage, "echo $SOME_VAR $OTHER_VAR")
+			cmd := exec.Command("docker", "run", "--rm", launchImage, "echo $SOME_VAR $OTHER_VAR $WORKER_VAR")
 			if runtime.GOOS == "windows" {
-				cmd = exec.Command("docker", "run", "--rm", launchImage, "echo %SOME_VAR% %OTHER_VAR%")
+				cmd = exec.Command("docker", "run", "--rm", launchImage, "echo %SOME_VAR% %OTHER_VAR% %WORKER_VAR%")
 			}
-			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsome-bp-val other-bp-val")
+			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsome-bp-val other-bp-val worker-no-process-val")
 		})
 
 		it("passes through env vars from user, excluding excluded vars", func() {

--- a/acceptance/testdata/launcher/posix/container/layers/config/metadata.toml
+++ b/acceptance/testdata/launcher/posix/container/layers/config/metadata.toml
@@ -12,3 +12,8 @@
   command = "echo"
   args = ["Executing other-process process-type"]
   direct = true
+
+[[processes]]
+  type = "worker"
+  command = "echo $WORKER_VAR"
+  direct = false

--- a/acceptance/testdata/launcher/posix/container/layers/some_buildpack/some_layer/env.launch/worker/WORKER_VAR
+++ b/acceptance/testdata/launcher/posix/container/layers/some_buildpack/some_layer/env.launch/worker/WORKER_VAR
@@ -1,0 +1,1 @@
+worker-process-val

--- a/acceptance/testdata/launcher/posix/container/layers/some_buildpack/some_layer/env/WORKER_VAR
+++ b/acceptance/testdata/launcher/posix/container/layers/some_buildpack/some_layer/env/WORKER_VAR
@@ -1,0 +1,1 @@
+worker-no-process-val

--- a/acceptance/testdata/launcher/posix/container/layers/some_buildpack/some_layer/profile.d/worker/0_bp_worker_profile.sh
+++ b/acceptance/testdata/launcher/posix/container/layers/some_buildpack/some_layer/profile.d/worker/0_bp_worker_profile.sh
@@ -1,0 +1,1 @@
+echo "sourced bp worker profile"

--- a/acceptance/testdata/launcher/windows/container/layers/config/metadata.toml
+++ b/acceptance/testdata/launcher/windows/container/layers/config/metadata.toml
@@ -12,3 +12,8 @@
   command = "ping"
   args = ["/?"]
   direct = true
+
+[[processes]]
+  type = "worker"
+  command = "echo %WORKER_VAR%"
+  direct = false

--- a/acceptance/testdata/launcher/windows/container/layers/some_buildpack/some_layer/env.launch/worker/WORKER_VAR
+++ b/acceptance/testdata/launcher/windows/container/layers/some_buildpack/some_layer/env.launch/worker/WORKER_VAR
@@ -1,0 +1,1 @@
+worker-process-val

--- a/acceptance/testdata/launcher/windows/container/layers/some_buildpack/some_layer/env/WORKER_VAR
+++ b/acceptance/testdata/launcher/windows/container/layers/some_buildpack/some_layer/env/WORKER_VAR
@@ -1,0 +1,1 @@
+worker-no-process-val

--- a/acceptance/testdata/launcher/windows/container/layers/some_buildpack/some_layer/profile.d/worker/0_bp_worker_profile.bat
+++ b/acceptance/testdata/launcher/windows/container/layers/some_buildpack/some_layer/profile.d/worker/0_bp_worker_profile.bat
@@ -1,0 +1,1 @@
+echo sourced bp worker profile

--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -26,12 +26,12 @@ type Launcher struct {
 }
 
 func (l *Launcher) Launch(self string, cmd []string) error {
-	if err := l.env(); err != nil {
-		return errors.Wrap(err, "modify env")
-	}
 	process, err := l.processFor(cmd)
 	if err != nil {
 		return errors.Wrap(err, "determine start command")
+	}
+	if err := l.env(process); err != nil {
+		return errors.Wrap(err, "modify env")
 	}
 	if err := os.Chdir(l.AppDir); err != nil {
 		return errors.Wrap(err, "change to app directory")
@@ -81,7 +81,7 @@ func (l *Launcher) Launch(self string, cmd []string) error {
 	return nil
 }
 
-func (l *Launcher) env() error {
+func (l *Launcher) env(process Process) error {
 	appInfo, err := os.Stat(l.AppDir)
 	if err != nil {
 		return errors.Wrap(err, "find app directory")
@@ -106,7 +106,13 @@ func (l *Launcher) env() error {
 			if err := l.Env.AddEnvDir(filepath.Join(path, "env")); err != nil {
 				return err
 			}
-			return l.Env.AddEnvDir(filepath.Join(path, "env.launch"))
+			if err := l.Env.AddEnvDir(filepath.Join(path, "env.launch")); err != nil {
+				return err
+			}
+			if process.Type == "" {
+				return nil
+			}
+			return l.Env.AddEnvDir(filepath.Join(path, "env.launch", process.Type))
 		}); err != nil {
 			return errors.Wrap(err, "add layer env")
 		}

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -277,15 +277,19 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 					env.EXPECT().AddRootDir(filepath.Join(tmpDir, "launch", "bp.1", "layer2")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.1", "layer1", "env")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.1", "layer1", "env.launch")),
+					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.1", "layer1", "env.launch", "start")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.1", "layer2", "env")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.1", "layer2", "env.launch")),
+					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.1", "layer2", "env.launch", "start")),
 
 					env.EXPECT().AddRootDir(filepath.Join(tmpDir, "launch", "bp.2", "layer3")),
 					env.EXPECT().AddRootDir(filepath.Join(tmpDir, "launch", "bp.2", "layer4")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer3", "env")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer3", "env.launch")),
+					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer3", "env.launch", "start")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer4", "env")),
 					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer4", "env.launch")),
+					env.EXPECT().AddEnvDir(filepath.Join(tmpDir, "launch", "bp.2", "layer4", "env.launch", "start")),
 				)
 				if err := launcher.Launch("/path/to/launcher", []string{"start"}); err != nil {
 					t.Fatal(err)

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -348,15 +348,21 @@ echo $OUT
 
 				mkdir(t,
 					filepath.Join(tmpDir, "launch", "bp.1", "layer", "profile.d"),
+					filepath.Join(tmpDir, "launch", "bp.1", "layer", "profile.d", "start"),
 					filepath.Join(tmpDir, "launch", "bp.2", "layer", "profile.d"),
+					filepath.Join(tmpDir, "launch", "bp.2", "layer", "profile.d", "start"),
 				)
 
 				if runtime.GOOS == "windows" {
 					mkfile(t, "set OUT=%OUT%prof1,", filepath.Join(tmpDir, "launch", "bp.1", "layer", "profile.d", "prof1.bat"))
+					mkfile(t, "set OUT=%OUT%prof1start,", filepath.Join(tmpDir, "launch", "bp.1", "layer", "profile.d", "start", "prof1.bat"))
 					mkfile(t, "set OUT=%OUT%prof2,", filepath.Join(tmpDir, "launch", "bp.2", "layer", "profile.d", "prof2.bat"))
+					mkfile(t, "set OUT=%OUT%prof2start,", filepath.Join(tmpDir, "launch", "bp.2", "layer", "profile.d", "start", "prof2.bat"))
 				} else {
 					mkfile(t, "export OUT=${OUT}prof1,", filepath.Join(tmpDir, "launch", "bp.1", "layer", "profile.d", "prof1"))
+					mkfile(t, "export OUT=${OUT}prof1start,", filepath.Join(tmpDir, "launch", "bp.1", "layer", "profile.d", "start", "prof1"))
 					mkfile(t, "export OUT=${OUT}prof2,", filepath.Join(tmpDir, "launch", "bp.2", "layer", "profile.d", "prof2"))
+					mkfile(t, "export OUT=${OUT}prof2start,", filepath.Join(tmpDir, "launch", "bp.2", "layer", "profile.d", "start", "prof2"))
 				}
 
 				env.EXPECT().AddRootDir(gomock.Any()).AnyTimes()
@@ -373,7 +379,7 @@ echo $OUT
 					stderr := rdfile(t, filepath.Join(tmpDir, "stderr"))
 					t.Fatalf("stdout was empty: stderr: %s\n", stderr)
 				}
-				if diff := cmp.Diff(strings.ReplaceAll(stdout, "\r\n", "\n"), "hi from app\nprof1,prof2,\n"); diff != "" {
+				if diff := cmp.Diff(strings.ReplaceAll(stdout, "\r\n", "\n"), "hi from app\nprof1,prof1start,prof2,prof2start,\n"); diff != "" {
 					t.Fatalf("syscall.Exec stdout did not match: (-got +want)\n%s\n", diff)
 				}
 			})
@@ -393,7 +399,7 @@ echo $OUT
 						stderr := rdfile(t, filepath.Join(tmpDir, "stderr"))
 						t.Fatalf("stdout was empty: stderr: %s\n", stderr)
 					}
-					if diff := cmp.Diff(strings.ReplaceAll(stdout, "\r\n", "\n"), "hi from app\nprof2,prof1,\n"); diff != "" {
+					if diff := cmp.Diff(strings.ReplaceAll(stdout, "\r\n", "\n"), "hi from app\nprof2,prof2start,prof1,prof1start,\n"); diff != "" {
 						t.Fatalf("syscall.Exec stdout did not match: (-got +want)\n%s\n", diff)
 					}
 				})
@@ -418,7 +424,7 @@ echo $OUT
 						stderr := rdfile(t, filepath.Join(tmpDir, "stderr"))
 						t.Fatalf("stdout was empty: stderr: %s\n", stderr)
 					}
-					if diff := cmp.Diff(strings.ReplaceAll(stdout, "\r\n", "\n"), "hi from app\nprof1,prof2,profile\n"); diff != "" {
+					if diff := cmp.Diff(strings.ReplaceAll(stdout, "\r\n", "\n"), "hi from app\nprof1,prof1start,prof2,prof2start,profile\n"); diff != "" {
 						t.Fatalf("syscall.Exec stdout did not match: (-got +want)\n%s\n", diff)
 					}
 				})


### PR DESCRIPTION
Include process type specific paths when processing env vars during launch.

Spec: https://github.com/buildpacks/spec/pull/98

Signed-off-by: Jesse Brown <jabrown85@gmail.com>