### PR TITLE
Remove double parsing of commit sha in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 /:=/
 endif
 
-PARSED_COMMIT:=$(shell git describe --always --dirty)
+PARSED_COMMIT:=$(shell git rev-parse --short HEAD)
 
 ifeq ($(LIFECYCLE_VERSION),)
 LIFECYCLE_VERSION:=$(shell go run tools/version/main.go)

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ else
 /:=/
 endif
 
+PARSED_COMMIT:=$(shell git describe --always --dirty)
+
 ifeq ($(LIFECYCLE_VERSION),)
-LIFECYCLE_IMAGE_TAG?=$(shell git describe --always --dirty)
 LIFECYCLE_VERSION:=$(shell go run tools/version/main.go)
+LIFECYCLE_IMAGE_TAG?=$(PARSED_COMMIT)
 else
 LIFECYCLE_IMAGE_TAG?=$(LIFECYCLE_VERSION)
 endif
@@ -20,7 +22,6 @@ GOARCH?=amd64
 GOENV=GOARCH=$(GOARCH) CGO_ENABLED=0
 LIFECYCLE_DESCRIPTOR_PATH?=lifecycle.toml
 SCM_REPO?=github.com/buildpacks/lifecycle
-PARSED_COMMIT=$(shell git rev-parse --short HEAD)
 SCM_COMMIT?=$(PARSED_COMMIT)
 LDFLAGS=-s -w
 LDFLAGS+=-X 'github.com/buildpacks/lifecycle/cmd.SCMRepository=$(SCM_REPO)'

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,13 +28,11 @@ const (
 // buildVersion is a display format of the version and build metadata in compliance with semver.
 func buildVersion() string {
 	// noinspection GoBoolExpressions
-
-	sha := strings.TrimSuffix(SCMCommit, "-dirty")
-	if SCMCommit == "" || strings.Contains(Version, sha) {
+	if SCMCommit == "" || strings.Contains(Version, SCMCommit) {
 		return Version
 	}
 
-	return fmt.Sprintf("%s+%s", Version, sha)
+	return fmt.Sprintf("%s+%s", Version, SCMCommit)
 }
 
 func VerifyPlatformAPI(requested string) error {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,11 +28,13 @@ const (
 // buildVersion is a display format of the version and build metadata in compliance with semver.
 func buildVersion() string {
 	// noinspection GoBoolExpressions
-	if SCMCommit == "" || strings.Contains(Version, SCMCommit) {
+
+	sha := strings.TrimSuffix(SCMCommit, "-dirty")
+	if SCMCommit == "" || strings.Contains(Version, sha) {
 		return Version
 	}
 
-	return fmt.Sprintf("%s+%s", Version, SCMCommit)
+	return fmt.Sprintf("%s+%s", Version, sha)
 }
 
 func VerifyPlatformAPI(requested string) error {


### PR DESCRIPTION
This requires extra processing in cmd/version.go because Version when it includes the commit will not contain
'-dirty'.

Signed-off-by: Natalie Arellano <narellano@vmware.com>