### PR TITLE
Remove all unsafe usage of filepath.Glob

### DIFF
--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -90,7 +90,7 @@ func (l *Launcher) env(process Process) error {
 	if err != nil {
 		return errors.Wrap(err, "find app directory")
 	}
-	return l.eachBuildpack(l.LayersDir, func(path string) error {
+	return l.eachBuildpack(func(path string) error {
 		bpInfo, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -142,9 +142,13 @@ func eachDir(dir string, fn func(path string) error) error {
 	return nil
 }
 
-func (l *Launcher) eachBuildpack(dir string, fn func(path string) error) error {
+func (l *Launcher) eachBuildpack(fn func(path string) error) error {
+	layersDir, err := filepath.Abs(l.LayersDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to compute absolute path of layers directory")
+	}
 	for _, bp := range l.Buildpacks {
-		if err := fn(filepath.Join(l.LayersDir, EscapeID(bp.ID))); err != nil {
+		if err := fn(filepath.Join(layersDir, EscapeID(bp.ID))); err != nil {
 			return err
 		}
 	}

--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -143,12 +143,8 @@ func eachDir(dir string, fn func(path string) error) error {
 }
 
 func (l *Launcher) eachBuildpack(fn func(path string) error) error {
-	layersDir, err := filepath.Abs(l.LayersDir)
-	if err != nil {
-		return errors.Wrap(err, "failed to compute absolute path of layers directory")
-	}
 	for _, bp := range l.Buildpacks {
-		if err := fn(filepath.Join(layersDir, EscapeID(bp.ID))); err != nil {
+		if err := fn(filepath.Join(l.LayersDir, EscapeID(bp.ID))); err != nil {
 			return err
 		}
 	}

--- a/launch/launcher_unix.go
+++ b/launch/launcher_unix.go
@@ -5,10 +5,9 @@ package launch
 import "syscall"
 
 const (
-	CNBDir      = `/cnb`
-	exe         = ""
-	profileGlob = "*"
-	appProfile  = ".profile"
+	CNBDir     = `/cnb`
+	exe        = ""
+	appProfile = ".profile"
 )
 
 var (

--- a/launch/launcher_windows.go
+++ b/launch/launcher_windows.go
@@ -6,10 +6,9 @@ import (
 )
 
 const (
-	CNBDir      = `c:\cnb`
-	exe         = ".exe"
-	profileGlob = "*.bat"
-	appProfile  = ".profile.bat"
+	CNBDir     = `c:\cnb`
+	exe        = ".exe"
+	appProfile = ".profile.bat"
 )
 
 var (

--- a/launch/shell.go
+++ b/launch/shell.go
@@ -69,7 +69,11 @@ func (l *Launcher) profiles(process Process) ([]string, error) {
 	}
 
 	if err := l.eachBuildpack(func(path string) error {
-		return eachDir(path, func(path string) error {
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		return eachDir(absPath, func(path string) error {
 			if err := appendFilesInDir(filepath.Join(path, "profile.d")); err != nil {
 				return err
 			}

--- a/launch/shell.go
+++ b/launch/shell.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -46,46 +47,48 @@ func (l *Launcher) launchWithShell(self string, process Process) error {
 func (l *Launcher) profiles(process Process) ([]string, error) {
 	var profiles []string
 
-	appendIfFile := func(path string) error {
-		fi, err := os.Stat(path)
+	appendIfFile := func(path string, fi os.FileInfo) {
+		if !fi.IsDir() {
+			profiles = append(profiles, path)
+		}
+	}
+
+	appendFilesInDir := func(path string) error {
+		fis, err := ioutil.ReadDir(path)
 		if os.IsNotExist(err) {
 			return nil
 		}
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to list files in dir '%s'", path)
 		}
-		if !fi.IsDir() {
-			profiles = append(profiles, path)
+
+		for _, fi := range fis {
+			appendIfFile(filepath.Join(path, fi.Name()), fi)
 		}
 		return nil
 	}
-	layersDir, err := filepath.Abs(l.LayersDir)
-	if err != nil {
-		return nil, err
-	}
-	for _, bp := range l.Buildpacks {
-		globPaths := []string{filepath.Join(layersDir, EscapeID(bp.ID), "*", "profile.d", profileGlob)}
-		if process.Type != "" {
-			globPaths = append(globPaths, filepath.Join(layersDir, EscapeID(bp.ID), "*", "profile.d", process.Type, profileGlob))
-		}
-		var scripts []string
-		for _, globPath := range globPaths {
-			matches, err := filepath.Glob(globPath)
-			if err != nil {
-				return nil, err
+
+	if err := l.eachBuildpack(func(path string) error {
+		return eachDir(path, func(path string) error {
+			if err := appendFilesInDir(filepath.Join(path, "profile.d")); err != nil {
+				return err
 			}
-			scripts = append(scripts, matches...)
-		}
-		for _, script := range scripts {
-			if err := appendIfFile(script); err != nil {
-				return nil, err
+			if process.Type != "" {
+				return appendFilesInDir(filepath.Join(path, "profile.d", process.Type))
 			}
-		}
+			return nil
+		})
+	}); err != nil {
+		return nil, errors.Wrapf(err, "failed to find all profile scripts in layers dir, '%s'", l.LayersDir)
 	}
 
-	if err := appendIfFile(filepath.Join(l.AppDir, appProfile)); err != nil {
-		return nil, err
+	fi, err := os.Stat(filepath.Join(l.AppDir, appProfile))
+	if os.IsNotExist(err) {
+		return profiles, nil
+	} else if err != nil {
+		return nil, errors.Wrapf(err, "failed to determine if app profile script exists at path '%s'", filepath.Join(l.AppDir, appProfile))
 	}
+	appendIfFile(filepath.Join(l.AppDir, appProfile), fi)
 
 	return profiles, nil
 }

--- a/layers.go
+++ b/layers.go
@@ -37,17 +37,18 @@ func readBuildpackLayersDir(layersDir string, buildpack Buildpack) (bpLayersDir,
 	}
 
 	names := map[string]struct{}{}
+	var tomls []string
 	for _, fi := range fis {
 		if fi.IsDir() {
 			bpDir.layers = append(bpDir.layers, *bpDir.newBPLayer(fi.Name()))
 			names[fi.Name()] = struct{}{}
+			continue
+		}
+		if strings.HasSuffix(fi.Name(), ".toml") {
+			tomls = append(tomls, filepath.Join(path, fi.Name()))
 		}
 	}
 
-	tomls, err := filepath.Glob(filepath.Join(path, "*.toml"))
-	if err != nil {
-		return bpLayersDir{}, err
-	}
 	for _, tf := range tomls {
 		name := strings.TrimSuffix(filepath.Base(tf), ".toml")
 		if name == "store" {

--- a/layers/slices_test.go
+++ b/layers/slices_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/sclevine/spec"
@@ -188,12 +189,21 @@ func testSlices(t *testing.T, when spec.G, it spec.S) {
 
 			it.Before(func() {
 				var err error
-				sliceLayers, err = factory.SliceLayers(dirToSlice, []layers.Slice{
-					{Paths: []string{"*.txt", "**/*.txt"}},
-					{Paths: []string{"other-dir"}},
-					{Paths: []string{"dir-link/*"}},
-					{Paths: []string{"../**/dir-to-exclude"}},
-				})
+				if runtime.GOOS == "windows" {
+					sliceLayers, err = factory.SliceLayers(dirToSlice, []layers.Slice{
+						{Paths: []string{"*.txt", "**\\*.txt"}},
+						{Paths: []string{"other-dir"}},
+						{Paths: []string{"dir-link\\*"}},
+						{Paths: []string{"..\\**\\dir-to-exclude"}},
+					})
+				} else {
+					sliceLayers, err = factory.SliceLayers(dirToSlice, []layers.Slice{
+						{Paths: []string{"*.txt", "**/*.txt"}},
+						{Paths: []string{"other-dir"}},
+						{Paths: []string{"dir-link/*"}},
+						{Paths: []string{"../**/dir-to-exclude"}},
+					})
+				}
 				h.AssertNil(t, err)
 			})
 
@@ -315,7 +325,7 @@ func testSlices(t *testing.T, when spec.G, it spec.S) {
 
 		when("the dir has special characters", func() {
 			it("does not treat the dir like a pattern", func() {
-				specialCharDir, err := filepath.Abs(filepath.Join("testdata", "target-di[rx]"))
+				specialCharDir, err := filepath.Abs(filepath.Join("testdata", "target-di[r]"))
 				h.AssertNil(t, err)
 				sliceLayers, err := factory.SliceLayers(specialCharDir, []layers.Slice{
 					{Paths: []string{"*"}},

--- a/layers/slices_test.go
+++ b/layers/slices_test.go
@@ -315,7 +315,7 @@ func testSlices(t *testing.T, when spec.G, it spec.S) {
 
 		when("the dir has special characters", func() {
 			it("does not treat the dir like a pattern", func() {
-				specialCharDir, err := filepath.Abs(filepath.Join("testdata", "*"))
+				specialCharDir, err := filepath.Abs(filepath.Join("testdata", "target-di[rx]"))
 				h.AssertNil(t, err)
 				sliceLayers, err := factory.SliceLayers(specialCharDir, []layers.Slice{
 					{Paths: []string{"*"}},


### PR DESCRIPTION
Fixes 2 issues:
**Issue 1** Unsafe use of `filepath.Glob`

We previous used filepath.Glob for four purposes:

1. Globbing slice files - This was updated to use a combination of filepath.Walk and filepath.Match to match children of the app dir by relative path. We already had logic to unsure that no files outside of the app dir were included. A test was added to confirm this and prevent regressions

2. Globbing profile scripts - This commit changes the implementation so that we no longer use filepath.Glob here

3. Globbing layer.toml files - This commit changes the implementation so that we no longer use filepath.Glob here

4. Test logic - unsafe use of filepath.Glob is unchanged in the test code

**Issue 2** Slice globbing on Windows

According to the buildpack API in the CNB Speciication slice path globs should follow the pattern syntac defined in the Go standard library (Follow the pattern syntax defined in the [Go standard library](https://golang.org/pkg/path/filepath/#Match).). We were previously translating unix path separators in slice patterns into windows slice separators before matching. This contradicts the wording of the spec. Instead windows path separators should be notated with '\\' as described in the stdlib godoc.