### PR TITLE
Semver tag release candidate lifecycle images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,10 +109,13 @@ jobs:
         with:
           name: lifecycle-windows-x86-64
           path: out/lifecycle-v*+windows.x86-64.tgz
+      - uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Publish images
         if: github.event_name == 'push'
         run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           LIFECYCLE_IMAGE_TAG=$(git describe --always --dirty)
           go run ./tools/image/main.go -lifecyclePath ./out/lifecycle-v*+linux.x86-64.tgz -tag buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux
           go run ./tools/image/main.go -lifecyclePath ./out/lifecycle-v*+windows.x86-64.tgz -tag buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-windows -os windows

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -108,59 +108,51 @@ jobs:
           unzip -d artifact-windows artifact-windows.zip
           lifecycle_path=$(ls artifact-windows/lifecycle-*windows.x86-64.tgz)
           echo "ARTIFACT_WINDOWS_PATH=$PWD/$lifecycle_path" >> $GITHUB_ENV
+      - name: Set pre-release kind
+        if: contains(env.LIFECYCLE_VERSION, 'rc') # e.g., 0.99.0-rc.1
+        run: |
+          echo "RELEASE_KIND=pre-release" >> $GITHUB_ENV
+      - name: Set release kind
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        run: |
+          echo "RELEASE_KIND=release" >> $GITHUB_ENV
+      - name: Set release body text
+        run: |
+          cat << EOF > body.txt
+          # lifecycle v${{ env.LIFECYCLE_VERSION }}
+
+          Welcome to v${{ env.LIFECYCLE_VERSION }}, a **beta** ${{ env.RELEASE_KIND }} of the Cloud Native Buildpacks Lifecycle.
+
+          ##  Prerequisites
+
+          The lifecycle runs as a normal user in a series of unprivileged containers. To export images and cache image layers, it requires access to a Docker daemon **or** Docker registry.
+
+          ## Install
+
+          Extract the .tgz file and copy the lifecycle binaries into a [build stack base image](https://github.com/buildpack/spec/blob/master/platform.md#stacks). The build image can then be orchestrated by a platform implementation such as the [pack CLI](https://github.com/buildpack/pack) or [tekton](https://github.com/tektoncd/catalog/blob/master/task/buildpacks/0.1/README.md).
+
+          ## Lifecycle Image
+
+          An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
+          EOF
       - name: Create Pre Release
         if: contains(env.LIFECYCLE_VERSION, 'rc') # e.g., 0.99.0-rc.1
-        id: create_pre_release
-        uses: softprops/action-gh-release@v1
+        run: |
+          gh release create v${{ env.LIFECYCLE_VERSION }} ${{ env.ARTIFACT_LINUX_PATH }} ${{ env.ARTIFACT_WINDOWS_PATH }} \
+            --draft \
+            --notes-file body.txt \
+            --prerelease \
+            --target $GITHUB_REF \
+            --title "lifecycle v${{ env.LIFECYCLE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.LIFECYCLE_VERSION }}
-          name: lifecycle v${{ env.LIFECYCLE_VERSION }}
-          draft: true
-          prerelease: true
-          files: ${{ env.ARTIFACT_LINUX_PATH }}, ${{ env.ARTIFACT_WINDOWS_PATH }}
-          body: |
-            # lifecycle v${{ env.LIFECYCLE_VERSION }}
-
-            Welcome to `v${{ env.LIFECYCLE_VERSION }}`, a **beta** pre-release of the Cloud Native Buildpacks Lifecycle.
-
-            ##  Prerequisites
-
-            The lifecycle runs as a normal user in a series of unprivileged containers. To export images and cache image layers, it requires access to a Docker daemon **or** Docker registry.
-
-            ## Install
-
-            Extract the `.tgz` file and copy the lifecycle binaries into a [build stack base image](https://github.com/buildpack/spec/blob/master/platform.md#stacks). The build image can then be orchestrated by a platform implementation such as the [pack CLI](https://github.com/buildpack/pack) or [tekton](https://github.com/tektoncd/catalog/blob/master/task/buildpacks/0.1/README.md).
-
-            ## Lifecycle Image
-
-            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
       - name: Create Release
         if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
-        id: create_release
-        uses: softprops/action-gh-release@v1
+        run: |
+          gh release create v${{ env.LIFECYCLE_VERSION }} ${{ env.ARTIFACT_LINUX_PATH }} ${{ env.ARTIFACT_WINDOWS_PATH }} \
+            --draft \
+            --notes-file body.txt \
+            --target $GITHUB_REF \
+            --title "lifecycle v${{ env.LIFECYCLE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ env.LIFECYCLE_VERSION }}
-          name: lifecycle v${{ env.LIFECYCLE_VERSION }}
-          draft: true
-          prerelease: false
-          files: ${{ env.ARTIFACT_LINUX_PATH }}, ${{ env.ARTIFACT_WINDOWS_PATH }}
-          body: |
-            # lifecycle v${{ env.LIFECYCLE_VERSION }}
-
-            Welcome to `v${{ env.LIFECYCLE_VERSION }}`, a **beta** release of the Cloud Native Buildpacks Lifecycle.
-
-            ##  Prerequisites
-
-            The lifecycle runs as a normal user in a series of unprivileged containers. To export images and cache image layers, it requires access to a Docker daemon **or** Docker registry.
-
-            ## Install
-
-            Extract the `.tgz` file and copy the lifecycle binaries into a [build stack base image](https://github.com/buildpack/spec/blob/master/platform.md#stacks). The build image can then be orchestrated by a platform implementation such as the [pack CLI](https://github.com/buildpack/pack) or [tekton](https://github.com/tektoncd/catalog/blob/master/task/buildpacks/0.1/README.md).
-
-            ## Lifecycle Image
-
-            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -23,9 +23,6 @@ jobs:
           fi
           echo "LIFECYCLE_VERSION=$version" >> $GITHUB_ENV
         shell: bash
-      - name: Compute short sha
-        run: |
-          echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
       - name: Determine download urls for linux and windows
         id: artifact-urls
         uses: actions/github-script@v3.0.0
@@ -112,16 +109,17 @@ jobs:
           lifecycle_path=$(ls artifact-windows/lifecycle-*windows.x86-64.tgz)
           echo "ARTIFACT_WINDOWS_PATH=$PWD/$lifecycle_path" >> $GITHUB_ENV
       - name: Create Pre Release
-        if: contains(env.LIFECYCLE_VERSION, 'rc')
+        if: contains(env.LIFECYCLE_VERSION, 'rc') # e.g., 0.99.0-rc.1
         id: create_pre_release
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ env.LIFECYCLE_VERSION }}
-          release_name: lifecycle v${{ env.LIFECYCLE_VERSION }}
+          name: lifecycle v${{ env.LIFECYCLE_VERSION }}
           draft: true
           prerelease: true
+          files: ${{ env.ARTIFACT_LINUX_PATH }}, ${{ env.ARTIFACT_WINDOWS_PATH }}
           body: |
             # lifecycle v${{ env.LIFECYCLE_VERSION }}
 
@@ -137,38 +135,19 @@ jobs:
 
             ## Lifecycle Image
 
-            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.SHORT_SHA }}.
-      - name: Upload Pre Release Asset - linux
-        if: contains(env.LIFECYCLE_VERSION, 'rc')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_pre_release.outputs.upload_url }}
-          asset_path: ${{ env.ARTIFACT_LINUX_PATH }}
-          asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz
-          asset_content_type: application/gzip
-      - name: Upload Pre Release Asset - windows
-        if: contains(env.LIFECYCLE_VERSION, 'rc')
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_pre_release.outputs.upload_url }}
-          asset_path: ${{ env.ARTIFACT_WINDOWS_PATH }}
-          asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+windows.x86-64.tgz
-          asset_content_type: application/gzip
+            An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
       - name: Create Release
         if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
         id: create_release
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ env.LIFECYCLE_VERSION }}
-          release_name: lifecycle v${{ env.LIFECYCLE_VERSION }}
+          name: lifecycle v${{ env.LIFECYCLE_VERSION }}
           draft: true
           prerelease: false
