### PR TITLE
Pin GitHub workflows to ubuntu-18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up go
@@ -48,7 +48,7 @@ jobs:
     needs:
       - test-linux
       - test-windows
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This fixes the build as the `ubuntu-latest` tag is now `20.04`.

See [more](https://github.com/actions/virtual-environments/issues/1816)

I expect this to be temporary once we discuss how to make the test that broke less brittle. I wanted to make sure we had an easy path to getting `main` green again.