### PR TITLE
Add GHA for shipping release candidates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           TEST_COVERAGE: 1
         run: make test
       - name: Upload Coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v1.0.5
         with:
           file: ./out/tests/coverage-unit.txt
           flags: unit,os_linux

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -108,7 +108,55 @@ jobs:
           unzip -d artifact-windows artifact-windows.zip
           lifecycle_path=$(ls artifact-windows/lifecycle-*windows.x86-64.tgz)
           echo "ARTIFACT_WINDOWS_PATH=$PWD/$lifecycle_path" >> $GITHUB_ENV
+      - name: Create Pre Release
+        if: contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.LIFECYCLE_VERSION }}
+          release_name: lifecycle v${{ env.LIFECYCLE_VERSION }}
+          draft: true
+          prerelease: true
+          body: |
+            # lifecycle v${{ env.LIFECYCLE_VERSION }}
+
+            Welcome to `v${{ env.LIFECYCLE_VERSION }}`, a **beta** pre-release of the Cloud Native Buildpacks Lifecycle.
+
+            ##  Prerequisites
+
+            The lifecycle runs as a normal user in a series of unprivileged containers. To export images and cache image layers, it requires access to a Docker daemon **or** Docker registry.
+
+            ## Install
+
+            Extract the `.tgz` file and copy the lifecycle binaries into a [build stack base image](https://github.com/buildpack/spec/blob/master/platform.md#stacks). The build image can then be orchestrated by a platform implementation such as the [pack CLI](https://github.com/buildpack/pack) or [tekton](https://github.com/tektoncd/catalog/blob/master/task/buildpacks/0.1/README.md).
+
+            ## Lifecycle Image
+
+            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ github.sha }}.
+      - name: Upload Pre Release Asset - linux
+        if: contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_pre_release.outputs.upload_url }}
+          asset_path: ${{ env.ARTIFACT_LINUX_PATH }}
+          asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz
+          asset_content_type: application/gzip
+      - name: Upload Pre Release Asset - windows
+        if: contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_pre_release.outputs.upload_url }}
+          asset_path: ${{ env.ARTIFACT_WINDOWS_PATH }}
+          asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+windows.x86-64.tgz
+          asset_content_type: application/gzip
       - name: Create Release
+        if: !contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
         id: create_release
         uses: actions/create-release@latest
         env:
@@ -121,7 +169,7 @@ jobs:
           body: |
             # lifecycle v${{ env.LIFECYCLE_VERSION }}
 
-            Welcome to `v${{ env.LIFECYCLE_VERSION }}`, a **beta** release of the Cloud Native Buildpack Lifecycle.
+            Welcome to `v${{ env.LIFECYCLE_VERSION }}`, a **beta** release of the Cloud Native Buildpacks Lifecycle.
 
             ##  Prerequisites
 
@@ -130,7 +178,12 @@ jobs:
             ## Install
 
             Extract the `.tgz` file and copy the lifecycle binaries into a [build stack base image](https://github.com/buildpack/spec/blob/master/platform.md#stacks). The build image can then be orchestrated by a platform implementation such as the [pack CLI](https://github.com/buildpack/pack) or [tekton](https://github.com/tektoncd/catalog/blob/master/task/buildpacks/0.1/README.md).
+
+            ## Lifecycle Image
+
+            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
       - name: Upload Release Asset - linux
+        if: !contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -140,6 +193,7 @@ jobs:
           asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz
           asset_content_type: application/gzip
       - name: Upload Release Asset - windows
+        if: !contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -23,11 +23,14 @@ jobs:
           fi
           echo "LIFECYCLE_VERSION=$version" >> $GITHUB_ENV
         shell: bash
+      - name: Compute short sha
+        run: |
+          echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
       - name: Determine download urls for linux and windows
         id: artifact-urls
         uses: actions/github-script@v3.0.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             return github.actions
               .listRepoWorkflows({
@@ -109,8 +112,8 @@ jobs:
           lifecycle_path=$(ls artifact-windows/lifecycle-*windows.x86-64.tgz)
           echo "ARTIFACT_WINDOWS_PATH=$PWD/$lifecycle_path" >> $GITHUB_ENV
       - name: Create Pre Release
-        if: contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
-        id: create_release
+        if: contains(env.LIFECYCLE_VERSION, 'rc')
+        id: create_pre_release
         uses: actions/create-release@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -134,9 +137,9 @@ jobs:
 
             ## Lifecycle Image
 
-            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ github.sha }}.
+            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.SHORT_SHA }}.
       - name: Upload Pre Release Asset - linux
-        if: contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        if: contains(env.LIFECYCLE_VERSION, 'rc')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -146,7 +149,7 @@ jobs:
           asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz
           asset_content_type: application/gzip
       - name: Upload Pre Release Asset - windows
-        if: contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        if: contains(env.LIFECYCLE_VERSION, 'rc')
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +159,7 @@ jobs:
           asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+windows.x86-64.tgz
           asset_content_type: application/gzip
       - name: Create Release
-        if: !contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
         id: create_release
         uses: actions/create-release@latest
         env:
@@ -183,7 +186,7 @@ jobs:
 
             An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
       - name: Upload Release Asset - linux
-        if: !contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -193,7 +196,7 @@ jobs:
           asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz
           asset_content_type: application/gzip
       - name: Upload Release Asset - windows
-        if: !contains(${{ env.LIFECYCLE_VERSION }}, 'rc')
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,7 +3,7 @@ name: post-release
 on:
   release:
     types:
-      - published
+      - released # do not trigger for pre-releases
 
 jobs:
   retag-lifecycle-images-linux:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,13 @@
 ## Release Finalization
 
+To cut a pre-release:
+1. If applicable, ensure the README is updated with the latest supported apis (example PR: https://github.com/buildpacks/lifecycle/pull/550).
+1. Create a release branch in the format `release/0.99.0-rc.1`. New commits to this branch will trigger the `build` workflow and produce a lifecycle image: `buildpacksio/lifecycle:<commit sha>`.
+1. When ready to cut the release, manually trigger the `draft-release` workflow: Actions -> draft-release -> Run workflow -> Use workflow from branch: `release/0.99.0-rc.1`. This will create a draft release on GitHub using the artifacts from the `build` workflow run for the latest commit on the release branch.
+1. Edit the release notes as necessary.
+1. Perform any manual validation of the artifacts (see below).
+1. When ready to publish the release, edit the release page and click "Publish release". Note that this will NOT trigger the `post-release` workflow (see below).
+
 To cut a release:
 1. Ensure the relevant spec APIs have been released.
 1. Ensure any [migration guides](https://github.com/buildpacks/docs/tree/main/content/docs/reference/spec/migration) have been created.


### PR DESCRIPTION
Resolves #561 

Note that publishing a pre-release doesn't re-tag the associated lifecycle image. I was concerned that consumers of the lifecycle might mistake it for a "real" release (see [Paketo issue](https://github.com/paketo-buildpacks/packit/issues/144), this has been fixed, but there could be other consumers with this problem). [pack](https://github.com/buildpacks/pack/blob/e53adb9c9e55b33e830f2e92bc4741cc32dc24f7/.github/workflows/delivery-docker.yml#L6) doesn't appear to ship pack images for pre-releases. 

However it's worth noting that potentially just publishing a pre-release on GitHub could confuse some people - perhaps we should do some socializing of this change.