### PR TITLE
packaging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,14 @@ ifeq ($(OS),Windows_NT)
 	call del $(OUT_DIR)$/builder.exe
 	call del $(OUT_DIR)$/exporter.exe
 	call del $(OUT_DIR)$/rebaser.exe
+	call del $(OUT_DIR)$/creator.exe
 	call mklink $(OUT_DIR)$/detector.exe lifecycle.exe
 	call mklink $(OUT_DIR)$/analyzer.exe lifecycle.exe
 	call mklink $(OUT_DIR)$/restorer.exe lifecycle.exe
 	call mklink $(OUT_DIR)$/builder.exe  lifecycle.exe
 	call mklink $(OUT_DIR)$/exporter.exe lifecycle.exe
 	call mklink $(OUT_DIR)$/rebaser.exe  lifecycle.exe
+	call mklink $(OUT_DIR)$/creator.exe  lifecycle.exe
 else
 	ln -sf lifecycle.exe $(OUT_DIR)$/detector.exe
 	ln -sf lifecycle.exe $(OUT_DIR)$/analyzer.exe
@@ -115,6 +117,7 @@ else
 	ln -sf lifecycle.exe $(OUT_DIR)$/builder.exe
 	ln -sf lifecycle.exe $(OUT_DIR)$/exporter.exe
 	ln -sf lifecycle.exe $(OUT_DIR)$/rebaser.exe
+	ln -sf lifecycle.exe $(OUT_DIR)$/creator.exe
 endif
 
 build-darwin: build-darwin-lifecycle build-darwin-launcher

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,7 @@ build: build-linux build-windows
 build-linux: build-linux-lifecycle build-linux-symlinks build-linux-launcher
 build-windows: build-windows-lifecycle build-windows-symlinks build-windows-launcher
 
-build-linux-lifecycle: descriptor-linux $(BUILD_DIR)/linux/lifecycle/lifecycle
-
-descriptor-linux: $(BUILD_DIR)/linux/lifecycle/lifecycle.toml
-$(BUILD_DIR)/linux/lifecycle/lifecycle.toml: $(LIFECYCLE_DESCRIPTOR_PATH)
-$(BUILD_DIR)/linux/lifecycle/lifecycle.toml:
-	mkdir -p $(BUILD_DIR)/linux/lifecycle
-	cp $(LIFECYCLE_DESCRIPTOR_PATH) $(BUILD_DIR)/linux/lifecycle/lifecycle.toml
+build-linux-lifecycle: $(BUILD_DIR)/linux/lifecycle/lifecycle
 
 $(BUILD_DIR)/linux/lifecycle/lifecycle: export GOOS:=linux
 $(BUILD_DIR)/linux/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
@@ -79,13 +73,7 @@ build-linux-symlinks:
 	ln -sf lifecycle $(OUT_DIR)/rebaser
 	ln -sf lifecycle $(OUT_DIR)/creator
 
-build-windows-lifecycle: descriptor-windows $(BUILD_DIR)/windows/lifecycle/lifecycle.exe
-
-descriptor-windows: $(BUILD_DIR)/windows/lifecycle/lifecycle.toml
-$(BUILD_DIR)/windows/lifecycle/lifecycle.toml: $(LIFECYCLE_DESCRIPTOR_PATH)
-$(BUILD_DIR)/windows/lifecycle/lifecycle.toml:
-	mkdir -p $(BUILD_DIR)$/windows$/lifecycle
-	cp $(LIFECYCLE_DESCRIPTOR_PATH) $(BUILD_DIR)$/windows$/lifecycle$/lifecycle.toml
+build-windows-lifecycle: $(BUILD_DIR)/windows/lifecycle/lifecycle.exe
 
 $(BUILD_DIR)/windows/lifecycle/lifecycle.exe: export GOOS:=windows
 $(BUILD_DIR)/windows/lifecycle/lifecycle.exe: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)$/lifecycle
@@ -129,13 +117,7 @@ else
 	ln -sf lifecycle.exe $(OUT_DIR)$/rebaser.exe
 endif
 
-descriptor-darwin: $(BUILD_DIR)/darwin/lifecycle/lifecycle.toml
-$(BUILD_DIR)/darwin/lifecycle/lifecycle.toml: $(LIFECYCLE_DESCRIPTOR_PATH)
-$(BUILD_DIR)/darwin/lifecycle/lifecycle.toml:
-	mkdir -p $(BUILD_DIR)/darwin/lifecycle
-	cp $(LIFECYCLE_DESCRIPTOR_PATH) $(BUILD_DIR)/darwin/lifecycle/lifecycle.toml
-
-build-darwin: descriptor-darwin build-darwin-lifecycle build-darwin-launcher
+build-darwin: build-darwin-lifecycle build-darwin-launcher
 
 build-darwin-lifecycle: $(BUILD_DIR)/darwin/lifecycle/lifecycle
 $(BUILD_DIR)/darwin/lifecycle/lifecycle: export GOOS:=darwin
@@ -214,7 +196,7 @@ package-linux: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS)
 package-linux: PACKAGER=./tools/packager/main.go
 package-linux:
 	@echo "> Packaging lifecycle for $(GOOS)..."
-	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH)
+	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH) -descriptorPath $(LIFECYCLE_DESCRIPTOR_PATH)
 
 package-windows: GOOS:=windows
 package-windows: INPUT_DIR:=$(BUILD_DIR)$/$(GOOS)$/lifecycle