+          files: ${{ env.ARTIFACT_LINUX_PATH }}, ${{ env.ARTIFACT_WINDOWS_PATH }}
           body: |
             # lifecycle v${{ env.LIFECYCLE_VERSION }}
 
@@ -185,23 +164,3 @@ jobs:
             ## Lifecycle Image
 
             An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
-      - name: Upload Release Asset - linux
-        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.ARTIFACT_LINUX_PATH }}
-          asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+linux.x86-64.tgz
-          asset_content_type: application/gzip
-      - name: Upload Release Asset - windows
-        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.ARTIFACT_WINDOWS_PATH }}
-          asset_name: lifecycle-v${{ env.LIFECYCLE_VERSION }}+windows.x86-64.tgz
-          asset_content_type: application/gzip

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,23 +9,7 @@ jobs:
   retag-lifecycle-images-linux:
     runs-on: ubuntu-latest
     steps:
-      - name: Determine version
-        uses: actions/github-script@v4.0.2
-        id: version
-        with:
-          result-encoding: string
-          script: |
-            let tag = (context.payload.release && context.payload.release.tag_name)
-              || (context.payload.inputs && context.payload.inputs.tag_name);
-
-            if (!tag) {
-              throw "ERROR: unable to determine tag";
-            }
-
-            return tag.replace(/^v/, '');
       - uses: actions/checkout@v2
