### PR TITLE
Fixes when a buildpack with no layers stops launch env processing

### DIFF
--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -125,7 +125,7 @@ func (l *Launcher) eachBuildpack(fn bpAction) error {
 	for _, bp := range l.Buildpacks {
 		dir := filepath.Join(l.LayersDir, EscapeID(bp.ID))
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			return nil
+			continue
 		} else if err != nil {
 			return errors.Wrap(err, "find buildpack directory")
 		}

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -78,6 +78,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			LayersDir:          filepath.Join(tmpDir, "launch"),
 			AppDir:             filepath.Join(tmpDir, "launch", "app"),
 			Buildpacks: []launch.Buildpack{
+				{API: "0.3", ID: "no-layers/buildpack"},
 				{API: "0.3", ID: "0.3/buildpack"},
 				{API: "0.4", ID: "0.4/buildpack"},
 				{API: "0.5", ID: "0.5/buildpack"},


### PR DESCRIPTION
When processing the environment continue when a buildpack has no layers dir instead of returning.

Signed-off-by: Emily Casey <ecasey@vmware.com>