### PR TITLE
feature: validate mixins during rebase

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -12,6 +12,7 @@ const (
 	BuildMetadataLabel = "io.buildpacks.build.metadata"
 	LayerMetadataLabel = "io.buildpacks.lifecycle.metadata"
 	StackIDLabel       = "io.buildpacks.stack.id"
+	MixinsLabel        = "io.buildpacks.stack.mixins"
 )
 
 type BuildMetadata struct {

--- a/rebaser.go
+++ b/rebaser.go
@@ -99,8 +99,8 @@ func validateMixins(appImg, newBaseImg imgutil.Image) error {
 		return errors.Wrap(err, "get run image mixins")
 	}
 
-	appImageMixins = RemoveStagePrefixes(appImageMixins)
-	newBaseImageMixins = RemoveStagePrefixes(newBaseImageMixins)
+	appImageMixins = removeStagePrefixes(appImageMixins)
+	newBaseImageMixins = removeStagePrefixes(newBaseImageMixins)
 
 	_, missing, _ := Compare(newBaseImageMixins, appImageMixins)
 

--- a/rebaser.go
+++ b/rebaser.go
@@ -50,7 +50,7 @@ func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, add
 		return RebaseReport{}, err
 	}
 
-	if err = appImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage); err != nil {
+	if err := appImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "rebase app image")
 	}
 

--- a/rebaser.go
+++ b/rebaser.go
@@ -46,13 +46,11 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 		return RebaseReport{}, errors.New(fmt.Sprintf("incompatible stack: '%s' is not compatible with '%s'", newBaseStackID, workingStackID))
 	}
 
-	err = validateMixins(workingImage, newBaseImage)
-	if err != nil {
+	if err := validateMixins(workingImage, newBaseImage); err != nil {
 		return RebaseReport{}, err
 	}
 
-	err = workingImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage)
-	if err != nil {
+	if err = workingImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "rebase working image")
 	}
 

