### PR TITLE
Prepare analyzer to be run before detect by removing the group option

### DIFF
--- a/acceptance/testdata/analyzer/analyze-image/container/cnb/buildpacks/some-buildpack-id/some-buildpack-version/buildpack.toml
+++ b/acceptance/testdata/analyzer/analyze-image/container/cnb/buildpacks/some-buildpack-id/some-buildpack-version/buildpack.toml
@@ -1,0 +1,6 @@
+api = "0.2"
+
+[buildpack]
+id = "some-buildpack-id"
+name = "Some Buildpack"
+version = "some-buildpack-version"

--- a/acceptance/testdata/analyzer/app-image/Dockerfile
+++ b/acceptance/testdata/analyzer/app-image/Dockerfile
@@ -3,5 +3,7 @@ ARG fromImage
 FROM $fromImage
 
 ARG metadata
+ARG buildMetadata
 
+LABEL io.buildpacks.build.metadata=$buildMetadata
 LABEL io.buildpacks.lifecycle.metadata=$metadata

--- a/acceptance/testdata/analyzer/build_metadata.json
+++ b/acceptance/testdata/analyzer/build_metadata.json
@@ -1,0 +1,8 @@
+{
+  "buildpacks": [
+    {
+      "id": "some-buildpack-id",
+      "version": "some-buildpack-version"
+    }
+  ]
+}

--- a/acceptance/testdata/analyzer/cache-image/Dockerfile
+++ b/acceptance/testdata/analyzer/cache-image/Dockerfile
@@ -3,5 +3,7 @@ ARG fromImage
 FROM $fromImage
 
 ARG metadata
+ARG buildMetadata
 
+LABEL io.buildpacks.build.metadata=$buildMetadata
 LABEL io.buildpacks.lifecycle.cache.metadata=$metadata

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -365,17 +365,17 @@ func testAnalyzer(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, testCache.Commit())
 				})
 
-				//it("restores cache=true layer metadata", func() {
-				//	_, err := analyzer.Analyze(image, testCache)
-				//	h.AssertNil(t, err)
-				//
-				//	for _, data := range []struct{ name, want string }{
-				//		{"metadata.buildpack/cache.toml", "[metadata]\n  cache-key = \"cache-value\""},
-				//	} {
-				//		got := h.MustReadFile(t, filepath.Join(layerDir, data.name))
-				//		h.AssertStringContains(t, string(got), data.want)
-				//	}
-				//})
+				it("restores cache=true layer metadata", func() {
+					_, err := analyzer.Analyze(image, testCache)
+					h.AssertNil(t, err)
+
+					for _, data := range []struct{ name, want string }{
+						{"metadata.buildpack/cache.toml", "[metadata]\n  cache-key = \"cache-value\""},
+					} {
+						got := h.MustReadFile(t, filepath.Join(layerDir, data.name))
+						h.AssertStringContains(t, string(got), data.want)
+					}
+				})
 
 				it("does not restore launch=true layer metadata", func() {
 					_, err := analyzer.Analyze(image, testCache)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -195,6 +195,10 @@ func FlagProcessType(processType *string) {
 	flagSet.StringVar(processType, "process-type", os.Getenv(EnvProcessType), "default process type")
 }
 
+func DeprecatedFlagGroupPath(group *string) {
+	flagSet.StringVar(group, "group", "", "path to group.toml")
+}
+
 func DeprecatedFlagRunImage(image *string) {
 	flagSet.StringVar(image, "image", "", "reference to run image")
 }

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -161,7 +161,7 @@ func (c *createCmd) Exec() error {
 		skipLayers:  c.skipRestore,
 		useDaemon:   c.useDaemon,
 		docker:      c.docker,
-	}.analyze(group, cacheStore)
+	}.analyze(cacheStore)
 	if err != nil {
 		return err
 	}

--- a/layers.go
+++ b/layers.go
@@ -8,28 +8,27 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/buildpacks/lifecycle/api"
+
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
 
-	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/launch"
 )
 
 type bpLayersDir struct {
-	path      string
-	layers    []bpLayer
-	name      string
-	buildpack GroupBuildpack
-	store     *StoreTOML
+	path   string
+	layers []bpLayer
+	id     string
+	store  *StoreTOML
 }
 
 func readBuildpackLayersDir(layersDir string, buildpack GroupBuildpack) (bpLayersDir, error) {
 	path := filepath.Join(layersDir, launch.EscapeID(buildpack.ID))
 	bpDir := bpLayersDir{
-		name:      buildpack.ID,
-		path:      path,
-		layers:    []bpLayer{},
-		buildpack: buildpack,
+		id:     buildpack.ID,
+		path:   path,
+		layers: []bpLayer{},
 	}
 
 	fis, err := ioutil.ReadDir(path)
@@ -108,7 +107,7 @@ func (bd *bpLayersDir) newBPLayer(name string) *bpLayer {
 	return &bpLayer{
 		layer{
 			path:       filepath.Join(bd.path, name),
-			identifier: fmt.Sprintf("%s:%s", bd.buildpack.ID, name),
+			identifier: fmt.Sprintf("%s:%s", bd.id, name),
 		},
 	}
 }

--- a/testdata/analyzer/build_metadata.json
+++ b/testdata/analyzer/build_metadata.json
@@ -1,0 +1,20 @@
+{
+  "buildpacks": [
+    {
+      "id": "escaped/buildpack/id",
+      "version": "v1"
+    },
+    {
+      "id": "metadata.buildpack",
+      "version": "v1"
+    },
+    {
+      "id": "no.cache.buildpack",
+      "version": "v1"
+    },
+    {
+      "id": "no.metadata.buildpack",
+      "version": "v1"
+    }
+  ]
+}

--- a/testdata/analyzer/buildpacks/escaped_buildpack_id/v1/buildpack.toml
+++ b/testdata/analyzer/buildpacks/escaped_buildpack_id/v1/buildpack.toml
@@ -1,0 +1,6 @@
+api = "0.3"
+
+[buildpack]
+id = "escaped/buildpack/id"
+name = "Escaped ID Buildpack"
+version = "v1"

--- a/testdata/analyzer/buildpacks/metadata.buildpack/v1/buildpack.toml
+++ b/testdata/analyzer/buildpacks/metadata.buildpack/v1/buildpack.toml
@@ -1,0 +1,7 @@
+api = "0.3"
+
+[buildpack]
+id = "metadata.buildpack"
+name = "Metadata Buildpack"
+version = "v1"
+homepage = "Metadata Buildpack Homepage"

--- a/testdata/analyzer/buildpacks/no.cache.buildpack/v1/buildpack.toml
+++ b/testdata/analyzer/buildpacks/no.cache.buildpack/v1/buildpack.toml
@@ -1,0 +1,6 @@
+api = "0.3"
+
+[buildpack]
+id = "no.cache.buildpack"
+name = "No Cache Buildpack"
+version = "v1"

--- a/testdata/analyzer/buildpacks/no.metadata.buildpack/v1/buildpack.toml
+++ b/testdata/analyzer/buildpacks/no.metadata.buildpack/v1/buildpack.toml
@@ -1,0 +1,6 @@
+api = "0.3"
+
+[buildpack]
+id = "no.metadata.buildpack"
+name = "No Metadata Buildpack"
+version = "v1"


### PR DESCRIPTION
This prepares the `analyzer` to run before the `detector`, which requires removing the `-group` flag. The buildpack group is determined by the detector. Instead, buildpack metadata is read from the previous image's label.