### PR TITLE
Validate stack during analyze phase

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -73,6 +73,36 @@ func TestAnalyzer(t *testing.T) {
 	h.AssertNil(t, os.RemoveAll(filepath.Join(targetDockerConfig, "config.json")))
 	h.RecursiveCopy(t, authRegistry.DockerDirectory, targetDockerConfig)
 
+	// build run-images into test registry
+	runImageContext := filepath.Join("testdata", "analyzer", "run-image")
+	buildAuthRegistryImage(
+		t,
+		"company/stack:bionic",
+		runImageContext,
+		"-f", filepath.Join(runImageContext, dockerfileName),
+		"--build-arg", "stackid=io.buildpacks.stacks.bionic",
+	)
+	buildAuthRegistryImage(
+		t,
+		"company/stack:centos",
+		runImageContext,
+		"-f", filepath.Join(runImageContext, dockerfileName),
+		"--build-arg", "stackid=io.company.centos",
+	)
+
+	// build run-image into daemon
+	h.DockerBuild(
+		t,
+		"localcompany/stack:bionic",
+		runImageContext,
+		h.WithArgs(
+			"-f", filepath.Join(runImageContext, dockerfileName),
+			"--build-arg", "stackid=io.buildpacks.stacks.bionic",
+		),
+	)
+
+	defer h.DockerImageRemove(t, "localcompany/stack:bionic")
+
 	// Setup test container
 
 	h.MakeAndCopyLifecycle(t, daemonOS, analyzerBinaryDir)
@@ -81,6 +111,7 @@ func TestAnalyzer(t *testing.T) {
 		analyzeDockerContext,
 		h.WithFlags(
 			"-f", filepath.Join(analyzeDockerContext, dockerfileName),
+			"--build-arg", "registry="+noAuthRegistry.Host+":"+noAuthRegistry.Port,
 		),
 	)
 	defer h.DockerImageRemove(t, analyzeImage)
@@ -253,7 +284,10 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					copyDir,
 					ctrPath("/some-dir/some-analyzed.toml"),
 					analyzeImage,
-					h.WithFlags("--env", "CNB_PLATFORM_API="+platformAPI),
+					h.WithFlags(
+						"--network", registryNetwork,
+						"--env", "CNB_PLATFORM_API="+platformAPI,
+					),
 					h.WithArgs(execArgs...),
 				)
 
@@ -277,6 +311,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					h.WithFlags(append(
 						dockerSocketMount,
 						"--env", "CNB_PLATFORM_API="+platformAPI,
+						"--env", "CNB_STACK_PATH=/cnb/local-bionic-stack.toml", // /cnb/local-bionic-stack.toml has `io.buildpacks.stacks.bionic` and points to run image `localcompany/stack:bionic` with same stack id
 					)...),
 					h.WithArgs(execArgs...),
 				)