--- a/rebaser.go
+++ b/rebaser.go
@@ -102,7 +102,7 @@ func validateMixins(appImg, newBaseImg imgutil.Image) error {
 	appImageMixins = removeStagePrefixes(appImageMixins)
 	newBaseImageMixins = removeStagePrefixes(newBaseImageMixins)
 
-	_, missing, _ := Compare(newBaseImageMixins, appImageMixins)
+	_, missing, _ := compare(newBaseImageMixins, appImageMixins)
 
 	if len(missing) > 0 {
 		sort.Strings(missing)

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -26,21 +26,21 @@ func TestRebaser(t *testing.T) {
 func testRebaser(t *testing.T, when spec.G, it spec.S) {
 	var (
 		rebaser          *lifecycle.Rebaser
-		fakeWorkingImage *fakes.Image
+		fakeAppImage     *fakes.Image
 		fakeNewBaseImage *fakes.Image
 		additionalNames  []string
 		md               lifecycle.LayersMetadataCompat
 	)
 
 	it.Before(func() {
-		fakeWorkingImage = fakes.NewImage(
+		fakeAppImage = fakes.NewImage(
 			"some-repo/app-image",
 			"some-top-layer-sha",
 			local.IDIdentifier{
 				ImageID: "some-image-id",
 			},
 		)
-		h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.bionic"))
+		h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.bionic"))
 
 		fakeNewBaseImage = fakes.NewImage(
 			"some-repo/new-base-image",
@@ -59,54 +59,54 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	it.After(func() {
-		h.AssertNil(t, fakeWorkingImage.Cleanup())
+		h.AssertNil(t, fakeAppImage.Cleanup())
 		h.AssertNil(t, fakeNewBaseImage.Cleanup())
 	})
 
 	when("#Rebase", func() {
 		when("app image and run image exist", func() {
-			it("updates the base image of the working image", func() {
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+			it("updates the base image of the app image", func() {
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertNil(t, err)
-				h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+				h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 			})
 
 			it("saves to all names", func() {
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertNil(t, err)
-				h.AssertContains(t, fakeWorkingImage.SavedNames(), "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
+				h.AssertContains(t, fakeAppImage.SavedNames(), "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
 			})
 
 			it("adds all names to report", func() {
-				report, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertNil(t, err)
 				h.AssertContains(t, report.Image.Tags, "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
 			})
 
 			it("sets the top layer in the metadata", func() {
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertNil(t, err)
-				h.AssertNil(t, lifecycle.DecodeLabel(fakeWorkingImage, lifecycle.LayerMetadataLabel, &md))
+				h.AssertNil(t, lifecycle.DecodeLabel(fakeAppImage, lifecycle.LayerMetadataLabel, &md))
 
 				h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
 			})
 
 			it("sets the run image reference in the metadata", func() {
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertNil(t, err)
-				h.AssertNil(t, lifecycle.DecodeLabel(fakeWorkingImage, lifecycle.LayerMetadataLabel, &md))
+				h.AssertNil(t, lifecycle.DecodeLabel(fakeAppImage, lifecycle.LayerMetadataLabel, &md))
 
 				h.AssertEq(t, md.RunImage.Reference, "new-run-id")
 			})
 
 			it("preserves other existing metadata", func() {
-				h.AssertNil(t, fakeWorkingImage.SetLabel(
+				h.AssertNil(t, fakeAppImage.SetLabel(
 					lifecycle.LayerMetadataLabel,
 					`{"app": [{"sha": "123456"}], "buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
 				))
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertNil(t, err)
-				h.AssertNil(t, lifecycle.DecodeLabel(fakeWorkingImage, lifecycle.LayerMetadataLabel, &md))
+				h.AssertNil(t, lifecycle.DecodeLabel(fakeAppImage, lifecycle.LayerMetadataLabel, &md))
 
 				h.AssertEq(t, len(md.Buildpacks), 1)
 				h.AssertEq(t, md.Buildpacks[0].ID, "buildpack.id")
@@ -115,10 +115,10 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 
 			when("image has io.buildpacks.stack.* labels", func() {
 				var tests = []struct {
-					label             string
-					workingImageValue string
-					runImageValue     string
-					want              string
+					label         string
+					appImageValue string
+					runImageValue string
+					want          string
 				}{
 					{"io.buildpacks.stack.distro.name", "ubuntu", "ubuntu", "ubuntu"},
 					{"io.buildpacks.stack.changed", "v1", "v2", "v2"},
@@ -133,20 +133,20 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						if l.runImageValue != "" {
 							h.AssertNil(t, fakeNewBaseImage.SetLabel(l.label, l.runImageValue))
 						}
-						if l.workingImageValue != "" {
-							h.AssertNil(t, fakeWorkingImage.SetLabel(l.label, l.workingImageValue))
+						if l.appImageValue != "" {
+							h.AssertNil(t, fakeAppImage.SetLabel(l.label, l.appImageValue))
 						}
 					}
 				})
 
 				it("syncs matching labels", func() {
-					_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 					h.AssertNil(t, err)
 
 					for _, test := range tests {
 						test := test
 						t.Run(test.label, func(t *testing.T) {
-							actual, err := fakeWorkingImage.Label(test.label)
+							actual, err := fakeAppImage.Label(test.label)
 							h.AssertNil(t, err)
 							h.AssertEq(t, test.want, actual)
 						})
@@ -160,13 +160,13 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				it.Before(func() {
 					digestRef, err := name.NewDigest("some-repo/app-image@" + fakeRemoteDigest)
 					h.AssertNil(t, err)
-					fakeWorkingImage.SetIdentifier(remote.DigestIdentifier{
+					fakeAppImage.SetIdentifier(remote.DigestIdentifier{
 						Digest: digestRef,
 					})
 				})
 
 				it("add the digest to the report", func() {
-					report, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, report.Image.Digest, fakeRemoteDigest)
@@ -175,7 +175,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 
 			when("image has an ID identifier", func() {
 				it("add the imageID to the report", func() {
-					report, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, report.Image.ImageID, "some-image-id")
@@ -185,85 +185,85 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			when("validating mixins", func() {
 				when("there are no mixin labels", func() {
 					it("allows rebase", func() {
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
 				when("there are invalid mixin labels", func() {
 					it("returns an error", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "thisisn'tvalid!"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
-						h.AssertError(t, err, "get working image mixins: failed to unmarshal context of label 'io.buildpacks.stack.mixins': invalid character 'h' in literal true (expecting 'r')")
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "thisisn'tvalid!"))
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						h.AssertError(t, err, "get app image mixins: failed to unmarshal context of label 'io.buildpacks.stack.mixins': invalid character 'h' in literal true (expecting 'r')")
 					})
 				})
 
 				when("mixins are not present in either image", func() {
 					it("allows rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "null"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "null"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "null"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
-				when("mixins are not present on the working image", func() {
+				when("mixins are not present on the app image", func() {
 					it("allows rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "null"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "null"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\"]"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
-				when("mixins match on the working and run images", func() {
+				when("mixins match on the app and run images", func() {
 					it("allows rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
 				when("extra mixins are present on the run image", func() {
 					it("allows rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\", \"mixin-3\"]"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
-				when("mixins on the working image have stage specifiers that do not match the run image", func() {
+				when("mixins on the app image have stage specifiers that do not match the run image", func() {
 					it("allows rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
-				when("mixins on the run image have stage specifiers that do not match the working image", func() {
+				when("mixins on the run image have stage specifiers that do not match the app image", func() {
 					it("allows rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "[\"run:mixin-1\", \"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertNil(t, err)
-						h.AssertEq(t, fakeWorkingImage.Base(), "some-repo/new-base-image")
+						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
 				})
 
 				when("mixins are missing on the run image", func() {
 					it("does not allow rebase", func() {
-						h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
+						h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.MixinsLabel, "[\"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 						h.AssertError(t, err, "missing required mixin(s): mixin-1")
 					})
 				})
@@ -272,27 +272,27 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 
 		when("app image and run image are based on different stacks", func() {
 			it("returns an error and prevents the rebase from taking place when the stacks are different", func() {
-				h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.bionic"))
+				h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.bionic"))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertError(t, err, "incompatible stack: 'io.buildpacks.stacks.cflinuxfs3' is not compatible with 'io.buildpacks.stacks.bionic'")
 			})
 
 			it("returns an error and prevents the rebase from taking place when the new base image has no stack defined", func() {
-				h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.bionic"))
+				h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.bionic"))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.StackIDLabel, ""))
 
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
 				h.AssertError(t, err, "stack not defined on new base image")
 			})
 
-			it("returns an error and prevents the rebase from taking place when the working image has no stack defined", func() {
-				h.AssertNil(t, fakeWorkingImage.SetLabel(lifecycle.StackIDLabel, ""))
+			it("returns an error and prevents the rebase from taking place when the app image has no stack defined", func() {
+				h.AssertNil(t, fakeAppImage.SetLabel(lifecycle.StackIDLabel, ""))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(lifecycle.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
-				_, err := rebaser.Rebase(fakeWorkingImage, fakeNewBaseImage, additionalNames)
-				h.AssertError(t, err, "stack not defined on working image")
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				h.AssertError(t, err, "stack not defined on app image")
 			})
 		})
 	})

--- a/utils.go
+++ b/utils.go
@@ -62,8 +62,7 @@ func DecodeLabel(image imgutil.Image, label string, v interface{}) error {
 	return nil
 }
 
-// RemoveStagePrefixes creates a slice with the build: or run: style prefixes removed.
-func RemoveStagePrefixes(mixins []string) []string {
+func removeStagePrefixes(mixins []string) []string {
 	var result []string
 	for _, m := range mixins {
 		s := strings.SplitN(m, ":", 2)
@@ -76,26 +75,20 @@ func RemoveStagePrefixes(mixins []string) []string {
 	return result
 }
 
-// FromSlice converts the given slice to a set in the form of unique keys in a map.
-// The value associated with each key should not be relied upon. A value is present
-// in the set if its key is present in the map, regardless of the key's value.
-// from: https://github.com/buildpacks/pack/blob/main/internal/stringset/stringset.go
-func FromSlice(strings []string) map[string]interface{} {
-	set := map[string]interface{}{}
-	for _, s := range strings {
-		set[s] = nil
-	}
-	return set
-}
-
 // Compare performs a set comparison between two slices. `extra` represents elements present in
 // `strings1` but not `strings2`. `missing` represents elements present in `strings2` that are
 // missing from `strings1`. `common` represents elements present in both slices. Since the input
 // slices are treated as sets, duplicates will be removed in any outputs.
 // from: https://github.com/buildpacks/pack/blob/main/internal/stringset/stringset.go
 func Compare(strings1, strings2 []string) (extra []string, missing []string, common []string) {
-	set1 := FromSlice(strings1)
-	set2 := FromSlice(strings2)
+	set1 := map[string]struct{}{}
+	set2 := map[string]struct{}{}
+	for _, s := range strings1 {
+		set1[s] = struct{}{}
+	}
+	for _, s := range strings2 {
+		set2[s] = struct{}{}
+	}
 
 	for s := range set1 {
 		if _, ok := set2[s]; !ok {

--- a/utils.go
+++ b/utils.go
@@ -62,6 +62,58 @@ func DecodeLabel(image imgutil.Image, label string, v interface{}) error {
 	return nil
 }
 
+// RemoveStagePrefixes creates a slice with the build: or run: style prefixes removed.
+func RemoveStagePrefixes(mixins []string) []string {
+	var result []string
+	for _, m := range mixins {
+		s := strings.SplitN(m, ":", 2)
+		if len(s) == 1 {
+			result = append(result, s[0])
+		} else {
+			result = append(result, s[1])
+		}
+	}
+	return result
+}
+
+// FromSlice converts the given slice to a set in the form of unique keys in a map.
+// The value associated with each key should not be relied upon. A value is present
+// in the set if its key is present in the map, regardless of the key's value.
+// from: https://github.com/buildpacks/pack/blob/main/internal/stringset/stringset.go
+func FromSlice(strings []string) map[string]interface{} {
+	set := map[string]interface{}{}
+	for _, s := range strings {
+		set[s] = nil
+	}
+	return set
+}
+
+// Compare performs a set comparison between two slices. `extra` represents elements present in
+// `strings1` but not `strings2`. `missing` represents elements present in `strings2` that are
+// missing from `strings1`. `common` represents elements present in both slices. Since the input
+// slices are treated as sets, duplicates will be removed in any outputs.
+// from: https://github.com/buildpacks/pack/blob/main/internal/stringset/stringset.go
+func Compare(strings1, strings2 []string) (extra []string, missing []string, common []string) {
+	set1 := FromSlice(strings1)
+	set2 := FromSlice(strings2)
+
+	for s := range set1 {
+		if _, ok := set2[s]; !ok {
+			extra = append(extra, s)
+			continue
+		}
+		common = append(common, s)
+	}
+
+	for s := range set2 {
+		if _, ok := set1[s]; !ok {
+			missing = append(missing, s)
+		}
+	}
+
+	return extra, missing, common
+}
+
 func syncLabels(sourceImg imgutil.Image, destImage imgutil.Image, test func(string) bool) error {
 	if err := removeLabels(destImage, test); err != nil {
 		return err

--- a/utils.go
+++ b/utils.go
@@ -75,12 +75,12 @@ func removeStagePrefixes(mixins []string) []string {
 	return result
 }
 
-// Compare performs a set comparison between two slices. `extra` represents elements present in
+// compare performs a set comparison between two slices. `extra` represents elements present in
 // `strings1` but not `strings2`. `missing` represents elements present in `strings2` that are
 // missing from `strings1`. `common` represents elements present in both slices. Since the input
 // slices are treated as sets, duplicates will be removed in any outputs.
 // from: https://github.com/buildpacks/pack/blob/main/internal/stringset/stringset.go
-func Compare(strings1, strings2 []string) (extra []string, missing []string, common []string) {
+func compare(strings1, strings2 []string) (extra []string, missing []string, common []string) {
 	set1 := map[string]struct{}{}
 	set2 := map[string]struct{}{}
 	for _, s := range strings1 {


### PR DESCRIPTION
Implemented as discussed [here](https://github.com/buildpacks/lifecycle/issues/425). Using the `io.buildpacks.stack.mixins` label of the working and new run image, lifecycle will now verify that mixins are present on the new base image prior to the rebase operation.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>