### PR TITLE
Exporter: when no default process is specified, don't set a default process (even when there is only one process)

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -353,14 +353,7 @@ func (e *Exporter) setEnv(opts ExportOptions, launchMD launch.Metadata) error {
 }
 
 func (e *Exporter) entrypoint(launchMD launch.Metadata, defaultProcessType string) (string, error) {
-	if !e.supportsMulticallLauncher() {
-		return launch.LauncherPath, nil
-	}
-	if defaultProcessType == "" {
-		if len(launchMD.Processes) == 1 {
-			e.Logger.Infof("Setting default process type '%s'", launchMD.Processes[0].Type)
-			return launch.ProcessPath(launchMD.Processes[0].Type), nil
-		}
+	if !e.supportsMulticallLauncher() || defaultProcessType == "" {
 		return launch.LauncherPath, nil
 	}
 	defaultProcess, ok := launchMD.FindProcessType(defaultProcessType)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1043,18 +1043,20 @@ version = "4.5.6"
 						exporter.PlatformAPI = api.MustParse("0.4")
 					})
 
-					it("sets ENTRYPOINT to launcher", func() {
-						_, err := exporter.Export(opts)
-						h.AssertNil(t, err)
+					when("there is exactly one process", func() {
+						it("sets ENTRYPOINT to launcher", func() {
+							_, err := exporter.Export(opts)
+							h.AssertNil(t, err)
 
-						ep, err := fakeAppImage.Entrypoint()
-						h.AssertNil(t, err)
-						h.AssertEq(t, len(ep), 1)
-						if runtime.GOOS == "windows" {
-							h.AssertEq(t, ep[0], `c:\cnb\lifecycle\launcher.exe`)
-						} else {
-							h.AssertEq(t, ep[0], `/cnb/lifecycle/launcher`)
-						}
+							ep, err := fakeAppImage.Entrypoint()
+							h.AssertNil(t, err)
+							h.AssertEq(t, len(ep), 1)
+							if runtime.GOOS == "windows" {
+								h.AssertEq(t, ep[0], `c:\cnb\lifecycle\launcher.exe`)
+							} else {
+								h.AssertEq(t, ep[0], `/cnb/lifecycle/launcher`)
+							}
+						})
 					})
 				})
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1043,20 +1043,18 @@ version = "4.5.6"
 						exporter.PlatformAPI = api.MustParse("0.4")
 					})
 
-					when("there is exactly one process", func() {
-						it("sets the ENTRYPOINT to the only process", func() {
-							_, err := exporter.Export(opts)
-							h.AssertNil(t, err)
+					it("sets ENTRYPOINT to launcher", func() {
+						_, err := exporter.Export(opts)
+						h.AssertNil(t, err)
 
-							ep, err := fakeAppImage.Entrypoint()
-							h.AssertNil(t, err)
-							h.AssertEq(t, len(ep), 1)
-							if runtime.GOOS == "windows" {
-								h.AssertEq(t, ep[0], `c:\cnb\process\some-process-type.exe`)
-							} else {
-								h.AssertEq(t, ep[0], `/cnb/process/some-process-type`)
-							}
-						})
+						ep, err := fakeAppImage.Entrypoint()
+						h.AssertNil(t, err)
+						h.AssertEq(t, len(ep), 1)
+						if runtime.GOOS == "windows" {
+							h.AssertEq(t, ep[0], `c:\cnb\lifecycle\launcher.exe`)
+						} else {
+							h.AssertEq(t, ep[0], `/cnb/lifecycle/launcher`)
+						}
 					})
 				})
 


### PR DESCRIPTION
Fixes #378 

Signed-off-by: Natalie Arellano <narellano@vmware.com>