### PR TITLE
(bugsbash) change template

### DIFF
--- a/tools/packager/main.go
+++ b/tools/packager/main.go
@@ -6,10 +6,10 @@ import (
 	"compress/gzip"
 	"flag"
 	"fmt"
+	"html/template"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"text/template"
 
 	"github.com/pkg/errors"
 


### PR DESCRIPTION
Signed-off-by: aSquare14 <atibhi.a@gmail.com>
opt.semgrep.import-text-template
'text/template' does not escape HTML content. If you need to escape HTML content, use 'html/template' instead.