### PR TITLE
Don't try to login to docker for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
           name: lifecycle-windows-x86-64
           path: out/lifecycle-v*+windows.x86-64.tgz
       - uses: azure/docker-login@v1
+        if: github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Otherwise the build will fail because secrets are not provided.
We don't intend to push an image, so there is no reason to login.

Signed-off-by: Natalie Arellano <narellano@vmware.com>