@@ -316,6 +351,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 						h.WithFlags(append(
 							dockerSocketMount,
 							"--env", "CNB_PLATFORM_API="+platformAPI,
+							"--env", "CNB_STACK_PATH=/cnb/local-bionic-stack.toml", // /cnb/local-bionic-stack.toml has `io.buildpacks.stacks.bionic` and points to run image `localcompany/stack:bionic` with same stack id
 						)...),
 						h.WithArgs(
 							ctrPath(analyzerPath),
@@ -624,6 +660,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					ctrPath("/layers/analyzed.toml"),
 					analyzeImage,
 					h.WithFlags(
+						"--network", registryNetwork,
 						"--env", "CNB_PLATFORM_API="+platformAPI,
 					),
 					h.WithArgs(ctrPath(analyzerPath), "some-image"),
@@ -1063,6 +1100,166 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				h.AssertPathExists(t, filepath.Join(copyDir, "some-other-layers", "another-buildpack-id")) // another-buildpack-id is found in the provided -layers directory: /some-other-layers/group.toml
 
 				assertAnalyzedMetadata(t, filepath.Join(copyDir, "some-other-layers", "analyzed.toml")) // analyzed.toml is written at the provided -layers directory: /some-other-layers
+			})
+		})
+
+		when("validating stack", func() {
+			it.Before(func() {
+				h.SkipIf(t, api.MustParse(platformAPI).Compare(api.MustParse("0.7")) < 0, "Platform API < 0.7 does not validate stack")
+			})
+
+			when("stack metadata is present", func() {
+				when("stacks match", func() {
+					it("passes validation", func() {
+						execArgs := []string{ctrPath(analyzerPath), "some-image"}
+						h.DockerRun(t,
+							analyzeImage, // /cnb/stack.toml has `io.buildpacks.stacks.bionic` and points to run image `company/stack:bionic` with same stack id
+							h.WithFlags(
+								"--network", registryNetwork,
+								"--env", "CNB_PLATFORM_API="+platformAPI,
+							),
+							h.WithArgs(execArgs...),
+						)
+					})
+				})
+
+				when("CNB_RUN_IMAGE is present", func() {
+					it("uses CNB_RUN_IMAGE for validation", func() {
+						execArgs := []string{ctrPath(analyzerPath), "some-image"}
+
+						h.DockerRun(t,
+							analyzeImage,
+							h.WithFlags(
+								"--network", registryNetwork,
+								"--env", "CNB_PLATFORM_API="+platformAPI,
+								"--env", "CNB_STACK_PATH=/cnb/mismatch-stack.toml", // /cnb/mismatch-stack.toml points to run image `company/stack:centos`
+								"--env", "CNB_RUN_IMAGE="+noAuthRegistry.RepoName("company/stack:bionic"),
+							),
+							h.WithArgs(execArgs...),
+						)
+					})
+				})
+
+				when("stack metadata file is invalid", func() {
+					it("fails validation", func() {
+						cmd := exec.Command(
+							"docker", "run", "--rm",
+							"--network", registryNetwork,
+							"--env", "CNB_PLATFORM_API="+platformAPI,
+							"--env", "CNB_STACK_PATH=/cnb/bad-stack.toml",
+							analyzeImage,
+							ctrPath(analyzerPath),
+							"some-image",
+						) // #nosec G204
+						output, err := cmd.CombinedOutput()
+
+						h.AssertNotNil(t, err)
+						expected := "get stack metadata"
+						h.AssertStringContains(t, string(output), expected)
+					})
+				})
+
+				when("run image inaccessible", func() {
+					it("fails validation", func() {
+						cmd := exec.Command(
+							"docker", "run", "--rm",
+							"--network", registryNetwork,
+							"--env", "CNB_PLATFORM_API="+platformAPI,
+							"--env", "CNB_RUN_IMAGE=fake.example.com/company/example:20",
+							analyzeImage,
+							ctrPath(analyzerPath),
+							"some-image",
+						) // #nosec G204
+						output, err := cmd.CombinedOutput()
+
+						h.AssertNotNil(t, err)
+						expected := "failed to resolve run image"
+						h.AssertStringContains(t, string(output), expected)
+					})
+				})
+
+				when("run image has mirrors", func() {
+					it("uses expected mirror for run-image", func() {
+						execArgs := []string{ctrPath(analyzerPath), noAuthRegistry.RepoName("apprepo/myapp")} // image located on same registry as mirror
+
+						h.DockerRunAndCopy(t,
+							containerName,
+							copyDir,
+							ctrPath("/layers/analyzed.toml"),
+							analyzeImage,
+							h.WithFlags(
+								"--network", registryNetwork,
+								"--env", "CNB_PLATFORM_API="+platformAPI,
+								"--env", "CNB_STACK_PATH=/cnb/run-mirror-stack.toml", // /cnb/run-mirror-stack.toml points to run image on gcr.io and mirror on test registry
+							),
+							h.WithArgs(execArgs...),
+						)
+					})
+				})
+
+				when("daemon case", func() {
+					when("stacks match", func() {
+						it("passes validation", func() {
+							execArgs := []string{ctrPath(analyzerPath), "-daemon", "some-image"}
+
+							h.DockerRunAndCopy(t,
+								containerName,
+								copyDir,
+								ctrPath("/layers/analyzed.toml"),
+								analyzeImage,
+								h.WithFlags(append(
+									dockerSocketMount,
+									"--network", registryNetwork,
+									"--env", "CNB_PLATFORM_API="+platformAPI,
+									"--env", "CNB_STACK_PATH=/cnb/local-bionic-stack.toml", // /cnb/local-bionic-stack.toml has `io.buildpacks.stacks.bionic` and points to run image `localcompany/stack:bionic` with same stack id
+								)...),
+								h.WithArgs(execArgs...),
+							)
+						})
+					})
+				})
+			})
+
+			when("stack metadata is not present", func() {
+				when("CNB_RUN_IMAGE and CNB_STACK_ID are set", func() {
+					it("passes validation", func() {
+						execArgs := []string{ctrPath(analyzerPath), "some-image"}
+
+						h.DockerRunAndCopy(t,
+							containerName,
+							copyDir,
+							ctrPath("/layers/analyzed.toml"),
+							analyzeImage,
+							h.WithFlags(
+								"--network", registryNetwork,
+								"--env", "CNB_PLATFORM_API="+platformAPI,
+								"--env", "CNB_STACK_PATH=/cnb/file-does-not-exist.toml",
+								"--env", "CNB_RUN_IMAGE="+noAuthRegistry.RepoName("company/stack:bionic"),
+								"--env", "CNB_STACK_ID=io.buildpacks.stacks.bionic",
+							),
+							h.WithArgs(execArgs...),
+						)
+					})
+				})
+
+				when("run image and stack id are not provided as arguments or in the environment", func() {
+					it("fails validation", func() {
+						cmd := exec.Command(
+							"docker", "run", "--rm",
+							"--network", registryNetwork,
+							"--env", "CNB_PLATFORM_API="+platformAPI,
+							"--env", "CNB_STACK_PATH=/cnb/file-does-not-exist.toml",
+							analyzeImage,
+							ctrPath(analyzerPath),
+							"some-image",
+						) // #nosec G204
+						output, err := cmd.CombinedOutput()
+
+						h.AssertNotNil(t, err)
+						expected := "a run image must be specified when there is no stack metadata available"
+						h.AssertStringContains(t, string(output), expected)
+					})
+				})
 			})
 		})
 	}

