### PR TITLE
feat: make buildpack detection errors info level

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -73,8 +73,6 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 
 		switch run.Code {
 		case CodeDetectPass, CodeDetectFail:
-		case -1:
-			outputLogf = c.Logger.Infof
 		default:
 			outputLogf = c.Logger.Infof
 		}

--- a/detector.go
+++ b/detector.go
@@ -69,23 +69,23 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 			return nil, nil, errors.Errorf("missing detection of '%s'", bp)
 		}
 		run := t.(detectRun)
+		outputLogf := c.Logger.Debugf
+
+		switch run.Code {
+		case CodeDetectPass, CodeDetectFail:
+		case -1:
+			outputLogf = c.Logger.Infof
+		default:
+			outputLogf = c.Logger.Infof
+		}
+
 		if len(run.Output) > 0 {
-			outputLogf := c.Logger.Debugf
-
-			switch run.Code {
-			case CodeDetectPass, CodeDetectFail:
-			case -1:
-				outputLogf = c.Logger.Infof
-			default:
-				outputLogf = c.Logger.Infof
-			}
-
 			outputLogf("======== Output: %s ========", bp)
 			outputLogf(string(run.Output))
 		}
 		if run.Err != nil {
-			c.Logger.Debugf("======== Error: %s ========", bp)
-			c.Logger.Debug(run.Err.Error())
+			outputLogf("======== Error: %s ========", bp)
+			outputLogf(run.Err.Error())
 		}
 		runs = append(runs, run)
 	}

--- a/detector.go
+++ b/detector.go
@@ -70,8 +70,18 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 		}
 		run := t.(detectRun)
 		if len(run.Output) > 0 {
-			c.Logger.Debugf("======== Output: %s ========", bp)
-			c.Logger.Debug(string(run.Output))
+			outputLogf := c.Logger.Debugf
+
+			switch run.Code {
+			case CodeDetectPass, CodeDetectFail:
+			case -1:
+				outputLogf = c.Logger.Infof
+			default:
+				outputLogf = c.Logger.Infof
+			}
+
+			outputLogf("======== Output: %s ========", bp)
+			outputLogf(string(run.Output))
 		}
 		if run.Err != nil {
 			c.Logger.Debugf("======== Error: %s ========", bp)
@@ -99,11 +109,11 @@ func (c *DetectConfig) process(done []Buildpack) ([]Buildpack, []BuildPlanEntry,
 			}
 			detected = detected && bp.Optional
 		case -1:
-			c.Logger.Debugf("err:  %s", bp)
+			c.Logger.Infof("err:  %s", bp)
 			buildpackErr = true
 			detected = detected && bp.Optional
 		default:
-			c.Logger.Debugf("err:  %s (%d)", bp, run.Code)
+			c.Logger.Infof("err:  %s (%d)", bp, run.Code)
 			buildpackErr = true
 			detected = detected && bp.Optional
 		}


### PR DESCRIPTION
Builpacks which do not return pass (`0`) or fail (`100`) will now have their output as well as the resulting `err` message logged at info level.

[Issue](https://github.com/buildpacks/lifecycle/issues/283)

Signed-off-by: Jesse Brown <jabrown85@gmail.com>