### PR TITLE
Fix goroutine race in detector

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -271,9 +271,9 @@ func (b *BuildpackTOML) Detect(c *DetectConfig) DetectRun {
 	cmd.Dir = appDir
 	cmd.Stdout = out
 	cmd.Stderr = out
-	cmd.Env = c.FullEnv
+	cmd.Env = append([]string{}, c.FullEnv...)
 	if b.Buildpack.ClearEnv {
-		cmd.Env = c.ClearEnv
+		cmd.Env = append([]string{}, c.ClearEnv...)
 	}
 	cmd.Env = append(cmd.Env, EnvBuildpackDir+"="+b.Dir)
 
@@ -351,12 +351,12 @@ func (bg BuildpackGroup) detect(done []GroupBuildpack, wg *sync.WaitGroup, c *De
 		}
 		done = append(done, bp)
 		wg.Add(1)
-		go func() {
+		go func(key string, info *BuildpackTOML) {
 			if _, ok := c.runs.Load(key); !ok {
 				c.runs.Store(key, info.Detect(c))
 			}
 			wg.Done()
-		}()
+		}(key, info)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Fixes #510 

@jonfriesen and I had been trying to debug a weird regression we started seeing after we upgraded from a `0.8.x` version of lifecycle to `0.10.1`. Eventually we narrowed it down to random Buildpacks intermittently having their `CNB_BUILDPACK_DIR` env var set to that of a different Buildpack like Jon described in #510.

The issue seems to be stemming from the fact that the goroutine runs `info.Detect(c)` which does the following:

```go
	cmd.Env = c.FullEnv
	if b.Buildpack.ClearEnv {
		cmd.Env = c.ClearEnv
	}
	cmd.Env = append(cmd.Env, EnvBuildpackDir+"="+b.Dir)
```

Copying the slice `c.FullEnv`/`c.ClearEnv` as-is and then appending to it inside the goroutine is unsafe. `cmd.Env` and `c.FullEnv` share the same underlying array. When it is appended to it affects the underlying array on `c.FullEnv`/`c.ClearEnv` which is also being used by the other goroutines.

Copying the slice using `newSlice = append([]string{}, oldSlice...)` ensures that the items are copied to a brand new slice and  makes it safe to modify inside the goroutine.

I also pass the `key` and `info` variables to the goroutine as function arguments although that didn't seem to be the cause of the issue we were seeing.

May I also suggest adding the `-race` flag to the test suite?