--- a/acceptance/testdata/analyzer/analyze-image/Dockerfile
+++ b/acceptance/testdata/analyzer/analyze-image/Dockerfile
@@ -19,3 +19,44 @@ RUN chown -R $CNB_USER_ID:$CNB_GROUP_ID /layers
 
 # ensure docker config directory is root owned and NOT world readable
 RUN chown -R root /docker-config; chmod -R 700 /docker-config
+
+ARG registry
+
+# write some stack.toml files to use in tests
+RUN echo "\
+[run-image]\n\
+ image = \"${registry}/company/stack:bionic\"\n\
+ mirrors = []\n\
+[build-image]\n\
+ stack-id = \"io.buildpacks.stacks.bionic\"\n\
+ mixins = []\n\
+" > /cnb/stack.toml
+
+RUN echo "\
+[run-image]\n\
+ image = \"${registry}/company/stack:centos\"\n\
+ mirrors = []\n\
+[build-image]\n\
+ stack-id = \"io.buildpacks.stacks.bionic\"\n\
+ mixins = []\n\
+" > /cnb/mismatch-stack.toml
+
+RUN echo "\
+[run-image]\n\
+ image = \"gcr.io/paketobuildpacks/invalidimg:20\"\n\
+ mirrors = [\"${registry}/company/stack:bionic\"]\n\
+[build-image]\n\
+ stack-id = \"io.buildpacks.stacks.bionic\"\n\
+ mixins = []\n\
+" > /cnb/run-mirror-stack.toml
+
+RUN echo "\
+[run-image]\n\
+ image = \"localcompany/stack:bionic\"\n\
+ mirrors = []\n\
+[build-image]\n\
+ stack-id = \"io.buildpacks.stacks.bionic\"\n\
+ mixins = []\n\
+" > /cnb/local-bionic-stack.toml
+
+RUN echo "[run-images" > /cnb/bad-stack.toml

--- a/acceptance/testdata/analyzer/analyze-image/Dockerfile.windows
+++ b/acceptance/testdata/analyzer/analyze-image/Dockerfile.windows
@@ -10,3 +10,36 @@ ENV CNB_USER_ID=1
 ENV CNB_GROUP_ID=1
 
 ENV CNB_PLATFORM_API=${cnb_platform_api}
