### PR TITLE
Use manifest tag instead of manifest list tag as windows base image

### DIFF
--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	baseImage := "gcr.io/distroless/static"
 	if targetOS == "windows" {
-		baseImage = "mcr.microsoft.com/windows/servercore:ltsc2019"
+		baseImage = "mcr.microsoft.com/windows/servercore:ltsc2019-amd64"
 	}
 
 	var img imgutil.Image


### PR DESCRIPTION
This is necessary because of this bug in imgutil https://github.com/buildpacks/imgutil/issues/54.

Signed-off-by: Emily Casey <ecasey@vmware.com>

Fixes image build failures https://github.com/buildpacks/lifecycle/actions/runs/304821754