### PR TITLE
Add a unit test

### DIFF
--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -372,6 +372,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							filepath.Join(layersDir, "A", "layer"),
 						)
 						h.Mkfile(t,
+							"",
 							filepath.Join(layersDir, "A", "layer.toml"),
 						)
 

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -349,19 +349,37 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("the launch, cache and build flags are false", func() {
-				it("renames <layers>/<layer> to <layers>/<layer>.ignore", func() {
-					h.Mkdir(t,
-						filepath.Join(layersDir, "A", "layer"),
-					)
-					h.Mkfile(t,
-						"[types]\n  build=false\n  cache=false\n  launch=false",
-						filepath.Join(layersDir, "A", "layer.toml"),
-					)
+				when("the flags are specified in <layer>.toml", func() {
+					it("renames <layers>/<layer> to <layers>/<layer>.ignore", func() {
+						h.Mkdir(t,
+							filepath.Join(layersDir, "A", "layer"),
+						)
+						h.Mkfile(t,
+							"[types]\n  build=false\n  cache=false\n  launch=false",
+							filepath.Join(layersDir, "A", "layer.toml"),
+						)
 
-					_, err := bpTOML.Build(buildpack.Plan{}, config)
-					h.AssertNil(t, err)
-					h.AssertPathDoesNotExist(t, filepath.Join(layersDir, "A", "layer"))
-					h.AssertPathExists(t, filepath.Join(layersDir, "A", "layer.ignore"))
+						_, err := bpTOML.Build(buildpack.Plan{}, config)
+						h.AssertNil(t, err)
+						h.AssertPathDoesNotExist(t, filepath.Join(layersDir, "A", "layer"))
+						h.AssertPathExists(t, filepath.Join(layersDir, "A", "layer.ignore"))
+					})
+				})
+
+				when("the flags aren't specified in <layer>.toml", func() {
+					it("renames <layers>/<layer> to <layers>/<layer>.ignore", func() {
+						h.Mkdir(t,
+							filepath.Join(layersDir, "A", "layer"),
+						)
+						h.Mkfile(t,
+							filepath.Join(layersDir, "A", "layer.toml"),
+						)
+
+						_, err := bpTOML.Build(buildpack.Plan{}, config)
+						h.AssertNil(t, err)
+						h.AssertPathDoesNotExist(t, filepath.Join(layersDir, "A", "layer"))
+						h.AssertPathExists(t, filepath.Join(layersDir, "A", "layer.ignore"))
+					})
 				})
 			})
 		})


### PR DESCRIPTION
rename `<layers>/<layer>` to `<layers>/<layer>.ignore` if the `launch`, `build` and `cache` flags aren't specified

Signed-off-by: Yael Harel <yharel@vmware.com>