### PR TITLE
Slices: Clean pattern before matching

### DIFF
--- a/layers/slices.go
+++ b/layers/slices.go
@@ -65,6 +65,7 @@ func (f *Factory) createLayerFromSlice(slice Slice, sdir *sliceableDir, layerID 
 }
 
 func glob(sdir *sliceableDir, pattern string) ([]string, error) {
+	pattern = filepath.Clean(pattern)
 	var matches []string
 	if err := filepath.Walk(sdir.path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/layers/slices_test.go
+++ b/layers/slices_test.go
@@ -353,5 +353,43 @@ func testSlices(t *testing.T, when spec.G, it spec.S) {
 				assertTarEntries(t, sliceLayers[1].TarPath, []*tar.Header{})
 			})
 		})
+
+		when("the pattern ends in a path separator", func() {
+			it("matches", func() {
+				pattern := "some-dir" + string(filepath.Separator)
+				sliceLayers, err := factory.SliceLayers(dirToSlice, []layers.Slice{
+					{Paths: []string{pattern}},
+				})
+				h.AssertNil(t, err)
+				h.AssertEq(t, len(sliceLayers), 2)
+				h.AssertEq(t, sliceLayers[0].ID, "slice-1")
+				assertTarEntries(t, sliceLayers[0].TarPath, append(parents(t, dirToSlice), []*tar.Header{
+					{
+						Name:     tarPath(dirToSlice),
+						Uid:      factory.UID,
+						Gid:      factory.GID,
+						Typeflag: tar.TypeDir,
+					},
+					{
+						Name:     tarPath(filepath.Join(dirToSlice, "some-dir")),
+						Uid:      factory.UID,
+						Gid:      factory.GID,
+						Typeflag: tar.TypeDir,
+					},
+					{
+						Name:     tarPath(filepath.Join(dirToSlice, "some-dir", "file.md")),
+						Uid:      factory.UID,
+						Gid:      factory.GID,
+						Typeflag: tar.TypeReg,
+					},
+					{
+						Name:     tarPath(filepath.Join(dirToSlice, "some-dir", "some-file.txt")),
+						Uid:      factory.UID,
+						Gid:      factory.GID,
+						Typeflag: tar.TypeReg,
+					},
+				}...))
+			})
+		})
 	})
 }


### PR DESCRIPTION
I took a stab at fixing #455 but I have some questions.

`filepath.Clean` seemed like the easiest fix, but it would also have the effect of making other patterns match - e.g., `some-dir//some-other-dir` would match `some-dir/some-other-dir` and I am not sure this is what we want.

Also it seems important to validate this change against the linked repro (spring-boot-buildpack) but having limited knowledge of Spring Boot, I am not sure how to do that.

