### PR TITLE
Bugfix/windows cmd syntax

### DIFF
--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -198,7 +198,6 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("sources scripts from process specific directories", func() {
-				h.SkipIf(t, runtime.GOOS == "windows", "profile scripts are broken on windows?")
 				cmd := exec.Command("docker", "run", "--rm", launchImage, "profile-checker")
 				expected := "sourced bp profile\nsourced bp profile-checker profile\nsourced app profile\nval-from-profile"
 				assertOutput(t, cmd, expected)

--- a/acceptance/testdata/launcher/windows/container/layers/config/metadata.toml
+++ b/acceptance/testdata/launcher/windows/container/layers/config/metadata.toml
@@ -27,7 +27,7 @@
 [[processes]]
   type = "profile-checker"
   command = "echo"
-  args = ["%VAR_FROM_PROFILE%"]
+  args = ["!VAR_FROM_PROFILE!"]
   direct = false
   buildpack-id = "some/buildpack"
 

--- a/launch/cmd.go
+++ b/launch/cmd.go
@@ -17,7 +17,7 @@ func (c *CmdShell) Launch(proc ShellProcess) error {
 	commandTokens = append(commandTokens, proc.Command)
 	commandTokens = append(commandTokens, proc.Args...)
 	if err := c.Exec("cmd",
-		append([]string{"cmd", "/q", "/v:on", "/c"}, commandTokens...), proc.Env,
+		append([]string{"cmd", "/q", "/v:on", "/s", "/c"}, commandTokens...), proc.Env,
 	); err != nil {
 		return errors.Wrap(err, "cmd execute")
 	}

--- a/launch/cmd.go
+++ b/launch/cmd.go
@@ -17,7 +17,7 @@ func (c *CmdShell) Launch(proc ShellProcess) error {
 	commandTokens = append(commandTokens, proc.Command)
 	commandTokens = append(commandTokens, proc.Args...)
 	if err := c.Exec("cmd",
-		append([]string{"cmd", "/q", "/c"}, commandTokens...), proc.Env,
+		append([]string{"cmd", "/q", "/v:on", "/c"}, commandTokens...), proc.Env,
 	); err != nil {
 		return errors.Wrap(err, "cmd execute")
 	}

--- a/launch/cmd_test.go
+++ b/launch/cmd_test.go
@@ -50,7 +50,7 @@ func testCmd(t *testing.T, when spec.G, it spec.S) {
 					process = launch.ShellProcess{
 						Script:  false,
 						Command: "echo",
-						Args:    []string{"profile env: '%PROFILE_VAR%'"},
+						Args:    []string{"profile env: '!PROFILE_VAR!'"},
 						Env: []string{
 							"SOME_VAR=some-val",
 						},
@@ -84,9 +84,7 @@ func testCmd(t *testing.T, when spec.G, it spec.S) {
 					h.AssertStringContains(t, stdout, "SOME_VAR: 'some-val'")
 				})
 
-				it.Pend("env vars set in profile scripts are available to the command", func() {
-					// currently broken
-
+				it("env vars set in profile scripts are available to the command", func() {
 					err := shell.Launch(process)
 					h.AssertNil(t, err)
 					stdout := rdfile(t, filepath.Join(tmpDir, "stdout"))


### PR DESCRIPTION
1. Enables `!VAR!`-style env vars in process `args` with otherwise no change to existing behavior

    Sets `/v:on` on `cmd` to enable usage of env vars set in profile scripts, in the same scope, known as Delayed Expansion

     From Microsoft Docs: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd
     > If you enable delayed environment variable expansion, you can use the exclamation point character to substitute the value of an environment variable at run time.

    From SS64.com: https://ss64.com/nt/delayedexpansion.html
    > Delayed Expansion will cause variables within a batch file to be expanded at execution time rather than at parse time

    Fixes #359

2. Also, makes cmd use consistent command quote interpretation 

    Sets `/s` on `cmd` to use consistent quote interpolation, matching current Docker `RUN` implementation and Microsoft-recommended `SHELL` syntax:

    From Docker Docs on `RUN` behavior: https://docs.docker.com/engine/reference/builder/#run
    > RUN <command> (shell form, the command is run in a shell, which by default is /bin/sh -c on Linux or cmd /S /C on Windows)

    From Microsoft Docs on recommended usage: https://docs.microsoft.com/en-us/visualstudio/install/advanced-build-tools-container#dockerfile
    > `# Restore the default Windows shell for correct batch processing.`
    > `SHELL ["cmd", "/S", "/C"]`

    From Microsoft Docs on /s behavior and the legacy corner case it avoids: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#remarks

    For brevity, I will not quote inline but my understanding of the 5 conditions of the corner case are: When not using /s, a user can have an ambiguous command when using a binary with spaces in the name followed by space-separated arguments. Cmd then parses any quotes, and if it finds a binary with a space-separated name matching a subset of the args, it will call it.
    
    Instead of allowing this ambiguous syntax, we should use `/s` and always require users to split commands as expected using `command` and `args` array. This also follows existing recommended Docker syntax anyways (`cmd /s /c`) so would be more likely to match existing commands being ported to CNBs.

   This should have been in the original implementation and will have no change on existing behavior (existing test case `indirect-process-with-args` using `command = "test tokens.bat"` works before and after this change), but this should prevent unintentionally supporting ambiguous syntax without proper escaping.
