### PR TITLE
Enable errcheck

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -59,7 +59,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 		}
 		if testing.Verbose() {
 			analyzer.Logger = cmd.DefaultLogger
-			cmd.SetLogLevel("debug")
+			h.AssertNil(t, cmd.SetLogLevel("debug"))
 		}
 		mockCtrl = gomock.NewController(t)
 	})
@@ -87,7 +87,7 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it.After(func() {
-			image.Cleanup()
+			h.AssertNil(t, image.Cleanup())
 		})
 
 		when("image exists", func() {

--- a/cache/image_cache_test.go
+++ b/cache/image_cache_test.go
@@ -51,9 +51,9 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		os.RemoveAll(tmpDir)
-		fakeOriginalImage.Cleanup()
-		fakeNewImage.Cleanup()
+		h.AssertNil(t, os.RemoveAll(tmpDir))
+		h.AssertNil(t, fakeOriginalImage.Cleanup())
+		h.AssertNil(t, fakeNewImage.Cleanup())
 	})
 
 	when("#Name", func() {
@@ -235,7 +235,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 		when("with #ReuseLayer", func() {
 			it.Before(func() {
 				fakeNewImage.AddPreviousLayer(testLayerSHA, testLayerTarPath)
-				fakeOriginalImage.AddLayer(testLayerTarPath)
+				h.AssertNil(t, fakeOriginalImage.AddLayer(testLayerTarPath))
 			})
 
 			when("reuse then commit", func() {

--- a/cache/image_cache_test.go
+++ b/cache/image_cache_test.go
@@ -51,9 +51,9 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		h.AssertNil(t, os.RemoveAll(tmpDir))
 		h.AssertNil(t, fakeOriginalImage.Cleanup())
 		h.AssertNil(t, fakeNewImage.Cleanup())
+		h.AssertNil(t, os.RemoveAll(tmpDir))
 	})
 
 	when("#Name", func() {
@@ -128,6 +128,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 			it("returns the layer's reader", func() {
 				rc, err := subject.RetrieveLayer(testLayerSHA)
 				h.AssertNil(t, err)
+				defer rc.Close()
 
 				bytes, err := ioutil.ReadAll(rc)
 				h.AssertNil(t, err)
@@ -206,6 +207,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 					rc, err := subject.RetrieveLayer(testLayerSHA)
 					h.AssertNil(t, err)
+					defer rc.Close()
 
 					bytes, err := ioutil.ReadAll(rc)
 					h.AssertNil(t, err)
@@ -247,6 +249,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 					rc, err := subject.RetrieveLayer(testLayerSHA)
 					h.AssertNil(t, err)
+					defer rc.Close()
 
 					bytes, err := ioutil.ReadAll(rc)
 					h.AssertNil(t, err)
@@ -269,6 +272,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 
 					rc, err := subject.RetrieveLayer(testLayerSHA)
 					h.AssertNil(t, err)
+					defer rc.Close()
 
 					bytes, err := ioutil.ReadAll(rc)
 					h.AssertNil(t, err)

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -99,10 +99,10 @@ func (c *createCmd) Privileges() error {
 		return cmd.FailErr(err, "chown volumes")
 	}
 	if err := priv.RunAs(c.uid, c.gid); err != nil {
-		cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", c.uid, c.gid))
+		return cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", c.uid, c.gid))
 	}
 	if err := priv.SetEnvironmentForUser(c.uid); err != nil {
-		cmd.FailErr(err, fmt.Sprintf("set environment for user %d", c.uid))
+		return cmd.FailErr(err, fmt.Sprintf("set environment for user %d", c.uid))
 	}
 	return nil
 }

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -118,7 +118,7 @@ func (e *exportCmd) Privileges() error {
 		return cmd.FailErr(err, "chown volumes")
 	}
 	if err := priv.RunAs(e.uid, e.gid); err != nil {
-		cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", e.uid, e.gid))
+		return cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", e.uid, e.gid))
 	}
 	return nil
 }

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -67,7 +67,7 @@ func (r *rebaseCmd) Privileges() error {
 		}
 	}
 	if err := priv.RunAs(r.uid, r.gid); err != nil {
-		cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", r.uid, r.gid))
+		return cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", r.uid, r.gid))
 	}
 	return nil
 }

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -39,10 +39,10 @@ func (r *restoreCmd) Args(nargs int, args []string) error {
 
 func (r *restoreCmd) Privileges() error {
 	if err := priv.EnsureOwner(r.uid, r.gid, r.layersDir, r.cacheDir); err != nil {
-		cmd.FailErr(err, "chown volumes")
+		return cmd.FailErr(err, "chown volumes")
 	}
 	if err := priv.RunAs(r.uid, r.gid); err != nil {
-		cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", r.uid, r.gid))
+		return cmd.FailErr(err, fmt.Sprintf("exec as user %d:%d", r.uid, r.gid))
 	}
 	return nil
 }

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
+	specreport "github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle"
 	"github.com/buildpacks/lifecycle/api"
@@ -32,7 +32,7 @@ import (
 
 func TestExporter(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
-	spec.Run(t, "Exporter", testExporter, spec.Parallel(), spec.Report(report.Terminal{}))
+	spec.Run(t, "Exporter", testExporter, spec.Parallel(), spec.Report(specreport.Terminal{}))
 }
 
 func testExporter(t *testing.T, when spec.G, it spec.S) {
@@ -144,7 +144,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		fakeAppImage.Cleanup()
+		h.AssertNil(t, fakeAppImage.Cleanup())
 		h.AssertNil(t, os.RemoveAll(tmpDir))
 		mockCtrl.Finish()
 	})
@@ -753,11 +753,11 @@ version = "4.5.6"
 
 				// TODO : this is an hacky way to create a non-existing image and should be improved in imgutil
 				nonExistingOriginalImage = fakes.NewImage("app/original-image", "", nil)
-				nonExistingOriginalImage.Delete()
+				h.AssertNil(t, nonExistingOriginalImage.Delete())
 			})
 
 			it.After(func() {
-				nonExistingOriginalImage.Cleanup()
+				h.AssertNil(t, nonExistingOriginalImage.Cleanup())
 			})
 
 			when("there are slices", func() {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/apex/log v1.9.0
-	github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655
+	github.com/buildpacks/imgutil v0.0.0-20201008151938-cea9fc548372
 	github.com/containerd/containerd v1.3.3 // indirect
 	github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37 // indirect
 	github.com/docker/docker v1.4.2-0.20200221181110-62bd5a33f707

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655 h1:jIbUElEczuGsQaXaQ5RJw2ip+ka0ao4unuAHUHvUhCA=
-github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
+github.com/buildpacks/imgutil v0.0.0-20201008151938-cea9fc548372 h1:wi7MUqpJeOww5M4o/+2uXD8hWhxntXbW1Nv+Sa9bjDw=
+github.com/buildpacks/imgutil v0.0.0-20201008151938-cea9fc548372/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -7,6 +7,7 @@ linters:
     - bodyclose
     - deadcode
     - dogsled
+    - errcheck
     - gocritic
     - goimports
     - golint

--- a/layers/digest_test.go
+++ b/layers/digest_test.go
@@ -4,17 +4,21 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"testing"
+
+	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestConcurrentHasher(t *testing.T) {
 	msg := []byte("Some important message")
 
 	hasher := sha256.New()
-	hasher.Write(msg)
+	_, err := hasher.Write(msg)
+	h.AssertNil(t, err)
 	digest := hex.EncodeToString(hasher.Sum(nil))
 
 	cHasher := newConcurrentHasher(sha256.New())
-	cHasher.Write(msg)
+	_, err = cHasher.Write(msg)
+	h.AssertNil(t, err)
 	cDigest := hex.EncodeToString(cHasher.Sum(nil))
 
 	if digest != cDigest {

--- a/restorer_test.go
+++ b/restorer_test.go
@@ -55,7 +55,7 @@ func testRestorer(t *testing.T, when spec.G, it spec.S) {
 			}
 			if testing.Verbose() {
 				restorer.Logger = cmd.DefaultLogger
-				cmd.SetLogLevel("debug")
+				h.AssertNil(t, cmd.SetLogLevel("debug"))
 			}
 		})
 
@@ -234,7 +234,7 @@ func testRestorer(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it.After(func() {
-				os.RemoveAll(tarTempDir)
+				h.AssertNil(t, os.RemoveAll(tarTempDir))
 			})
 
 			when("there is a cache=true layer", func() {
@@ -437,7 +437,7 @@ func TestWriteLayer(t *testing.T) {
 	}
 	defer os.RemoveAll(layersDir)
 
-	writeLayer(layersDir, "test-buildpack", "test-layer", "test-metadata", "test-sha")
+	h.AssertNil(t, writeLayer(layersDir, "test-buildpack", "test-layer", "test-metadata", "test-sha"))
 
 	got := h.MustReadFile(t, filepath.Join(layersDir, "test-buildpack", "test-layer.toml"))
 	want := "test-metadata"

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -219,6 +219,7 @@ func ComputeSHA256ForFile(t *testing.T, path string) string {
 	if err != nil {
 		t.Fatalf("failed to open file: %s", err)
 	}
+	defer file.Close()
 	hasher := sha256.New()
 	if _, err := io.Copy(hasher, file); err != nil {
 		t.Fatalf("failed to copy file to hasher: %s", err)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Djarvur/go-err113 v0.1.0 // indirect
-	github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655
+	github.com/buildpacks/imgutil v0.0.0-20201008151938-cea9fc548372
 	github.com/buildpacks/lifecycle v0.8.1
 	github.com/docker/docker v1.4.2-0.20200221181110-62bd5a33f707
 	github.com/golang/mock v1.4.4

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -91,8 +91,10 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bombsimon/wsl/v3 v3.1.0 h1:E5SRssoBgtVFPcYWUOFJEcgaySgdtTNYzsSKDOY7ss8=
 github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
+github.com/buildpacks/imgutil v0.0.0-20200528211046-5c4cfa56bb24/go.mod h1:rkRDOGpntpFhgj0gIUhQnEt5DYvi7xUTHkZWSxbWJP0=
 github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655 h1:jIbUElEczuGsQaXaQ5RJw2ip+ka0ao4unuAHUHvUhCA=
 github.com/buildpacks/imgutil v0.0.0-20200831154319-afd98bd2f655/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
+github.com/buildpacks/imgutil v0.0.0-20201008151938-cea9fc548372/go.mod h1:Oj9x40zkDyafaKpvgPuLGFjzzrdQQ+w9DNi1JzqJV1I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/utils.go
+++ b/utils.go
@@ -77,7 +77,9 @@ func removeLabels(image imgutil.Image, test func(string) bool) error {
 
 	for label := range labels {
 		if test(label) {
-			image.RemoveLabel(label)
+			if err := image.RemoveLabel(label); err != nil {
+				return errors.Wrapf(err, "failed to remove label '%s'", label)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Enables `errcheck` linter in golangci-lint. Fixes missing error checks!