### PR TITLE
Sets working dir to /layers in lifecycle image

### DIFF
--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -73,6 +73,13 @@ func main() {
 	if err := img.SetLabel("io.buildpacks.builder.metadata", legacyLabel(descriptor)); err != nil {
 		log.Fatal("Failed to set 'io.buildpacks.builder.metadata' label:", err)
 	}
+	workDir := "/layers"
+	if targetOS == "windows" {
+		workDir = `c:\layers`
+	}
+	if err := img.SetWorkingDir(workDir); err != nil {
+		log.Fatal("Failed to set working directory:", err)
+	}
 	if len(tags) > 1 {
 		if err := img.Save(tags[1:]...); err != nil {
 			log.Fatal("Failed to save image:", err)


### PR DESCRIPTION
I manually released the `buildpacksio/lifecycle:0.9.0` and `buildpacksio/lifecycle:latest` images to fix this.

In the future I think we need a way configure the lifecycle image in `pack` and in the `pack` acceptance tests to enable better testing of lifecycle images.