-        with:
-          ref: v${{ steps.version.outputs.result }}
       - uses: azure/docker-login@v1
         with:
          username: ${{ secrets.DOCKER_USERNAME }}
@@ -48,23 +32,7 @@ jobs:
   retag-lifecycle-images-windows:
     runs-on: windows-latest
     steps:
-      - name: Determine version
-        uses: actions/github-script@v4.0.2
-        id: version
-        with:
-          result-encoding: string
-          script: |
-            let tag = (context.payload.release && context.payload.release.tag_name)
-              || (context.payload.inputs && context.payload.inputs.tag_name);
-
-            if (!tag) {
-              throw "ERROR: unable to determine tag";
-            }
-
-            return tag.replace(/^v/, '');
       - uses: actions/checkout@v2
-        with:
-          ref: v${{ steps.version.outputs.result }}
       - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -34,12 +34,12 @@ jobs:
         run: |
           echo "LIFECYCLE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)" >> $GITHUB_ENV
           echo "LIFECYCLE_IMAGE_TAG=$(git describe --always --dirty)" >> $GITHUB_ENV
-      - name: Retag release candidate lifecycle images - semver
+      - name: Retag lifecycle images - semver
         run: |
           docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux
           docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-linux
           docker push buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-linux
-      - name: Retag release candidate lifecycle images - latest
+      - name: Retag lifecycle images - latest
         if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
         run: |
           docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux
@@ -73,12 +73,12 @@ jobs:
         run: |
           echo "LIFECYCLE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)" >> $env:GITHUB_ENV
           echo "LIFECYCLE_IMAGE_TAG=$(git describe --always --dirty)" >> $env:GITHUB_ENV
-      - name: Retag release candidate lifecycle images - semver
+      - name: Retag lifecycle images - semver
         run: |
           docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows
           docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-windows
           docker push buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-windows
-      - name: Retag release candidate lifecycle images - latest
+      - name: Retag lifecycle images - latest
         if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
         run: |
           docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -3,58 +3,104 @@ name: post-release
 on:
   release:
     types:
-      - released # do not trigger for pre-releases
+      - published # trigger for releases and pre-releases
 
 jobs:
   retag-lifecycle-images-linux:
     runs-on: ubuntu-latest
     steps:
+      - name: Determine version
+        uses: actions/github-script@v4.0.2
+        id: version
+        with:
+          result-encoding: string
+          script: |
+            let tag = (context.payload.release && context.payload.release.tag_name)
+              || (context.payload.inputs && context.payload.inputs.tag_name);
+
+            if (!tag) {
+              throw "ERROR: unable to determine tag";
+            }
+
+            return tag.replace(/^v/, '');
       - uses: actions/checkout@v2
-      - name: Docker login
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        with:
+          ref: v${{ steps.version.outputs.result }}
+      - uses: azure/docker-login@v1
+        with:
+         username: ${{ secrets.DOCKER_USERNAME }}
+         password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set env
         run: |
           echo "LIFECYCLE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)" >> $GITHUB_ENV
           echo "LIFECYCLE_IMAGE_TAG=$(git describe --always --dirty)" >> $GITHUB_ENV
-      - name: Retag release candidate lifecycle images
+      - name: Retag release candidate lifecycle images - semver
         run: |
           docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux
           docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-linux
-          docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux buildpacksio/lifecycle:latest-linux
           docker push buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-linux
