### PR TITLE
Bumps imgutil to fix daemon image bugs

### DIFF
--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -259,6 +259,7 @@ func initDaemonImage(imagName string, runImageRef string, analyzedMD lifecycle.A
 		opts = append(opts, local.WithPreviousImage(analyzedMD.Image.Reference))
 	}
 
+	var appImage imgutil.Image
 	appImage, err := local.NewImage(
 		imagName,
 		docker,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 // indirect
 	github.com/apex/log v1.9.0
-	github.com/buildpacks/imgutil v0.0.0-20201201142712-a6b11a745ca6
+	github.com/buildpacks/imgutil v0.0.0-20201209143029-339e186e495a
 	github.com/containerd/containerd v1.3.3 // indirect
 	github.com/docker/cli v0.0.0-20200312141509-ef2f64abbd37 // indirect
 	github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/buildpacks/imgutil v0.0.0-20201022190551-6525b8cdcdd0 h1:NfMkYsjGmNJG
 github.com/buildpacks/imgutil v0.0.0-20201022190551-6525b8cdcdd0/go.mod h1:tG2oQSjijSLsymHJz/K3dJyUfmQ72dBfxDqWlNMPFUQ=
 github.com/buildpacks/imgutil v0.0.0-20201201142712-a6b11a745ca6 h1:rV6HuGwGHYnqwcDdR1yhC5Ksmq7axwFwnwEv7B00Pag=
 github.com/buildpacks/imgutil v0.0.0-20201201142712-a6b11a745ca6/go.mod h1:jrlRd+Htv2BB3l5ri0TBj49Nk5NuakkOe6Nx4+EUjYM=
+github.com/buildpacks/imgutil v0.0.0-20201209143029-339e186e495a h1:XGfPOtXJL8izPAA+Vixbl1BeTG5Pe1evubfOdxDAmpM=
+github.com/buildpacks/imgutil v0.0.0-20201209143029-339e186e495a/go.mod h1:NC93OGDehA2ksqgTzugeQcPqmTpilMPYRO+XaFsDyts=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/buildpacks/imgutil v0.0.0-20201201142712-a6b11a745ca6
+	github.com/buildpacks/imgutil v0.0.0-20201209143029-339e186e495a
 	github.com/buildpacks/lifecycle v0.9.2
 	github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7
 	github.com/golang/mock v1.4.4

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -94,6 +94,7 @@ github.com/bombsimon/wsl/v3 v3.1.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2
 github.com/buildpacks/imgutil v0.0.0-20201022190551-6525b8cdcdd0 h1:NfMkYsjGmNJGl80WHEa4rGM1hU8IDUIdqBiPZpxkvRM=
 github.com/buildpacks/imgutil v0.0.0-20201022190551-6525b8cdcdd0/go.mod h1:tG2oQSjijSLsymHJz/K3dJyUfmQ72dBfxDqWlNMPFUQ=
 github.com/buildpacks/imgutil v0.0.0-20201201142712-a6b11a745ca6/go.mod h1:jrlRd+Htv2BB3l5ri0TBj49Nk5NuakkOe6Nx4+EUjYM=
+github.com/buildpacks/imgutil v0.0.0-20201209143029-339e186e495a/go.mod h1:NC93OGDehA2ksqgTzugeQcPqmTpilMPYRO+XaFsDyts=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
Falls back to slower behavior if the daemon does not accept empty layers. This allows the lifecycle to be compatible with podman which requires all layers to be preset during a docker load: buildpacks/imgutil#80

Fixes "manifest.json had unexpected number of entries"  errors in analyze, export, and rebase resulting from a bug in our daemon save logic: buildpacks/imgutil#63

Signed-off-by: Emily Casey <ecasey@vmware.com>