### PR TITLE
Fix make docker-run-windows branch merge-slice-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,14 +180,16 @@ package-windows:
 	@echo "> Packaging lifecycle for $(GOOS)..."
 	$(GOCMD) run tools$/packager$/main.go -os $(GOOS) -launcherExePath $(GOOS_DIR)$/lifecycle$/launcher.exe -lifecycleExePath $(GOOS_DIR)$/lifecycle$/lifecycle.exe -lifecycleVersion $(LIFECYCLE_VERSION) -platformAPI $(PLATFORM_API) -buildpackAPI $(BUILDPACK_API) -outputPackagePath $(BUILD_DIR)$/$(ARCHIVE_NAME).tgz
 
+# Ensure workdir is clean and build image from .git
 docker-build-source-image-windows:
-	docker build -f tools/Dockerfile.windows --tag $(SOURCE_COMPILATION_IMAGE) --build-arg image_tag=$(WINDOWS_COMPILATION_IMAGE) --cache-from=$(SOURCE_COMPILATION_IMAGE) --isolation=process --quiet .
+	$(if $(shell git status --short), @echo Uncommitted changes. Refusing to run. && exit 1)
+	docker build -f tools/Dockerfile.windows --tag $(SOURCE_COMPILATION_IMAGE) --build-arg image_tag=$(WINDOWS_COMPILATION_IMAGE) --cache-from=$(SOURCE_COMPILATION_IMAGE) --isolation=process --quiet .git
 
 docker-run-windows: docker-build-source-image-windows
 docker-run-windows:
 	@echo "> Running '$(DOCKER_CMD)' in docker windows..."
 	@docker volume rm -f lifecycle-out
-	@docker run -v lifecycle-out:c:/lifecycle/out -e LIFECYCLE_VERSION -e PLATFORM_API -e BUILDPACK_API -v gopathcache:c:/gopath -v '\\.\pipe\docker_engine:\\.\pipe\docker_engine' --isolation=process --rm $(SOURCE_COMPILATION_IMAGE) $(DOCKER_CMD)
+	docker run -v lifecycle-out:c:/lifecycle/out -e LIFECYCLE_VERSION -e PLATFORM_API -e BUILDPACK_API -v gopathcache:c:/gopath -v '\\.\pipe\docker_engine:\\.\pipe\docker_engine' --isolation=process --interactive --tty --rm $(SOURCE_COMPILATION_IMAGE) $(DOCKER_CMD)
 	docker run -v lifecycle-out:c:/lifecycle/out --rm $(SOURCE_COMPILATION_IMAGE) tar -cf- out | tar -xf-
 	@docker volume rm -f lifecycle-out
 

--- a/tools/Dockerfile.windows
+++ b/tools/Dockerfile.windows
@@ -15,7 +15,11 @@ RUN mklink C:\git\usr\bin\bash.exe sh.exe && \
     mkdir c:\docker-cli\bin && \
     curl.exe -o c:\docker-cli\bin\docker.exe -L "https://github.com/StefanScherer/docker-cli-builder/releases/download/19.03.3/docker.exe" && \
     \
-    setx /M PATH "%PATH%;c:\make\bin;c:\jq\bin;c:\docker-cli\bin"
+    setx /M PATH "%PATH%;c:\make\bin;c:\jq\bin;c:\docker-cli\bin" && \
+    \
+    git config --global core.autocrlf false && \
+    git config --global core.eol lf && \
+    git config --global core.symlinks true
 
 # For reusing dependencies `-v gopathcache:c:/gopath`
 ENV GOPATH=c:\\gopath
@@ -24,5 +28,7 @@ VOLUME ["c:/gopath"]
 
 WORKDIR /lifecycle
 
-# Copy source for consistent filesystem duplication of source (docker cp, volumes are inconsistent with symlinks/hardlinks on Windows)
-COPY . /lifecycle/
+# Copy git directory for consistent filesystem duplication of source (docker build, cp, volumes are inconsistent with symlinks/hardlinks on Windows)
+COPY . /lifecycle/.git
+
+RUN git reset --hard HEAD


### PR DESCRIPTION
This a fix for `make docker-run-windows` on top of #340 

It changes the Windows-daemon-only target