### PR TITLE
Fix creator not replacing placeholder path for -order

### DIFF
--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -99,6 +99,10 @@ func (c *createCmd) Args(nargs int, args []string) error {
 		c.reportPath = cmd.DefaultReportPath(c.platform.API(), c.layersDir)
 	}
 
+	if c.orderPath == cmd.PlaceholderOrderPath {
+		c.orderPath = cmd.DefaultOrderPath(c.platform.API(), c.layersDir)
+	}
+
 	var err error
 	c.stackMD, c.runImageRef, c.registry, err = resolveStack(c.imageName, c.stackPath, c.runImageRef)
 	if err != nil {


### PR DESCRIPTION
The placeholder replacement code was not being executed in `creator` flow