### PR TITLE
Make lifecycle.toml backwards compatible

### DIFF
--- a/lifecycle.toml
+++ b/lifecycle.toml
@@ -6,5 +6,11 @@
   deprecated = []
   supported = ["0.3", "0.4"]
 
+# For backwards compatibility the minimum supported APIs are provided in RFC-0011 format
+# https://github.com/buildpacks/rfcs/blob/main/text/0011-lifecycle-descriptor.md
+[api]
+  platform = "0.3"
+  buildpack = "0.2"
+
 [lifecycle]
   version = "0.9.0"


### PR DESCRIPTION
We said this likely wasn't necessary in (RFC-0049)[https://github.com/buildpacks/rfcs/blob/main/text/0049-multi-api-lifecycle-descriptor.md#backwards-compatibility]

But... after seeing how `pack` fails when provided the new format (an NPE) I think making `lifecycle.toml` backwards compatible is probably the right call.