### PR TITLE
Sync io.buildpacks.stack.* labels from run image during rebase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/apex/log v1.1.2-0.20190827100214-baa5455d1012
-	github.com/buildpacks/imgutil v0.0.0-20200814190540-04db0a9bb84f
+	github.com/buildpacks/imgutil v0.0.0-20200828191547-108a5c59537a
 	github.com/containerd/containerd v1.3.3 // indirect
 	github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37 // indirect
 	github.com/docker/docker v1.4.2-0.20200221181110-62bd5a33f707

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/apex/log v1.1.2-0.20190827100214-baa5455d1012
-	github.com/buildpacks/imgutil v0.0.0-20200828191547-108a5c59537a
+	github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655
 	github.com/containerd/containerd v1.3.3 // indirect
 	github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37 // indirect
 	github.com/docker/docker v1.4.2-0.20200221181110-62bd5a33f707

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/buildpacks/imgutil v0.0.0-20200814190540-04db0a9bb84f h1:obnRAv2tc0ANz20Muuz1ETaRaXe8f8WR6zNplXum2dc=
-github.com/buildpacks/imgutil v0.0.0-20200814190540-04db0a9bb84f/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
+github.com/buildpacks/imgutil v0.0.0-20200828191547-108a5c59537a h1:l/veqbhUsWMzjA7nqMqStRb3IBtkbg3kmogcDxcglKg=
+github.com/buildpacks/imgutil v0.0.0-20200828191547-108a5c59537a/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -146,8 +146,6 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
-github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.0.0-20200311163244-4b1985e5ea21/go.mod h1:m8YvHwSOuBCq25yrj1DaX/fIMrv6ec3CNg8jY8+5PEA=

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/buildpacks/imgutil v0.0.0-20200828191547-108a5c59537a h1:l/veqbhUsWMzjA7nqMqStRb3IBtkbg3kmogcDxcglKg=
-github.com/buildpacks/imgutil v0.0.0-20200828191547-108a5c59537a/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
+github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655 h1:jIbUElEczuGsQaXaQ5RJw2ip+ka0ao4unuAHUHvUhCA=
+github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/rebaser.go
+++ b/rebaser.go
@@ -72,7 +72,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 
 	hasPrefix := func(l string) bool { return strings.HasPrefix(l, "io.buildpacks.stack.") }
 	if err := SyncLabels(newBaseImage, workingImage, hasPrefix); err != nil {
-		return RebaseReport{}, errors.Wrap(err, "set stack metadata label")
+		return RebaseReport{}, errors.Wrap(err, "set stack labels")
 	}
 
 	report := RebaseReport{}

--- a/rebaser.go
+++ b/rebaser.go
@@ -71,7 +71,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	}
 
 	hasPrefix := func(l string) bool { return strings.HasPrefix(l, "io.buildpacks.stack.") }
-	if err := SyncLabels(newBaseImage, workingImage, hasPrefix); err != nil {
+	if err := syncLabels(newBaseImage, workingImage, hasPrefix); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "set stack labels")
 	}
 

--- a/rebaser.go
+++ b/rebaser.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/buildpacks/imgutil"
 	"github.com/pkg/errors"
@@ -67,6 +68,11 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 
 	if err := workingImage.SetLabel(LayerMetadataLabel, string(data)); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "set app image metadata label")
