### PR TITLE
Add missing link to GH Actions to build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lifecycle
 
-![Build Status](https://github.com/buildpacks/lifecycle/workflows/build/badge.svg)
+[![Build Status](https://github.com/buildpacks/lifecycle/workflows/build/badge.svg)](https://github.com/buildpacks/lifecycle/actions)
 [![GoDoc](https://godoc.org/github.com/buildpacks/lifecycle?status.svg)](https://godoc.org/github.com/buildpacks/lifecycle)
 
 A reference implementation of the [Cloud Native Buildpacks specification](https://github.com/buildpacks/spec).


### PR DESCRIPTION
Currently, the Build Status badge links to the badge image. This commit adds the link GitHub Actions. 

