### PR TITLE
Re-Align analyzer with spec and creator

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -113,7 +113,6 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 
 		when("called without an app image", func() {
 			it("errors", func() {
-				h.SkipIf(t, api.MustParse(platformAPI).Compare(api.MustParse("0.7")) >= 0, "Platform API >= 0.7 does not accept an image argument")
 				cmd := exec.Command(
 					"docker", "run", "--rm",
 					"--env", "CNB_PLATFORM_API="+platformAPI,
@@ -206,11 +205,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 			it("recursively chowns the directory", func() {
 				h.SkipIf(t, runtime.GOOS == "windows", "Not relevant on Windows")
 
-				imgArg := ""
-				// Platform >= 0.7 does not allow an argument, < 7 requires an argument
-				if api.MustParse(platformAPI).Compare(api.MustParse("0.7")) < 0 {
-					imgArg = "some-image"
-				}
+				imgArg := "some-image"
 
 				output := h.DockerRun(t,
 					analyzeImage,
@@ -252,16 +247,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				execArgs := []string{
 					ctrPath(analyzerPath),
 					"-analyzed", ctrPath("/some-dir/some-analyzed.toml"),
-					"-previous-image", "some-image",
-				}
-
-				// Platform >= 0.7 does not allow an argument, < 7 requires an argument
-				if api.MustParse(platformAPI).Compare(api.MustParse("0.7")) < 0 {
-					execArgs = []string{
-						ctrPath(analyzerPath),
-						"-analyzed", ctrPath("/some-dir/some-analyzed.toml"),
-						"some-image",
-					}
+					"some-image",
 				}
 
 				h.DockerRunAndCopy(t,
@@ -282,16 +268,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				execArgs := []string{
 					ctrPath(analyzerPath),
 					"-daemon",
-					"-previous-image", "some-image",
-				}
-
-				// Platform >= 0.7 does not allow an argument, < 7 requires an argument
-				if api.MustParse(platformAPI).Compare(api.MustParse("0.7")) < 0 {
-					execArgs = []string{
-						ctrPath(analyzerPath),
-						"-daemon",
-						"some-image",
-					}
+					"some-image",
 				}
 
 				h.DockerRunAndCopy(t,
@@ -345,7 +322,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 						h.WithArgs(
 							ctrPath(analyzerPath),
 							"-daemon",
-							"-previous-image", appImage),
+							appImage),
 					)
 
 					assertNoRestoreOfAppMetadata(t, copyDir, output)
@@ -643,11 +620,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 
 		when("registry case", func() {
 			it("writes analyzed.toml", func() {
-				execArgs := []string{ctrPath(analyzerPath)}
-				// Platform >= 0.7 does not allow an argument, < 7 requires an argument
-				if api.MustParse(platformAPI).Compare(api.MustParse("0.7")) < 0 {
-					execArgs = append(execArgs, "some-image")
-				}
+				execArgs := []string{ctrPath(analyzerPath), "some-image"}
 
 				h.DockerRunAndCopy(t,
 					containerName,

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -828,7 +828,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							h.WithArgs(execArgs...),
 						)
 
-						md := getAnalyzedMetadataImageRef(t, filepath.Join(copyDir, "analyzed.toml"))
+						md := getAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))
 						h.AssertStringContains(t, md.Image.Reference, authRegAppImage)
 					})
 				})
@@ -1068,7 +1068,7 @@ func assertAnalyzedMetadata(t *testing.T, path string) {
 	h.AssertNil(t, err)
 }
 
-func getAnalyzedMetadataImageRef(t *testing.T, path string) *platform.AnalyzedMetadata {
+func getAnalyzedMetadata(t *testing.T, path string) *platform.AnalyzedMetadata {
 	contents, _ := ioutil.ReadFile(path)
 	h.AssertEq(t, len(contents) > 0, true)
 

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -136,7 +136,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					analyzeImage,
 					ctrPath(analyzerPath),
 					"-group", "group.toml",
-					"-previous-image", "some-image",
+					"some-image",
 				) // #nosec G204
 				output, err := cmd.CombinedOutput()
 
@@ -155,7 +155,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					analyzeImage,
 					ctrPath(analyzerPath),
 					"-skip-layers",
-					"-previous-image", "some-image",
+					"some-image",
 				) // #nosec G204
 				output, err := cmd.CombinedOutput()
 
@@ -174,7 +174,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					analyzeImage,
 					ctrPath(analyzerPath),
 					"-cache-dir", "/cache",
-					"-previous-image", "some-image",
+					"some-image",
 				) // #nosec G204
 				output, err := cmd.CombinedOutput()
 
@@ -205,12 +205,10 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 			it("recursively chowns the directory", func() {
 				h.SkipIf(t, runtime.GOOS == "windows", "Not relevant on Windows")
 
-				imgArg := "some-image"
-
 				output := h.DockerRun(t,
 					analyzeImage,
 					h.WithFlags("--env", "CNB_PLATFORM_API="+platformAPI),
-					h.WithBash(fmt.Sprintf("chown -R 9999:9999 /layers; chmod -R 775 /layers; %s %s; ls -al /layers", analyzerPath, imgArg)),
+					h.WithBash(fmt.Sprintf("chown -R 9999:9999 /layers; chmod -R 775 /layers; %s some-image; ls -al /layers", analyzerPath)),
 				)
 
 				h.AssertMatch(t, output, "2222 3333 .+ \\.")
@@ -620,8 +618,6 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 
 		when("registry case", func() {
 			it("writes analyzed.toml", func() {
-				execArgs := []string{ctrPath(analyzerPath), "some-image"}
-
 				h.DockerRunAndCopy(t,
 					containerName,
 					copyDir,
@@ -630,7 +626,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					h.WithFlags(
 						"--env", "CNB_PLATFORM_API="+platformAPI,
 					),
-					h.WithArgs(execArgs...),
+					h.WithArgs(ctrPath(analyzerPath), "some-image"),
 				)
 
 				assertAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -215,8 +215,7 @@ func (a *analyzeCmd) registryImages() []string {
 		registryImages = append(registryImages, a.platform06.cacheImageTag)
 	}
 	if !a.useDaemon {
-		registryImages = append(registryImages, append([]string{a.imageName}, a.additionalTags...)...)
-		registryImages = append(registryImages, a.runImageRef, a.previousImage)
+		registryImages = append(registryImages, append([]string{a.imageName, a.previousImage, a.runImageRef}, a.additionalTags...)...)
 	}
 	return registryImages
 }

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -176,23 +176,21 @@ func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
 		img imgutil.Image
 		err error
 	)
-	if aa.previousImage != "" {
-		if aa.useDaemon {
-			img, err = local.NewImage(
-				aa.previousImage,
-				aa.docker,
-				local.FromBaseImage(aa.previousImage),
-			)
-		} else {
-			img, err = remote.NewImage(
-				aa.previousImage,
-				aa.keychain,
-				remote.FromBaseImage(aa.previousImage),
-			)
-		}
-		if err != nil {
-			return platform.AnalyzedMetadata{}, cmd.FailErr(err, "get previous image")
-		}
+	if aa.useDaemon {
+		img, err = local.NewImage(
+			aa.previousImage,
+			aa.docker,
+			local.FromBaseImage(aa.previousImage),
+		)
+	} else {
+		img, err = remote.NewImage(
+			aa.previousImage,
+			aa.keychain,
+			remote.FromBaseImage(aa.previousImage),
+		)
+	}
+	if err != nil {
+		return platform.AnalyzedMetadata{}, cmd.FailErr(err, "get previous image")
 	}
 
 	analyzedMD, err := (&lifecycle.Analyzer{


### PR DESCRIPTION
See [here](https://github.com/buildpacks/spec/pull/225#pullrequestreview-663490720)

We should still be taking in `<image>` to represent the write location and optionally the `<previous-image>` if no explicitly defined. This re-aligns with the spec and `creator` behavior.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>