+	}
+
+	hasPrefix := func(l string) bool { return strings.HasPrefix(l, "io.buildpacks.stack.") }
+	if err := SyncLabels(newBaseImage, workingImage, hasPrefix); err != nil {
+		return RebaseReport{}, errors.Wrap(err, "set stack metadata label")
 	}
 
 	report := RebaseReport{}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -3,7 +3,7 @@ module github.com/buildpacks/lifecycle/tools
 go 1.14
 
 require (
-	github.com/buildpacks/imgutil v0.0.0-20200814190540-04db0a9bb84f
+	github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655
 	github.com/buildpacks/lifecycle v0.8.1
 	github.com/golang/mock v1.4.4
 	github.com/golangci/golangci-lint v1.22.2

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -232,6 +232,7 @@ github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.0.0-20200311163244-4b1985e5ea21/go.mod h1:m8YvHwSOuBCq25yrj1DaX/fIMrv6ec3CNg8jY8+5PEA=
 github.com/google/go-containerregistry v0.0.0-20200313165449-955bf358a3d8 h1:S7U1nPK3fi2xjZkMrQKcRayVtMmqMFJs9UtXQW3GPzM=
 github.com/google/go-containerregistry v0.0.0-20200313165449-955bf358a3d8/go.mod h1:pD1UFYs7MCAx+ZLShBdttcaOSbyc8F9Na/9IZLNwJeA=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -59,6 +59,7 @@ github.com/buildpacks/imgutil v0.0.0-20200805143852-1844b230530d/go.mod h1:uVv0f
 github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a h1:VfNxNjP1Y5nM49gF2UkNTq5CoqELkmxdRUUYn8tZvj4=
 github.com/buildpacks/imgutil v0.0.0-20200808231819-bedc3d0cd75a/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
 github.com/buildpacks/imgutil v0.0.0-20200814190540-04db0a9bb84f/go.mod h1:uVv0fNwOEBNgyM9ZvwV0g2Dvzk31q5TtSeoC1GGmW+k=
+github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
 github.com/buildpacks/lifecycle v0.8.1 h1:sRyb9281MrrJNfuaQBTI8hu1ERz9iiYtaDmp5xm6VyQ=
 github.com/buildpacks/lifecycle v0.8.1/go.mod h1:Spd3VyskOqUNXx76FKMRU3L3PLHxVGQBJ/JqXlFeLh8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/utils.go
+++ b/utils.go
@@ -61,3 +61,45 @@ func DecodeLabel(image imgutil.Image, label string, v interface{}) error {
 	}
 	return nil
 }
+
+// SyncLabels adds/updates/removes labels matching the predicate and a source image
+func SyncLabels(sourceImg imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
+	if err := RemoveLabels(destImage, test); err != nil {
+		return err
+	}
+	return CopyLabels(sourceImg, destImage, test)
+}
+
+// RemoveLabels removes labels from an image matching the predicate
+func RemoveLabels(image imgutil.Image, test func(string) bool) error {
+	labels, err := image.Labels()
+	if err != nil {
+		return err
+	}
+
+	for label := range labels {
+		if test(label) {
+			if err := image.SetLabel(label, ""); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// CopyLabels copies labels from a source image to the destination image matching the predicate
+func CopyLabels(fromImage imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
+	fromLabels, err := fromImage.Labels()
+	if err != nil {
+		return err
+	}
+
+	for label, labelValue := range fromLabels {
+		if test(label) {
+			if err := destImage.SetLabel(label, labelValue); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/utils.go
+++ b/utils.go
@@ -79,9 +79,7 @@ func RemoveLabels(image imgutil.Image, test func(string) bool) error {
 
 	for label := range labels {
 		if test(label) {
-			if err := image.SetLabel(label, ""); err != nil {
-				return err
-			}
+			delete(labels, label)
 		}
 	}
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -79,7 +79,7 @@ func RemoveLabels(image imgutil.Image, test func(string) bool) error {
 
 	for label := range labels {
 		if test(label) {
-			delete(labels, label)
+			image.RemoveLabel(label)
 		}
 	}
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -62,16 +62,14 @@ func DecodeLabel(image imgutil.Image, label string, v interface{}) error {
 	return nil
 }
 
-// SyncLabels adds/updates/removes labels matching the predicate and a source image
-func SyncLabels(sourceImg imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
-	if err := RemoveLabels(destImage, test); err != nil {
+func syncLabels(sourceImg imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
+	if err := removeLabels(destImage, test); err != nil {
 		return err
 	}
-	return CopyLabels(sourceImg, destImage, test)
+	return copyLabels(sourceImg, destImage, test)
 }
 
-// RemoveLabels removes labels from an image matching the predicate
-func RemoveLabels(image imgutil.Image, test func(string) bool) error {
+func removeLabels(image imgutil.Image, test func(string) bool) error {
 	labels, err := image.Labels()
 	if err != nil {
 		return err
@@ -85,8 +83,7 @@ func RemoveLabels(image imgutil.Image, test func(string) bool) error {
 	return nil
 }
 
-// CopyLabels copies labels from a source image to the destination image matching the predicate
-func CopyLabels(fromImage imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
+func copyLabels(fromImage imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
 	fromLabels, err := fromImage.Labels()
 	if err != nil {
 		return err


### PR DESCRIPTION
- Update matching labels present on both images to value on run image
- Remove matching labels no long present on run image
- Add matching labels that are newly added on run image
- Ignore non-matching labels on both working and run image

Ref #390

Signed-off-by: Jesse Brown <jabrown85@gmail.com>