### PR TITLE
Gitpodified the repo

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,15 @@
+
+tasks:
+  - init: make build-linux
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+
+vscode:
+  extensions:
+    - golang.go
+    - ms-azuretools.vscode-docker

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/buildpacks/lifecycle/workflows/build/badge.svg)](https://github.com/buildpacks/lifecycle/actions)
 [![GoDoc](https://godoc.org/github.com/buildpacks/lifecycle?status.svg)](https://godoc.org/github.com/buildpacks/lifecycle)
 [![codecov](https://codecov.io/gh/buildpacks/pack/branch/main/graph/badge.svg)](https://codecov.io/gh/buildpacks/pack)
+ [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/buildpacks/lifecycle)
 
 A reference implementation of the [Cloud Native Buildpacks specification](https://github.com/buildpacks/spec).
 


### PR DESCRIPTION
Hi buildpacks team! 👋

here is a PR that fully-automates the dev setup of buildpacks/lifecycle with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/buildpacks/lifecycle/pull/604)

<img width="1377" alt="Screen Shot 2021-05-04 at 18 01 53" src="https://user-images.githubusercontent.com/377752/117033767-fe204680-ad02-11eb-918c-e6ea0d42fc74.png">

### What it does

* Comes with all buildpack lifecycle dependencies pre-installed (Go, Docker...)
* Runs `make  build` ahead-of-time so you don't need to wait
* Gives anyone immediate access to the pre-compiled buildpacks CLI, and allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

I'm looking forward to your feedback on this PR! 🚀
