### PR TITLE
Adding registry credentials validations - Issue 572

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -980,7 +980,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							output, err := cmd.CombinedOutput()
 
 							h.AssertNotNil(t, err)
-							expected := "failed to : read/write image "+noAuthRegCacheImage+" from/to the registry"
+							expected := "failed to : read/write image " + noAuthRegCacheImage + " from/to the registry"
 							h.AssertStringContains(t, string(output), expected)
 						})
 					})

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -120,6 +120,30 @@ func (a *analyzeCmd) Privileges() error {
 		if err != nil {
 			return cmd.FailErr(err, "initialize docker client")
 		}
+	} else {
+		if a.platformAPIVersionGreaterThan06() {
+			err := a.verifyReadAccess(a.previousImage)
+			if err != nil {
+				return cmd.FailErr(err)
+			}
+			err = a.verifyReadAccess(a.runImageRef)
+			if err != nil {
+				return cmd.FailErr(err)
+			}
+			if len(a.additionalTags) > 0 {
+				for _, tag := range a.additionalTags {
+					err := a.verifyReadWriteAccess(tag)
+					if err != nil {
+						return cmd.FailErr(err)
+					}
+				}
+			}
+		} else {
+			err := a.verifyReadWriteAccess(a.platform06.cacheImageTag)
+			if err != nil {
+				return cmd.FailErr(err)
+			}
+		}
 	}
 	if err := priv.EnsureOwner(a.uid, a.gid, a.layersDir, a.platform06.cacheDir); err != nil {
 		return cmd.FailErr(err, "chown volumes")
@@ -224,4 +248,24 @@ func (a *analyzeCmd) restoresLayerMetadata() bool {
 
 func (a *analyzeCmd) platformAPIVersionGreaterThan06() bool {
 	return api.MustParse(a.platform.API()).Compare(api.MustParse("0.7")) >= 0
+}
+
+func (a *analyzeCmd) verifyReadAccess(name string) error {
+	if name != "" {
+		img, _ := remote.NewImage(name, a.keychain)
+		if !img.CheckReadAccess() {
+			return errors.New(fmt.Sprintf("read image %s from the registry", name))
+		}
+	}
+	return nil
+}
+
+func (a *analyzeCmd) verifyReadWriteAccess(name string) error {
+	if name != "" {
+		img, _ := remote.NewImage(name, a.keychain)
+		if !img.CheckReadWriteAccess() {
+			return errors.New(fmt.Sprintf("read/write image %s from/to the registry", name))
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

As part of the [Stack Buildpacks](https://github.com/buildpacks/rfcs/blob/app-mixins/text/0000-app-mixins-stack-buildpacks.md) feature, these validations improve the *fast failing builds* concept. Checking the registry credentials earlier in the process will avoid executing build processes and fail the build during the interaction with the registry.

The following validations were added when the analyzer is executed without `daemon` flag:

**API version >= 0.7**

- Ensure registry read/write access to <tags>
- Ensure registry read access to `<previous-image>`, `<run-image>`

**API version <  0.7**

- Ensure registry read/write access to `<cache-image>`

## Output

#### Before

#### After

## Documentation

- Should this change be documented?
    - [x] Yes

## Related
Resolves #572