+      - name: Retag release candidate lifecycle images - latest
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        run: |
+          docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux
+          docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux buildpacksio/lifecycle:latest-linux
           docker push buildpacksio/lifecycle:latest-linux
   retag-lifecycle-images-windows:
     runs-on: windows-latest
     steps:
+      - name: Determine version
+        uses: actions/github-script@v4.0.2
+        id: version
+        with:
+          result-encoding: string
+          script: |
+            let tag = (context.payload.release && context.payload.release.tag_name)
+              || (context.payload.inputs && context.payload.inputs.tag_name);
+
+            if (!tag) {
+              throw "ERROR: unable to determine tag";
+            }
+
+            return tag.replace(/^v/, '');
       - uses: actions/checkout@v2
-      - name: Docker login
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        with:
+          ref: v${{ steps.version.outputs.result }}
+      - uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set env
         run: |
           echo "LIFECYCLE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)" >> $env:GITHUB_ENV
           echo "LIFECYCLE_IMAGE_TAG=$(git describe --always --dirty)" >> $env:GITHUB_ENV
-      - name: Retag release candidate lifecycle images
+      - name: Retag release candidate lifecycle images - semver
         run: |
           docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows
           docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-windows
-          docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows buildpacksio/lifecycle:latest-windows
           docker push buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-windows
+      - name: Retag release candidate lifecycle images - latest
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        run: |
+          docker pull buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows
+          docker image tag buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-windows buildpacksio/lifecycle:latest-windows
           docker push buildpacksio/lifecycle:latest-windows
   create-manifest-lists:
     runs-on: ubuntu-latest
     needs: [retag-lifecycle-images-linux, retag-lifecycle-images-windows]
     steps:
-      - name: Docker login
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set env
         run: |
           echo "LIFECYCLE_VERSION=$(echo ${{ github.event.release.tag_name }} | cut -d "v" -f2)" >> $GITHUB_ENV
-      - name: Create lifecycle image manifest lists
+      - name: Create lifecycle image manifest lists - semver
         run: |
           DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }} buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-linux buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}-windows
           DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}
+      - name: Create lifecycle image manifest lists - latest
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        run: |
           DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create buildpacksio/lifecycle:latest buildpacksio/lifecycle:latest-linux buildpacksio/lifecycle:latest-windows
           DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push buildpacksio/lifecycle:latest

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ To cut a pre-release:
 1. When ready to cut the release, manually trigger the `draft-release` workflow: Actions -> draft-release -> Run workflow -> Use workflow from branch: `release/0.99.0-rc.1`. This will create a draft release on GitHub using the artifacts from the `build` workflow run for the latest commit on the release branch.
 1. Edit the release notes as necessary.
 1. Perform any manual validation of the artifacts (see below).
-1. When ready to publish the release, edit the release page and click "Publish release". Note that this will NOT trigger the `post-release` workflow (see below).
+1. When ready to publish the release, edit the release page and click "Publish release". This will trigger the `post-release` workflow that will re-tag the lifecycle image from `buildpacksio/lifecycle:<commit sha>` to `buildpacksio/lifecycle:0.99.0` but will NOT update the `latest` tag.
 
 To cut a release:
 1. Ensure the relevant spec APIs have been released.
@@ -29,5 +29,5 @@ Inside the `pack` repo:
     $env:LIFECYCLE_IMAGE="buildpacksio/lifecycle:<commit sha>"
     make acceptance
     ```
-1. When ready to publish the release, edit the release page and click "Publish release". This will trigger the `post-release` workflow that will re-tag the lifecycle image from `buildpacksio/lifecycle:<commit sha>` to `buildpacksio/lifecycle:0.99.0`.
+1. When ready to publish the release, edit the release page and click "Publish release". This will trigger the `post-release` workflow that will re-tag the lifecycle image from `buildpacksio/lifecycle:<commit sha>` to `buildpacksio/lifecycle:0.99.0` and `buildpacksio/lifecycle:latest`.
 1. Once released, update the `main` branch to remove the pre-release note in [README.md](https://github.com/buildpacks/lifecycle/blob/main/README.md) and/or merge `release/0.99.0` into `main`.


### PR DESCRIPTION
As discussed in implementation sync. We'll semver tag the images but NOT update `latest`.

Signed-off-by: Natalie Arellano <narellano@vmware.com>