### PR TITLE
feat: use more specific codes during detect

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -12,9 +12,10 @@ const (
 	CodeInvalidArgs = 3
 	// 4: CodeInvalidEnv
 	// 5: CodeNotFound
-	CodeFailedDetect = 6
-	CodeFailedBuild  = 7
-	CodeFailedLaunch = 8
+	CodeFailedDetect           = 100
+	CodeFailedDetectWithErrors = 101
+	CodeFailedBuild            = 7
+	CodeFailedLaunch           = 8
 	// 9: CodeFailedUpdate
 	CodeFailedSave   = 10
 	CodeIncompatible = 11

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -79,11 +79,15 @@ func (da detectArgs) detect() (lifecycle.BuildpackGroup, lifecycle.BuildPlan, er
 		Logger:        cmd.Logger,
 	})
 	if err != nil {
-		if err == lifecycle.ErrFail {
+		if err == lifecycle.ErrFail || err == lifecycle.ErrFailWithErrors {
 			cmd.Logger.Error("No buildpack groups passed detection.")
 			cmd.Logger.Error("Please check that you are running against the correct path.")
 		}
-		return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, cmd.CodeFailedDetect, "detect")
+		exitCode := cmd.CodeFailedDetect
+		if err == lifecycle.ErrFailWithErrors {
+			exitCode = cmd.CodeFailedDetectWithErrors
+		}
+		return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, exitCode, "detect")
 	}
 
 	return group, plan, nil

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -79,15 +79,17 @@ func (da detectArgs) detect() (lifecycle.BuildpackGroup, lifecycle.BuildPlan, er
 		Logger:        cmd.Logger,
 	})
 	if err != nil {
-		if err == lifecycle.ErrFailedDetection || err == lifecycle.ErrBuildpack {
+		switch err {
+		case lifecycle.ErrFailedDetection:
 			cmd.Logger.Error("No buildpack groups passed detection.")
 			cmd.Logger.Error("Please check that you are running against the correct path.")
+			return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, cmd.CodeFailedDetect, "detect")
+		case lifecycle.ErrBuildpack:
+			cmd.Logger.Error("No buildpack groups passed detection.")
+			return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, cmd.CodeFailedDetectWithErrors, "detect")
+		default:
+			return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, 1, "detect")
 		}
