### PR TITLE
Fix inconsistent Config.Env.PATH behavior for Windows images

### DIFF
--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -282,6 +282,22 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				)
 			})
 
+			it("merges env vars from system, user provided and CNB", func() {
+				if runtime.GOOS == "windows" {
+					cmd := exec.Command("docker", "run", "--rm",
+						`--env=PATH=c:\Windows\system32;c:\extra`,
+						launchImage, "--",
+						`cmd`, `/c`, `echo %PATH%`)
+					assertOutput(t, cmd, `c:\layers\some_buildpack\some_layer\bin;C:\Windows\system32;C:\Windows;c:\extra`)
+				} else {
+					cmd := exec.Command("docker", "run", "--rm",
+						"--env=PATH=/bin:/extra",
+						launchImage, "--",
+						"sh", "-c", "echo $PATH")
+					assertOutput(t, cmd, "/layers/some_buildpack/some_layer/bin:/bin:/extra")
+				}
+			})
+
 			it("passes through env vars from user, excluding excluded vars", func() {
 				cmd := exec.Command("docker", "run", "--rm",
 					"--env", "CNB_APP_DIR=/workspace",

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+
+	"github.com/buildpacks/lifecycle/env"
 )
 
 var (
@@ -205,4 +208,17 @@ func EnvOrDefault(key string, defaultVal string) string {
 		return envVal
 	}
 	return defaultVal
+}
+
+func PrepareOSEnv() error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+
+	regEnvMap, err := env.WindowsRegistryEnvMap()
+	if err != nil {
+		return err
+	}
+
+	return env.PrepareWindowsOSEnv(regEnvMap, os.Getenv, os.Setenv)
 }

--- a/cmd/launcher/main.go
+++ b/cmd/launcher/main.go
@@ -19,6 +19,10 @@ func main() {
 }
 
 func runLaunch() error {
+	if err := cmd.PrepareOSEnv(); err != nil {
+		cmd.Exit(err)
+	}
+
 	color.Disable(cmd.BoolEnv(cmd.EnvNoColor))
 
 	platformAPI := cmd.EnvOrDefault(cmd.EnvPlatformAPI, cmd.DefaultPlatformAPI)

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -12,6 +12,10 @@ import (
 )
 
 func main() {
+	if err := cmd.PrepareOSEnv(); err != nil {
+		cmd.Exit(err)
+	}
+
 	platformAPI := cmd.EnvOrDefault(cmd.EnvPlatformAPI, cmd.DefaultPlatformAPI)
 	if err := cmd.VerifyPlatformAPI(platformAPI); err != nil {
 		cmd.Exit(err)

--- a/env/prepare.go
+++ b/env/prepare.go
@@ -1,0 +1,65 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PrepareWindowsOSEnv merges map of Windows registry environment variables with in-memory environment vars
+// Injects os.Getenv an os.Setenv
+func PrepareWindowsOSEnv(regEnvMap map[string]string, getenv func(string) string, setenv func(string, string) error) error {
+	for regKey, regValue := range regEnvMap {
+		envValue := getenv(regKey)
+
+		// exit early if values match
+		if regValue == envValue {
+			continue
+		}
+
+		newValue := ""
+
+		if regKey == "PATH" || regKey == "PATHEXT" {
+			newValue = mergePathVars(regValue, envValue)
+		} else {
+			// prefer env value if set
+			if envValue != "" {
+				continue
+			}
+
+			newValue = regValue
+		}
+
+		if err := setenv(regKey, newValue); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// merge PATH and PATH by prepending registry value to existing env value
+func mergePathVars(regValue, envValue string) string {
+	var newValueParts []string
+	newValueMap := map[string]bool{}
+
+	for _, regValuePart := range filepath.SplitList(regValue) {
+		key := strings.ToLower(regValuePart)
+		if regValuePart == "" || newValueMap[key] {
+			continue
+		}
+
+		newValueMap[key] = true
+		newValueParts = append(newValueParts, regValuePart)
+	}
+
+	for _, envValuePart := range filepath.SplitList(envValue) {
+		key := strings.ToLower(envValuePart)
+		if envValuePart == "" || newValueMap[key] {
+			continue
+		}
+		newValueParts = append(newValueParts, envValuePart)
+	}
+
+	return strings.Join(newValueParts, string(os.PathListSeparator))
+}

--- a/env/prepare_test.go
+++ b/env/prepare_test.go
@@ -1,0 +1,126 @@
+package env_test
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/buildpacks/lifecycle/env"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestPrepare(t *testing.T) {
+	spec.Run(t, "Env", testPrepare, spec.Report(report.Terminal{}))
+}
+
+func testPrepare(t *testing.T, when spec.G, it spec.S) {
+	var (
+		getEnvMap = map[string]string{}
+		getEnvFn  = func(k string) string {
+			return getEnvMap[k]
+		}
+
+		setEnvMap = map[string]string{}
+		setEnvFn  = func(k, v string) error {
+			setEnvMap[k] = v
+			return nil
+		}
+
+		regEnvMap map[string]string
+	)
+
+	when("#PrepareWindowsOSEnv", func() {
+		when("reg and env values differ", func() {
+			it("prepends reg values to env PATH and PATHEXT", func() {
+				regEnvMap = map[string]string{
+					"PATH":     pathList(`c\reg-first`, `c\reg-second`),
+					"PATHEXT":  pathList(`.REG1`, `.REG2`),
+					"BOTH":     `reg-ignored`,
+					"REG_ONLY": `reg-only`,
+					"EMPTY":    ``,
+				}
+				getEnvMap = map[string]string{
+					"PATH":     pathList(`c\env-first`, `c\env-second`),
+					"PATHEXT":  pathList(`.ENV1`, `.ENV2`),
+					"BOTH":     `env-wins`,
+					"ENV_ONLY": `env-only`,
+					"EMPTY":    ``,
+				}
+
+				h.AssertNil(t, env.PrepareWindowsOSEnv(regEnvMap, getEnvFn, setEnvFn))
+
+				expectedSetEnvKV := map[string]string{
+					"PATH":     pathList(`c\reg-first`, `c\reg-second`, `c\env-first`, `c\env-second`),
+					"PATHEXT":  pathList(`.REG1`, `.REG2`, `.ENV1`, `.ENV2`),
+					"REG_ONLY": `reg-only`,
+				}
+				h.AssertEq(t, setEnvMap, expectedSetEnvKV)
+			})
+		})
+
+		when("reg and env values are identical", func() {
+			it("no change", func() {
+				regEnvMap = map[string]string{
+					"PATH":    pathList(`c\both-first`, `c\both-second`),
+					"PATHEXT": pathList(`.BOTH1`, `.BOTH2`),
+					"BOTH":    `tie`,
+					"EMPTY":   ``,
+				}
+				getEnvMap = map[string]string{
+					"PATH":    pathList(`c\both-first`, `c\both-second`),
+					"PATHEXT": pathList(`.BOTH1`, `.BOTH2`),
+					"BOTH":    `tie`,
+					"EMPTY":   ``,
+				}
+				h.AssertNil(t, env.PrepareWindowsOSEnv(regEnvMap, getEnvFn, setEnvFn))
+
+				// nothing needs to be set
+				h.AssertEq(t, setEnvMap, map[string]string{})
+			})
+		})
+
+		when("values have different case", func() {
+			it("de-dupe path values, preferring reg case, otherwise don't consider case", func() {
+				regEnvMap = map[string]string{
+					"PATH":    pathList(`C\BOTH-FIRST`, `c\both-second`, `c\REG-third`),
+					"PATHEXT": pathList(`.BOTH1`, `.both2`, `.REG3`),
+					"BOTH":    `TIE`,
+					"EMPTY":   ``,
+				}
+				getEnvMap = map[string]string{
+					"PATH":    pathList(`c\both-first`, `C\BOTH-SECOND`, `c\ENV-third`),
+					"PATHEXT": pathList(`.both1`, `.BOTH2`, `.ENV3`),
+					"BOTH":    `tie`,
+					"EMPTY":   ``,
+				}
+				h.AssertNil(t, env.PrepareWindowsOSEnv(regEnvMap, getEnvFn, setEnvFn))
+
+				expectedSetEnvMap := map[string]string{
+					"PATH":    pathList(`C\BOTH-FIRST`, `c\both-second`, `c\REG-third`, `c\ENV-third`),
+					"PATHEXT": pathList(`.BOTH1`, `.both2`, `.REG3`, `.ENV3`),
+				}
+				h.AssertEq(t, setEnvMap, expectedSetEnvMap)
+			})
+		})
+	})
+
+	when("#WindowsRegistryEnvMap", func() {
+		it.Before(func() {
+			h.SkipIf(t, runtime.GOOS != "windows", "uses windows-only library")
+		})
+
+		it("returns registry env vars", func() {
+			regEnvMap, err := env.WindowsRegistryEnvMap()
+			h.AssertNil(t, err)
+			h.AssertStringContains(t, strings.ToLower(regEnvMap["PATH"]), `c:\windows\system32;`)
+		})
+	})
+}
+
+func pathList(pathParts ...string) string {
+	return strings.Join(pathParts, string(os.PathListSeparator))
+}

--- a/env/prepare_unix.go
+++ b/env/prepare_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package env
+
+// Define only for compiler
+func WindowsRegistryEnvMap() (map[string]string, error) {
+	return nil, nil
+}

--- a/env/prepare_windows.go
+++ b/env/prepare_windows.go
@@ -1,0 +1,45 @@
+package env
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// WindowsRegistryEnvMap returns a maps of Windows registry environment variabes
+// All keys are upper-cased for equivalence with os.Getenv
+func WindowsRegistryEnvMap() (map[string]string, error) {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SYSTEM\CurrentControlSet\Control\Session Manager\Environment`, registry.QUERY_VALUE)
+	if err != nil {
+		return nil, err
+	}
+	defer key.Close()
+
+	ki, err := key.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	regKeys, err := key.ReadValueNames(int(ki.ValueCount))
+	if err != nil {
+		return nil, err
+	}
+
+	regKeyValues := map[string]string{}
+	for _, regKey := range regKeys {
+		regValue, _, err := key.GetStringValue(regKey)
+		if err != nil {
+			return nil, err
+		}
+
+		regExpandedValue, err := registry.ExpandString(regValue)
+		if err != nil {
+			return nil, err
+		}
+
+		// set keys to upper for Getenv parity
+		regKeyValues[strings.ToUpper(regKey)] = regExpandedValue
+	}
+
+	return regKeyValues, nil
+}


### PR DESCRIPTION
- When launcher or lifecycle are executed, immediately sync env vars from the Windows registry and runtime environment (no-op for Linux)
- Works around Docker only using Windows registry PATH when image Config.Env.PATH is not set (same is true for other env vars):
  Moby issue: https://github.com/moby/moby/issues/22017
  BuildKit issue: https://github.com/moby/buildkit/issues/74
  PR attempt: https://github.com/moby/moby/pull/29048

Fixes: https://github.com/buildpacks/lifecycle/issues/384

Signed-off-by: Micah Young <ymicah@vmware.com>