### PR TITLE
Fix PAX headers in windows lifecycle images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/apex/log v1.1.2-0.20190827100214-baa5455d1012
-	github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d
+	github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a
 	github.com/containerd/containerd v1.3.3 // indirect
 	github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37 // indirect
 	github.com/docker/docker v1.4.2-0.20200221181110-62bd5a33f707

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/buildpacks/imgutil v0.0.0-20200625161542-2281cd9b1414 h1:p0JTQSapoTcx
 github.com/buildpacks/imgutil v0.0.0-20200625161542-2281cd9b1414/go.mod h1:0MWMP1K2tA1fJnQOzGZDq8NHaWH+r7YUuyYLCEqYCx8=
 github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d h1:uVTFIiev3f7fi5BSv1RtM5W5lcqQodqLRBG5AdoDe2U=
 github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
+github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a h1:VfNxNjP1Y5nM49gF2UkNTq5CoqELkmxdRUUYn8tZvj4=
+github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/buildpacks/lifecycle/tools
 go 1.14
 
 require (
-	github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d
+	github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a
 	github.com/buildpacks/lifecycle v0.8.1
 	github.com/golang/mock v1.4.4
 	github.com/golangci/golangci-lint v1.22.2

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -56,6 +56,7 @@ github.com/buildpacks/imgutil v0.0.0-20200528211046-5c4cfa56bb24/go.mod h1:rkRDO
 github.com/buildpacks/imgutil v0.0.0-20200625161542-2281cd9b1414 h1:p0JTQSapoTcxDG8pMgeXJ5Z9sYhYiFSVc/+0GM2RiTA=
 github.com/buildpacks/imgutil v0.0.0-20200625161542-2281cd9b1414/go.mod h1:0MWMP1K2tA1fJnQOzGZDq8NHaWH+r7YUuyYLCEqYCx8=
 github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
+github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
 github.com/buildpacks/lifecycle v0.8.1 h1:sRyb9281MrrJNfuaQBTI8hu1ERz9iiYtaDmp5xm6VyQ=
 github.com/buildpacks/lifecycle v0.8.1/go.mod h1:Spd3VyskOqUNXx76FKMRU3L3PLHxVGQBJ/JqXlFeLh8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -192,16 +192,21 @@ func lifecycleLayer() string {
 	var mode int64
 	if targetOS == "windows" {
 		ntw = archive.NewNormalizingTarWriter(layer.NewWindowsWriter(lf))
-		mode = 0755
+		mode = 0777
 	} else {
 		tw := tar.NewWriter(lf)
 		ntw = archive.NewNormalizingTarWriter(tw)
-		mode = 0777
+		mode = 0755
 	}
 
 	ntw.WithModTime(archive.NormalizedModTime)
-	ntw.WithUID(0)
-	ntw.WithGID(0)
+	if targetOS == "windows" {
+		ntw.WithUID(1) //gets translated to user permissions in windows writer
+		ntw.WithGID(1) //gets translated to user permissions in windows writer
+	} else {
+		ntw.WithUID(0)
+		ntw.WithGID(0)
+	}
 	ntw.WriteHeader(&tar.Header{
 		Typeflag: tar.TypeDir,
 		Name:     "/cnb",


### PR DESCRIPTION
* bumps to new imgutil that always adds security descriptor record
* allow windows image builds on any OS

Signed-off-by: Emily Casey <ecasey@vmware.com>