### PR TITLE
Update windows base image to use LTSC Server Core 2019

### DIFF
--- a/acceptance/testdata/launcher/windows/Dockerfile
+++ b/acceptance/testdata/launcher/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/nanoserver:1809
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 COPY container /
 

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	baseImage := "gcr.io/distroless/static"
 	if targetOS == "windows" {
-		baseImage = "mcr.microsoft.com/windows/nanoserver:1809-amd64"
+		baseImage = "mcr.microsoft.com/windows/servercore:ltsc2019"
 	}
 
 	var img imgutil.Image


### PR DESCRIPTION
The lifecycle currently uses a Windows base image called `nanoserver`, which is going out of support soon.  This change updates the base image to `servercore:ltsc2019`