### PR TITLE
Leave metadata.version in buildpack plan provided to 0.2 buildpacks

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -227,7 +227,6 @@ func (bom *BOMEntry) convertMetadataToVersion() error {
 			return errors.New("top level version does not match metadata version")
 		}
 		bom.Version = metadataVersion
-		delete(bom.Metadata, "version")
 	}
 	return nil
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -109,7 +109,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					}
 					h.AssertEq(t, buildMetadata.BOM[0].Version, "v1")
 					_, versionExist := buildMetadata.BOM[0].Metadata["version"]
-					h.AssertEq(t, versionExist, false)
+					h.AssertEq(t, versionExist, true)
 				})
 			})
 


### PR DESCRIPTION
Addresses updates to:

#357 
#330 

This change perserves `metadata.version` keys in the buildpack plan provided to `0.2` buildpacks. `0.2` buildpacks may expect `metadata.version` or `version` and therefore we provide both. The same change has been made for the Platform`0.3` BOM. Users of existing APIs may receive extra keys but no keys are removed.