+
+ARG registry
+
+# write some stack.toml files to use in tests
+RUN echo [run-image] > /cnb/stack.toml &\
+ echo   image = "%registry%/company/stack:bionic" >> /cnb/stack.toml &\
+ echo   mirrors = [] >> /cnb/stack.toml &\
+ echo [build-image] >> /cnb/stack.toml &\
+ echo   stack-id = "io.buildpacks.stacks.bionic" >> /cnb/stack.toml &\
+ echo   mixins = [] >> /cnb/stack.toml
+
+RUN echo [run-image] > /cnb/mismatch-stack.toml &\
+ echo   image = "%registry%/company/stack:centos" >> /cnb/mismatch-stack.toml &\
+ echo   mirrors = [] >> /cnb/mismatch-stack.toml &\
+ echo [build-image] >> /cnb/mismatch-stack.toml &\
+ echo   stack-id = "io.buildpacks.stacks.bionic" >> /cnb/mismatch-stack.toml &\
+ echo   mixins = [] >> /cnb/mismatch-stack.toml
+
+RUN echo [run-image] > /cnb/run-mirror-stack.toml &\
+ echo   image = "gcr.io/paketobuildpacks/invalidimg:20" >> /cnb/run-mirror-stack.toml &\
+ echo   mirrors = ["%registry%/company/stack:bionic"] >> /cnb/run-mirror-stack.toml &\
+ echo [build-image] >> /cnb/run-mirror-stack.toml &\
+ echo   stack-id = "io.buildpacks.stacks.bionic" >> /cnb/run-mirror-stack.toml &\
+ echo   mixins = [] >> /cnb/run-mirror-stack.toml
+
+RUN echo [run-image] > /cnb/local-bionic-stack.toml &\
+ echo   image = "localcompany/stack:bionic" >> /cnb/local-bionic-stack.toml &\
+ echo   mirrors = [] >> /cnb/local-bionic-stack.toml &\
+ echo [build-image] >> /cnb/local-bionic-stack.toml &\
+ echo   stack-id = "io.buildpacks.stacks.bionic" >> /cnb/local-bionic-stack.toml &\
+ echo   mixins = [] >> /cnb/local-bionic-stack.toml
+
+RUN echo [run-images > /cnb/bad-stack.toml

--- a/acceptance/testdata/analyzer/run-image/Dockerfile
+++ b/acceptance/testdata/analyzer/run-image/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+ARG stackid
+LABEL io.buildpacks.stack.id=${stackid}

--- a/acceptance/testdata/analyzer/run-image/Dockerfile.windows
+++ b/acceptance/testdata/analyzer/run-image/Dockerfile.windows
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+USER ContainerAdministrator
+
+ARG stackid
+LABEL io.buildpacks.stack.id=${stackid}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -62,6 +62,7 @@ const (
 	EnvSkipLayers          = "CNB_ANALYZE_SKIP_LAYERS" // defaults to false
 	EnvSkipRestore         = "CNB_SKIP_RESTORE"        // defaults to false
 	EnvStackPath           = "CNB_STACK_PATH"
+	EnvStackID             = "CNB_STACK_ID"
 	EnvUID                 = "CNB_USER_ID"
 	EnvUseDaemon           = "CNB_USE_DAEMON" // defaults to false
 )

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -154,12 +154,14 @@ func (c *createCmd) Exec() error {
 	if api.MustParse(c.platform.API()).Compare(api.MustParse("0.7")) >= 0 {
 		cmd.DefaultLogger.Phase("ANALYZING")
 		analyzedMD, err = analyzeArgs{
-			imageName: c.previousImage,
-			keychain:  c.keychain,
-			layersDir: c.layersDir,
-			platform:  c.platform,
-			useDaemon: c.useDaemon,
-			docker:    c.docker,
+			imageName:   c.imageName,
+			keychain:    c.keychain,
+			layersDir:   c.layersDir,
+			platform:    c.platform,
+			runImageRef: c.runImageRef,
+			stackPath:   c.stackPath,
+			useDaemon:   c.useDaemon,
+			docker:      c.docker,
 		}.analyze()
 		if err != nil {
 			return err

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -154,14 +154,15 @@ func (c *createCmd) Exec() error {
 	if api.MustParse(c.platform.API()).Compare(api.MustParse("0.7")) >= 0 {
 		cmd.DefaultLogger.Phase("ANALYZING")
 		analyzedMD, err = analyzeArgs{
-			imageName:   c.imageName,
-			keychain:    c.keychain,
-			layersDir:   c.layersDir,
-			platform:    c.platform,
-			runImageRef: c.runImageRef,
-			stackPath:   c.stackPath,
-			useDaemon:   c.useDaemon,
-			docker:      c.docker,
+			imageName:     c.imageName,
+			keychain:      c.keychain,
+			layersDir:     c.layersDir,
+			platform:      c.platform,
+			previousImage: c.previousImage,
+			runImageRef:   c.runImageRef,
+			stackPath:     c.stackPath,
+			useDaemon:     c.useDaemon,
+			docker:        c.docker,
 		}.analyze()
 		if err != nil {
 			return err

--- a/platform/files.go
+++ b/platform/files.go
@@ -205,12 +205,18 @@ type ImageReport struct {
 // stack.toml
 
 type StackMetadata struct {
-	RunImage StackRunImageMetadata `json:"runImage" toml:"run-image"`
+	RunImage   StackRunImageMetadata   `json:"runImage" toml:"run-image"`
+	BuildImage StackBuildImageMetadata `json:"buildImage" toml:"build-image"`
 }
 
 type StackRunImageMetadata struct {
 	Image   string   `toml:"image" json:"image"`
 	Mirrors []string `toml:"mirrors" json:"mirrors,omitempty"`
+}
+
+type StackBuildImageMetadata struct {
+	StackID string   `toml:"stack-id" json:"stack-id"`
+	Mixins  []string `toml:"mixins" json:"mixins,omitempty"`
 }
 
 func (sm *StackMetadata) BestRunImageMirror(registry string) (string, error) {

--- a/stack_validation.go
+++ b/stack_validation.go
@@ -1,0 +1,51 @@
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/buildpacks/imgutil"
+	"github.com/pkg/errors"
+
+	"github.com/buildpacks/lifecycle/cmd"
+	"github.com/buildpacks/lifecycle/platform"
+)
+
+func ValidateStack(stackMD platform.StackMetadata, runImage imgutil.Image) error {
+	buildStackID, err := getBuildStack(stackMD)
+	if err != nil {
+		return err
+	}
+
+	runStackID, err := getRunStack(runImage)
+	if err != nil {
+		return err
+	}
+
+	if buildStackID != runStackID {
+		return errors.New(fmt.Sprintf("incompatible stack: '%s' is not compatible with '%s'", runStackID, buildStackID))
+	}
+	return nil
+}
+
+func getRunStack(runImage imgutil.Image) (string, error) {
+	runStackID, err := runImage.Label(platform.StackIDLabel)
+	if err != nil {
+		return "", errors.Wrap(err, "get run image label")
+	}
+	if runStackID == "" {
+		return "", errors.New("get run image label: io.buildpacks.stack.id")
+	}
+	return runStackID, nil
+}
+
+func getBuildStack(stackMD platform.StackMetadata) (string, error) {
+	var buildStackID string
+	if buildStackID = os.Getenv(cmd.EnvStackID); buildStackID != "" {
+		return buildStackID, nil
+	}
+	if buildStackID = stackMD.BuildImage.StackID; buildStackID != "" {
+		return buildStackID, nil
+	}
+	return "", errors.New("CNB_STACK_ID is required when there is no stack metadata available")
+}

--- a/stack_validation_test.go
+++ b/stack_validation_test.go
@@ -1,0 +1,82 @@
+package lifecycle_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/buildpacks/imgutil/fakes"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/lifecycle"
+	"github.com/buildpacks/lifecycle/platform"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+func TestStackValidation(t *testing.T) {
+	spec.Run(t, "StackValidation", testStackValidation, spec.Report(report.Terminal{}))
+}
+
+func testStackValidation(t *testing.T, when spec.G, it spec.S) {
+	when("ValidateStack", func() {
+		when("build and run stack ids match", func() {
+			it("should not err", func() {
+				md := platform.StackMetadata{BuildImage: platform.StackBuildImageMetadata{StackID: "my-stack"}}
+				runImage := fakes.NewImage("runimg", "", nil)
+				h.AssertNil(t, runImage.SetLabel(platform.StackIDLabel, "my-stack"))
+				err := lifecycle.ValidateStack(md, runImage)
+				h.AssertNil(t, err)
+			})
+		})
+
+		when("build and run stack ids do not match", func() {
+			it("should fail", func() {
+				md := platform.StackMetadata{BuildImage: platform.StackBuildImageMetadata{StackID: "my-stack"}}
+				runImage := fakes.NewImage("runimg", "", nil)
+				h.AssertNil(t, runImage.SetLabel(platform.StackIDLabel, "my-other-stack"))
+				err := lifecycle.ValidateStack(md, runImage)
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "incompatible stack: 'my-other-stack' is not compatible with 'my-stack'")
+			})
+		})
+
+		when("run image is missing io.buildpacks.stack.id label", func() {
+			it("should fail", func() {
+				md := platform.StackMetadata{BuildImage: platform.StackBuildImageMetadata{StackID: "my-stack"}}
+				runImage := fakes.NewImage("runimg", "", nil)
+				err := lifecycle.ValidateStack(md, runImage)
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "get run image label: io.buildpacks.stack.id")
+			})
+		})
+
+		when("CNB_STACK_ID is present", func() {
+			it.Before(func() {
+				os.Setenv("CNB_STACK_ID", "my-stack")
+			})
+
+			it.After(func() {
+				h.AssertNil(t, os.Unsetenv("CNB_STACK_ID"))
+			})
+
+			it("prefers that value", func() {
+				md := platform.StackMetadata{BuildImage: platform.StackBuildImageMetadata{StackID: "my-other-stack"}}
+				runImage := fakes.NewImage("runimg", "", nil)
+				h.AssertNil(t, runImage.SetLabel(platform.StackIDLabel, "my-stack"))
+				err := lifecycle.ValidateStack(md, runImage)
+				h.AssertNil(t, err)
+			})
+		})
+
+		when("no build stack is present", func() {
+			it("should fail", func() {
+				md := platform.StackMetadata{BuildImage: platform.StackBuildImageMetadata{StackID: ""}}
+				runImage := fakes.NewImage("runimg", "", nil)
+				h.AssertNil(t, runImage.SetLabel(platform.StackIDLabel, "my-stack"))
+				err := lifecycle.ValidateStack(md, runImage)
+				h.AssertNotNil(t, err)
+				h.AssertError(t, err, "CNB_STACK_ID is required when there is no stack metadata available")
+			})
+		})
+	})
+}

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -244,6 +244,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.5.0/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-containerregistry v0.5.1 h1:/+mFTs4AlwsJ/mJe8NDtKb7BxLtbZFpcn8vDsneEkwQ=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=

--- a/utils.go
+++ b/utils.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/imgutil"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/lifecycle/buildpack"
+	"github.com/buildpacks/lifecycle/platform"
 )
 
 func WriteTOML(path string, data interface{}) error {
@@ -62,6 +64,30 @@ func DecodeLabel(image imgutil.Image, label string, v interface{}) error {
 		return errors.Wrapf(err, "failed to unmarshal context of label '%s'", label)
 	}
 	return nil
+}
+
+func ResolveRunImage(stackMD platform.StackMetadata, destinationImageRef string) (string, error) {
+	runImageRef := stackMD.RunImage.Image
+
+	if runImageRef == "" {
+		return "", errors.New("a run image must be specified when there is no stack metadata available")
+	}
+
+	if destinationImageRef != "" && len(stackMD.RunImage.Mirrors) > 0 {
+		ref, err := name.ParseReference(destinationImageRef, name.WeakValidation)
+		if err != nil {
+			return "", err
+		}
+
+		registry := ref.Context().RegistryStr()
+
+		runImageRef, err = stackMD.BestRunImageMirror(registry)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return runImageRef, nil
 }
 
 func removeStagePrefixes(mixins []string) []string {


### PR DESCRIPTION
During analyze, Platform 0.7 and above will validate the build and stack image if the data is available to do so.

Addresses Part of: #471

[Spec](https://github.com/buildpacks/spec/blob/platform/0.7/platform.md#analyzer) being implemented:
> The lifecycle MUST fail if the stack ID of the `<run-image>` does not match `<stack-id>`


Signed-off-by: Jesse Brown <jabrown85@gmail.com>