### PR TITLE
Warn when exporting with non-existing process type

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -397,11 +397,7 @@ func (e *Exporter) supportsMulticallLauncher() bool {
 }
 
 func processTypeError(launchMD launch.Metadata, defaultProcessType string) error {
-	var typeList []string
-	for _, p := range launchMD.Processes {
-		typeList = append(typeList, p.Type)
-	}
-	return fmt.Errorf("default process type '%s' not present in list %+v", defaultProcessType, typeList)
+	return fmt.Errorf(processTypeWarning(launchMD, defaultProcessType))
 }
 
 func processTypeWarning(launchMD launch.Metadata, defaultProcessType string) string {

--- a/exporter.go
+++ b/exporter.go
@@ -365,7 +365,8 @@ func (e *Exporter) entrypoint(launchMD launch.Metadata, defaultProcessType strin
 	}
 	defaultProcess, ok := launchMD.FindProcessType(defaultProcessType)
 	if !ok {
-		return "", processTypeError(launchMD, defaultProcessType)
+		e.Logger.Warn(processTypeWarning(launchMD, defaultProcessType))
+		return launch.LauncherPath, nil
 	}
 	e.Logger.Infof("Setting default process type '%s'", defaultProcess.Type)
 	return launch.ProcessPath(defaultProcess.Type), nil
@@ -401,6 +402,14 @@ func processTypeError(launchMD launch.Metadata, defaultProcessType string) error
 		typeList = append(typeList, p.Type)
 	}
 	return fmt.Errorf("default process type '%s' not present in list %+v", defaultProcessType, typeList)
+}
+
+func processTypeWarning(launchMD launch.Metadata, defaultProcessType string) string {
+	var typeList []string
+	for _, p := range launchMD.Processes {
+		typeList = append(typeList, p.Type)
+	}
+	return fmt.Sprintf("default process type '%s' not present in list %+v", defaultProcessType, typeList)
 }
 
 func (e *Exporter) Cache(layersDir string, cacheStore Cache) error {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1028,10 +1028,20 @@ version = "4.5.6"
 					})
 
 					when("default process type is not in metadata.toml", func() {
-						it("returns an error", func() {
+						it("warns and sets the ENTRYPOINT to launcher", func() {
 							opts.DefaultProcessType = "some-missing-process"
 							_, err := exporter.Export(opts)
-							h.AssertError(t, err, "default process type 'some-missing-process' not present in list [some-process-type]")
+							h.AssertNil(t, err)
+
+							assertLogEntry(t, logHandler, "default process type 'some-missing-process' not present in list [some-process-type]")
+							ep, err := fakeAppImage.Entrypoint()
+							h.AssertNil(t, err)
+							h.AssertEq(t, len(ep), 1)
+							if runtime.GOOS == "windows" {
+								h.AssertEq(t, ep[0], `c:\cnb\lifecycle\launcher.exe`)
+							} else {
+								h.AssertEq(t, ep[0], `/cnb/lifecycle/launcher`)
+							}
 						})
 					})
 				})

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -56,6 +56,7 @@ github.com/buildpacks/imgutil v0.0.0-20200528211046-5c4cfa56bb24/go.mod h1:rkRDO
 github.com/buildpacks/imgutil v0.0.0-20200625161542-2281cd9b1414 h1:p0JTQSapoTcxDG8pMgeXJ5Z9sYhYiFSVc/+0GM2RiTA=
 github.com/buildpacks/imgutil v0.0.0-20200625161542-2281cd9b1414/go.mod h1:0MWMP1K2tA1fJnQOzGZDq8NHaWH+r7YUuyYLCEqYCx8=
 github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
+github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a h1:VfNxNjP1Y5nM49gF2UkNTq5CoqELkmxdRUUYn8tZvj4=
 github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
 github.com/buildpacks/lifecycle v0.8.1 h1:sRyb9281MrrJNfuaQBTI8hu1ERz9iiYtaDmp5xm6VyQ=
 github.com/buildpacks/lifecycle v0.8.1/go.mod h1:Spd3VyskOqUNXx76FKMRU3L3PLHxVGQBJ/JqXlFeLh8=


### PR DESCRIPTION
Fixes #376 

When platform API >= 0.4 and default process type is not defined,
warn and set the entrypoint to /cnb/lifecycle/launcher

Signed-off-by: Natalie Arellano <narellano@vmware.com>