### PR TITLE
Omit build bom from report.toml if empty

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -63,7 +63,7 @@ type ExportOptions struct {
 }
 
 type ExportReport struct {
-	Build BuildReport `toml:"build"`
+	Build BuildReport `toml:"build,omitempty"`
 	Image ImageReport `toml:"image"`
 }
 


### PR DESCRIPTION
This will keep the output consistent for users of older platform APIs

Signed-off-by: Natalie Arellano <narellano@vmware.com>