### PR TITLE
Changes windows base image back to nanoserver:1809

### DIFF
--- a/acceptance/testdata/launcher/windows/Dockerfile
+++ b/acceptance/testdata/launcher/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/nanoserver:1809
 
 COPY container /
 

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -26,6 +26,12 @@ import (
 	"github.com/buildpacks/lifecycle/archive"
 )
 
+const (
+	linuxBaseImage   = "gcr.io/distroless/static"
+	windowsBaseImage = "mcr.microsoft.com/windows/nanoserver:1809-amd64"
+)
+
+// commandline flags
 var (
 	lifecyclePath string      // path to lifecycle TGZ
 	tags          stringSlice // tag reference to write lifecycle image
@@ -57,9 +63,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	baseImage := "gcr.io/distroless/static"
+	baseImage := linuxBaseImage
 	if targetOS == "windows" {
-		baseImage = "mcr.microsoft.com/windows/servercore:ltsc2019-amd64"
+		baseImage = windowsBaseImage
 	}
 
 	var img imgutil.Image


### PR DESCRIPTION
Nanoserver 1809 will now be supported through January 2024. Therefore, we should use this image because it is smaller than ltsc2019.

* https://github.com/microsoft/Windows-Containers/issues/52

Signed-off-by: Emily Casey <ecasey@vmware.com>