### PR TITLE
Use syscall package instead of cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,6 @@ docker-compilation-image-linux:
 
 $(BUILD_DIR)/linux/lifecycle/lifecycle: export GOOS:=linux
 $(BUILD_DIR)/linux/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
-$(BUILD_DIR)/linux/lifecycle/lifecycle: GOENV:=GOARCH=$(GOARCH) CGO_ENABLED=1
 $(BUILD_DIR)/linux/lifecycle/lifecycle: docker-compilation-image-linux
 $(BUILD_DIR)/linux/lifecycle/lifecycle: $(GOFILES)
 $(BUILD_DIR)/linux/lifecycle/lifecycle:

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -11,27 +11,6 @@ import (
 	"syscall"
 )
 
-/*
-#cgo LDFLAGS: --static
-#define _GNU_SOURCE
-#include <unistd.h>
-#include <errno.h>
-
-static int
-csetresuid(uid_t ruid, uid_t euid, uid_t suid) {
-  int ec = setresuid(ruid, euid, suid);
-  return (ec < 0) ? errno : 0;
-}
-
-static int
-csetresgid(gid_t rgid, gid_t egid, gid_t sgid) {
-  int ec = setresgid(rgid, egid, sgid);
-  return (ec < 0) ? errno : 0;
-}
-
-*/
-import "C"
-
 // EnsureOwner recursively chowns a dir if it isn't writable
 func EnsureOwner(uid, gid int, paths ...string) error {
 	for _, p := range paths {
@@ -105,29 +84,13 @@ func RunAs(uid, gid int) error {
 		return nil
 	}
 
-	if err := setresgid(gid, gid, gid); err != nil {
+	if err := syscall.Setresgid(gid, gid, gid); err != nil {
 		return err
 	}
-	if err := setresuid(uid, uid, uid); err != nil {
+	if err := syscall.Setresuid(uid, uid, uid); err != nil {
 		return err
 	}
 
-	return nil
-}
-
-func setresgid(rgid, egid, sgid int) error {
-	eno := C.csetresgid(C.gid_t(rgid), C.gid_t(egid), C.gid_t(sgid))
-	if eno != 0 {
-		return syscall.Errno(eno)
-	}
-	return nil
-}
-
-func setresuid(ruid, euid, suid int) error {
-	eno := C.csetresuid(C.uid_t(ruid), C.uid_t(euid), C.uid_t(suid))
-	if eno != 0 {
-		return syscall.Errno(eno)
-	}
 	return nil
 }
 


### PR DESCRIPTION
The use of cgo was introduced in https://github.com/buildpacks/lifecycle/pull/268, instead of using golang.org/x/sys/unix. I believe syscall.Setres{g,u}id is the platform-independent equivalent, but I admit I don't know enough about this to be confident this isn't a regression.

If this is acceptable, it could be a step toward unblocking https://github.com/buildpacks/lifecycle/issues/435

@ekcasey 