-		exitCode := cmd.CodeFailedDetect
-		if err == lifecycle.ErrBuildpack {
-			exitCode = cmd.CodeFailedDetectWithErrors
-		}
-		return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, exitCode, "detect")
 	}
 
 	return group, plan, nil

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -79,12 +79,12 @@ func (da detectArgs) detect() (lifecycle.BuildpackGroup, lifecycle.BuildPlan, er
 		Logger:        cmd.Logger,
 	})
 	if err != nil {
-		if err == lifecycle.ErrFail || err == lifecycle.ErrFailWithErrors {
+		if err == lifecycle.ErrFailedDetection || err == lifecycle.ErrBuildpack {
 			cmd.Logger.Error("No buildpack groups passed detection.")
 			cmd.Logger.Error("Please check that you are running against the correct path.")
 		}
 		exitCode := cmd.CodeFailedDetect
-		if err == lifecycle.ErrFailWithErrors {
+		if err == lifecycle.ErrBuildpack {
 			exitCode = cmd.CodeFailedDetectWithErrors
 		}
 		return lifecycle.BuildpackGroup{}, lifecycle.BuildPlan{}, cmd.FailErrCode(err, exitCode, "detect")

--- a/detector.go
+++ b/detector.go
@@ -21,7 +21,7 @@ const (
 )
 
 var ErrFailedDetection = errors.New("no buildpacks participating")
-var ErrBuildpack = errors.New("no buildpacks participating: detect failed with errors")
+var ErrBuildpack = errors.New("buildpack(s) failed with err")
 
 type BuildPlan struct {
 	Entries []BuildPlanEntry `toml:"entries"`

--- a/detector_test.go
+++ b/detector_test.go
@@ -81,7 +81,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			_, _, err := lifecycle.BuildpackOrder{
 				{Group: []lifecycle.Buildpack{{ID: "E", Version: "v1"}}},
 			}.Detect(config)
-			if err != lifecycle.ErrFail {
+			if err != lifecycle.ErrFailedDetection {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
@@ -128,7 +128,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 		it("should fail if the group is empty", func() {
 			_, _, err := lifecycle.BuildpackOrder([]lifecycle.BuildpackGroup{{}}).Detect(config)
-			if err != lifecycle.ErrFail {
+			if err != lifecycle.ErrFailedDetection {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
@@ -149,7 +149,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					{ID: "B", Version: "v1", Optional: true},
 				}},
 			}.Detect(config)
-			if err != lifecycle.ErrFail {
+			if err != lifecycle.ErrFailedDetection {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
@@ -174,7 +174,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					{ID: "B", Version: "v1", Optional: false},
 				}},
 			}.Detect(config)
-			if err != lifecycle.ErrFailWithErrors {
+			if err != lifecycle.ErrBuildpack {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
@@ -331,7 +331,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						{ID: "C", Version: "v1"},
 					}},
 				}.Detect(config)
-				if err != lifecycle.ErrFail {
+				if err != lifecycle.ErrFailedDetection {
 					t.Fatalf("Unexpected error:\n%s\n", err)
 				}
 
@@ -359,7 +359,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 						{ID: "C", Version: "v1", Optional: true},
 					}},
 				}.Detect(config)
-				if err != lifecycle.ErrFail {
+				if err != lifecycle.ErrFailedDetection {
 					t.Fatalf("Unexpected error:\n%s\n", err)
 				}
 

--- a/detector_test.go
+++ b/detector_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -167,7 +166,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		it("should fail with specific error if any bp detect fails in an unexpected way", func() {
 			mkappfile("100", "detect-status")
 			mkappfile("0", "detect-status-A-v1")
-			mkappfile("-1", "detect-status-B-v1")
+			mkappfile("127", "detect-status-B-v1")
 			_, _, err := lifecycle.BuildpackOrder{
 				{Group: []lifecycle.Buildpack{
 					{ID: "A", Version: "v1", Optional: false},
@@ -178,22 +177,12 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
-			if runtime.GOOS == "windows" {
-				if s := allLogs(logHandler); !strings.HasSuffix(s,
-					"======== Results ========\n"+
-						"pass: A@v1\n"+
-						"err:  B@v1 (4294967295)\n",
-				) {
-					t.Fatalf("Unexpected log:\n%s\n", s)
-				}
-			} else {
-				if s := allLogs(logHandler); !strings.HasSuffix(s,
-					"======== Results ========\n"+
-						"pass: A@v1\n"+
-						"err:  B@v1 (255)\n",
-				) {
-					t.Fatalf("Unexpected log:\n%s\n", s)
-				}
+			if s := allLogs(logHandler); !strings.HasSuffix(s,
+				"======== Results ========\n"+
+					"pass: A@v1\n"+
+					"err:  B@v1 (127)\n",
+			) {
+				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
 		})
 

--- a/detector_test.go
+++ b/detector_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -177,12 +178,22 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
-			if s := allLogs(logHandler); !strings.HasSuffix(s,
-				"======== Results ========\n"+
-					"pass: A@v1\n"+
-					"err:  B@v1 (255)\n",
-			) {
-				t.Fatalf("Unexpected log:\n%s\n", s)
+			if runtime.GOOS == "windows" {
+				if s := allLogs(logHandler); !strings.HasSuffix(s,
+					"======== Results ========\n"+
+						"pass: A@v1\n"+
+						"err:  B@v1 (4294967295)\n",
+				) {
+					t.Fatalf("Unexpected log:\n%s\n", s)
+				}
+			} else {
+				if s := allLogs(logHandler); !strings.HasSuffix(s,
+					"======== Results ========\n"+
+						"pass: A@v1\n"+
+						"err:  B@v1 (255)\n",
+				) {
+					t.Fatalf("Unexpected log:\n%s\n", s)
+				}
 			}
 		})
 

--- a/detector_test.go
+++ b/detector_test.go
@@ -163,6 +163,29 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 
+		it("should fail with specific error if any bp detect fails in an unexpected way", func() {
+			mkappfile("100", "detect-status")
+			mkappfile("0", "detect-status-A-v1")
+			mkappfile("-1", "detect-status-B-v1")
+			_, _, err := lifecycle.BuildpackOrder{
+				{Group: []lifecycle.Buildpack{
+					{ID: "A", Version: "v1", Optional: false},
+					{ID: "B", Version: "v1", Optional: false},
+				}},
+			}.Detect(config)
+			if err != lifecycle.ErrFailWithErrors {
+				t.Fatalf("Unexpected error:\n%s\n", err)
+			}
+
+			if s := allLogs(logHandler); !strings.HasSuffix(s,
+				"======== Results ========\n"+
+					"pass: A@v1\n"+
+					"err:  B@v1 (255)\n",
+			) {
+				t.Fatalf("Unexpected log:\n%s\n", s)
+			}
+		})
+
 		it("should select an appropriate env type", func() {
 			mkappfile("0", "detect-status-A-v1.clear", "detect-status-B-v1")
 


### PR DESCRIPTION
Platforms should have the ability to tell the difference between a detector failure because of no passing buildpacks and a detector failure because of no passing buildpacks that _had errors_ during detect.

Detector will now return a `100` or `101` depending on how detection failed.

[Issue #306](https://github.com/buildpacks/lifecycle/issues/306)
[Updatd Spec](https://github.com/buildpacks/spec/blob/platform/0.4/platform.md#outputs)

Signed-off-by: Jesse Brown <jabrown85@gmail.com>