### PR TITLE
Fix case-sensitivity bug when initializing env vars

### DIFF
--- a/env/build.go
+++ b/env/build.go
@@ -1,6 +1,9 @@
 package env
 
-import "runtime"
+import (
+	"runtime"
+	"strings"
+)
 
 var BuildEnvIncludelist = []string{
 	"CNB_STACK_ID",
@@ -8,22 +11,32 @@ var BuildEnvIncludelist = []string{
 	"HOME",
 }
 
+var ignoreEnvVarCase = runtime.GOOS == "windows"
+
 func NewBuildEnv(environ []string) *Env {
 	return &Env{
 		RootDirMap: POSIXBuildEnv,
-		Vars:       varsFromEnviron(environ, runtime.GOOS == "windows", isNotIncluded),
+		Vars:       varsFromEnviron(environ, ignoreEnvVarCase, isNotIncluded),
 	}
+}
+
+func matches(k1, k2 string) bool {
+	if ignoreEnvVarCase {
+		k1 = strings.ToUpper(k1)
+		k2 = strings.ToUpper(k2)
+	}
+	return k1 == k2
 }
 
 func isNotIncluded(k string) bool {
 	for _, wk := range BuildEnvIncludelist {
-		if wk == k {
+		if matches(wk, k) {
 			return false
 		}
 	}
 	for _, wks := range POSIXBuildEnv {
 		for _, wk := range wks {
-			if wk == k {
+			if matches(wk, k) {
 				return false
 			}
 		}

--- a/env/build_test.go
+++ b/env/build_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"runtime"
 	"sort"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/env"
+	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestBuildEnv(t *testing.T) {
@@ -39,6 +41,23 @@ func testBuildEnv(t *testing.T, when spec.G, it spec.S) {
 			}); s != "" {
 				t.Fatalf("Unexpected env\n%s\n", s)
 			}
+		})
+
+		when("building in Windows", func() {
+			it.Before(func() {
+				if runtime.GOOS != "windows" {
+					t.Skip("This test only applies to Windows builds")
+				}
+			})
+
+			it("ignores case when initializing", func() {
+				benv := env.NewBuildEnv([]string{
+					"Path=some-path",
+				})
+				out := benv.List()
+				h.AssertEq(t, len(out), 1)
+				h.AssertEq(t, out[0], "PATH=some-path")
+			})
 		})
 
 		it("allows keys with '='", func() {

--- a/env/launch.go
+++ b/env/launch.go
@@ -1,7 +1,5 @@
 package env
 
-import "runtime"
-
 var LaunchEnvExcludelist = []string{
 	"CNB_LAYERS_DIR",
 	"CNB_APP_DIR",
@@ -11,13 +9,13 @@ var LaunchEnvExcludelist = []string{
 func NewLaunchEnv(environ []string) *Env {
 	return &Env{
 		RootDirMap: POSIXLaunchEnv,
-		Vars:       varsFromEnviron(environ, runtime.GOOS == "windows", isExcluded),
+		Vars:       varsFromEnviron(environ, ignoreEnvVarCase, isExcluded),
 	}
 }
 
 func isExcluded(k string) bool {
 	for _, wk := range LaunchEnvExcludelist {
-		if wk == k {
+		if matches(wk, k) {
 			return true
 		}
 	}

--- a/env/launch_test.go
+++ b/env/launch_test.go
@@ -1,6 +1,7 @@
 package env_test
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -8,6 +9,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/env"
+	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestLaunchEnv(t *testing.T) {
@@ -28,6 +30,23 @@ func testLaunchEnv(t *testing.T, when spec.G, it spec.S) {
 			}); s != "" {
 				t.Fatalf("Unexpected env\n%s\n", s)
 			}
+		})
+
+		when("launching in Windows", func() {
+			it.Before(func() {
+				if runtime.GOOS != "windows" {
+					t.Skip("This test only applies to Windows launches")
+				}
+			})
+
+			it("ignores case when initializing", func() {
+				benv := env.NewBuildEnv([]string{
+					"Path=some-path",
+				})
+				out := benv.List()
+				h.AssertEq(t, len(out), 1)
+				h.AssertEq(t, out[0], "PATH=some-path")
+			})
 		})
 
 		it("allows keys with '='", func() {


### PR DESCRIPTION
Signed-off-by: Malini Valliath <mvalliath@pivotal.io>
Signed-off-by: Victoria Henry<vhenry@pivotal.io>
Signed-off-by: Andrew Meyer <meyeran@vmware.com>