@@ -222,7 +204,7 @@ package-windows: ARCHIVE_PATH=$(BUILD_DIR)$/lifecycle-v$(LIFECYCLE_VERSION)+$(GO
 package-windows: PACKAGER=.$/tools$/packager$/main.go
 package-windows:
 	@echo "> Packaging lifecycle for $(GOOS)..."
-	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH)
+	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH) -descriptorPath $(LIFECYCLE_DESCRIPTOR_PATH)
 
 # Ensure workdir is clean and build image from .git
 docker-build-source-image-windows:

--- a/archive/compress_test.go
+++ b/archive/compress_test.go
@@ -51,6 +51,7 @@ func testWrite(t *testing.T, when spec.G, it spec.S) {
 			tw = &archive.NormalizingTarWriter{TarWriter: tar.NewWriter(file)}
 			tw.WithUID(uid)
 			tw.WithGID(gid)
+			tw.WithModTime(archive.NormalizedModTime)
 		})
 
 		it.After(func() {

--- a/archive/writer_test.go
+++ b/archive/writer_test.go
@@ -31,13 +31,13 @@ func testNormalizingTarWriter(t *testing.T, when spec.G, it spec.S) {
 			ntw = archive.NewNormalizingTarWriter(ftw)
 		})
 
-		it("normalizes the mod time", func() {
+		it("sets empty Uname and Gname", func() {
 			h.AssertNil(t, ntw.WriteHeader(&tar.Header{
-				ModTime: time.Now(),
+				Uname: "some-uname",
+				Gname: "some-gname",
 			}))
-			if !ftw.getLastHeader().ModTime.Equal(time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)) {
-				t.Fatalf("failed to normalize the mod time")
-			}
+			h.AssertEq(t, ftw.getLastHeader().Uname, "")
+			h.AssertEq(t, ftw.getLastHeader().Gname, "")
 		})
 
 		when("windows", func() {
@@ -55,7 +55,7 @@ func testNormalizingTarWriter(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("#UID", func() {
+		when("#WithUID", func() {
 			it("sets the uid", func() {
 				ntw.WithUID(999)
 				h.AssertNil(t, ntw.WriteHeader(&tar.Header{
@@ -65,13 +65,25 @@ func testNormalizingTarWriter(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("#GID", func() {
+		when("#WithGID", func() {
 			it("sets the gid", func() {
 				ntw.WithGID(999)
 				h.AssertNil(t, ntw.WriteHeader(&tar.Header{
 					Gid: 888,
 				}))
 				h.AssertEq(t, ftw.getLastHeader().Gid, 999)
+			})
+		})
+
+		when("#WithModTime", func() {
+			it("sets the mod time", func() {
+				ntw.WithModTime(archive.NormalizedModTime)
+				h.AssertNil(t, ntw.WriteHeader(&tar.Header{
+					ModTime: time.Now(),
+				}))
+				if !ftw.getLastHeader().ModTime.Equal(time.Date(1980, time.January, 1, 0, 0, 1, 0, time.UTC)) {
+					t.Fatalf("failed to normalize the mod time")
+				}
 			})
 		})
 	})

--- a/layers/writer.go
+++ b/layers/writer.go
@@ -35,8 +35,12 @@ func (lw *layerWriter) Digest() string {
 }
 
 func tarWriter(lw *layerWriter) *archive.NormalizingTarWriter {
+	var tw *archive.NormalizingTarWriter
 	if runtime.GOOS == "windows" {
-		return archive.NewNormalizingTarWriter(layer.NewWindowsWriter(lw))
+		tw = archive.NewNormalizingTarWriter(layer.NewWindowsWriter(lw))
+	} else {
+		tw = archive.NewNormalizingTarWriter(tar.NewWriter(lw))
 	}
-	return archive.NewNormalizingTarWriter(tar.NewWriter(lw))
+	tw.WithModTime(archive.NormalizedModTime)
+	return tw
 }

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -181,6 +181,7 @@ func lifecycleLayer() string {
 	defer lf.Close()
 	tw := tar.NewWriter(lf)
 	ntw := archive.NewNormalizingTarWriter(tw)
+	ntw.WithModTime(archive.NormalizedModTime)
 	ntw.WithUID(0)
 	ntw.WithGID(0)
 	ntw.WriteHeader(&tar.Header{

--- a/tools/packager/main.go
+++ b/tools/packager/main.go
@@ -48,7 +48,7 @@ func main() {
 		os.Exit(3)
 	}
 	if err := archive.AddFileToArchive(tw, "lifecycle.toml", descriptorInfo); err != nil {
-		fmt.Printf("Failed to write descriptor to arichive: %s", err)
+		fmt.Printf("Failed to write descriptor to archive: %s", err)
 		os.Exit(4)
 	}
 
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	if err := archive.AddDirToArchive(tw, filepath.Base(inputDir)); err != nil {
-		fmt.Printf("Failed to write dir to arichive: %s", err)
+		fmt.Printf("Failed to write dir to archive: %s", err)
 		os.Exit(6)
 	}
 }


### PR DESCRIPTION
* Uses Normalizing tar writer to fix paths when running on windows
* Move lifecycle.toml to top-level in archive
* Zeros UID/GID

Signed-off-by: Emily Casey <ecasey@vmware.com>