### PR TITLE
Bash process handles more than 9 args correctly

### DIFF
--- a/launch/bash.go
+++ b/launch/bash.go
@@ -53,7 +53,7 @@ func (b *BashShell) Launch(proc ShellProcess) error {
 func bashCommandWithTokens(nTokens int) string {
 	commandScript := `"$(eval echo \"$0\")"`
 	for i := 1; i < nTokens; i++ {
-		commandScript += fmt.Sprintf(` "$(eval echo \"$%d\")"`, i)
+		commandScript += fmt.Sprintf(` "$(eval echo \"${%d}\")"`, i)
 	}
 	return fmt.Sprintf(`exec bash -c '%s' "${@:1}"`, commandScript)
 }

--- a/launch/bash_test.go
+++ b/launch/bash_test.go
@@ -130,6 +130,37 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 				}
 				h.AssertStringContains(t, stdout, "SOME_ARG: 'some arg1'")
 			})
+
+			it("handles many args", func() {
+				process = launch.ShellProcess{
+					Script:  false,
+					Command: `echo`,
+					Args: []string{
+						"one",
+						"two",
+						"three",
+						"four",
+						"five",
+						"six",
+						"seven",
+						"eight",
+						"nine",
+						"ten",
+					},
+					Caller: "some-profile-argv0",
+					Env: []string{
+						"SOME_VAR=some-val",
+					},
+				}
+				err := shell.Launch(process)
+				h.AssertNil(t, err)
+				stdout := rdfile(t, filepath.Join(tmpDir, "stdout"))
+				if len(stdout) == 0 {
+					stderr := rdfile(t, filepath.Join(tmpDir, "stderr"))
+					t.Fatalf("stdout was empty: stderr: %s\n", stderr)
+				}
+				h.AssertStringContains(t, stdout, "one two three four five six seven eight nine ten")
+			})
 		})
 
 		when("is not script", func() {


### PR DESCRIPTION
Our magic bash command was mising some important curly brances and therefore the tenth argument was being set to the equivalent of "${1}0" instead of "${10}".

Resolves #445

Signed-off-by: Emily Casey <ecasey@vmware.com>