### PR TITLE
Build lifecycle binaries and images for linux/arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,10 @@ jobs:
           path: out/lifecycle-v*+linux.x86-64.tgz
       - uses: actions/upload-artifact@v2
         with:
+          name: lifecycle-linux-arm64
+          path: out/lifecycle-v*+linux.arm64.tgz
+      - uses: actions/upload-artifact@v2
+        with:
           name: lifecycle-windows-x86-64
           path: out/lifecycle-v*+windows.x86-64.tgz
       - uses: azure/docker-login@v1
@@ -118,7 +122,12 @@ jobs:
         if: github.event_name == 'push'
         run: |
           LIFECYCLE_IMAGE_TAG=$(git describe --always --dirty)
+          DOCKER_CLI_EXPERIMENTAL=enabled
           go run ./tools/image/main.go -lifecyclePath ./out/lifecycle-v*+linux.x86-64.tgz -tag buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux
+          go run ./tools/image/main.go -lifecyclePath ./out/lifecycle-v*+linux.arm64.tgz -tag buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux-arm64 -arch amd64
           go run ./tools/image/main.go -lifecyclePath ./out/lifecycle-v*+windows.x86-64.tgz -tag buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-windows -os windows
-          DOCKER_CLI_EXPERIMENTAL=enabled docker manifest create buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG} buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-windows
-          DOCKER_CLI_EXPERIMENTAL=enabled docker manifest push buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}
+          docker manifest create buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG} \
+              buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux \
+              buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux-arm64 \
+              buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-windows
+          docker manifest push buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ LIFECYCLE_IMAGE_TAG?=$(LIFECYCLE_VERSION)
 endif
 
 GOCMD?=go
-GOARCH?=amd64
 GOENV=GOARCH=$(GOARCH) CGO_ENABLED=0
 LIFECYCLE_DESCRIPTOR_PATH?=lifecycle.toml
 SCM_REPO?=github.com/buildpacks/lifecycle
@@ -40,33 +39,41 @@ GOFILES := $(shell $(GOCMD) run tools$/lister$/main.go)
 
 all: test build package
 
-build: build-linux build-windows
+build: build-linux-amd64 build-linux-arm64 build-windows-amd64
 
-build-linux: build-linux-lifecycle build-linux-symlinks build-linux-launcher
-build-windows: build-windows-lifecycle build-windows-symlinks build-windows-launcher
+build-linux-amd64: build-linux-amd64-lifecycle build-linux-amd64-symlinks build-linux-amd64-launcher
+build-linux-arm64: build-linux-arm64-lifecycle build-linux-arm64-symlinks build-linux-arm64-launcher
+build-windows-amd64: build-windows-amd64-lifecycle build-windows-amd64-symlinks build-windows-amd64-launcher
 
-build-image-linux: build-linux package-linux
-build-image-linux: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+linux.x86-64.tgz
-build-image-linux:
-	$(GOCMD) run ./tools/image/main.go -daemon -lifecyclePath $(ARCHIVE_PATH) -os linux -tag lifecycle:$(LIFECYCLE_IMAGE_TAG)
+build-image-linux-amd64: build-linux-amd64 package-linux-amd64
+build-image-linux-amd64: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+linux.x86-64.tgz
+build-image-linux-amd64:
+	$(GOCMD) run ./tools/image/main.go -daemon -lifecyclePath $(ARCHIVE_PATH) -os linux -arch amd64 -tag lifecycle:$(LIFECYCLE_IMAGE_TAG)
 
-build-image-windows: build-windows package-windows
-build-image-windows: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+windows.x86-64.tgz
-build-image-windows:
-	$(GOCMD) run ./tools/image/main.go -daemon -lifecyclePath $(ARCHIVE_PATH) -os windows -tag lifecycle:$(LIFECYCLE_IMAGE_TAG)
+build-image-linux-arm64: build-linux-arm64 package-linux-arm64
+build-image-linux-arm64: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+linux.arm64.tgz
+build-image-linux-arm64:
+	$(GOCMD) run ./tools/image/main.go -daemon -lifecyclePath $(ARCHIVE_PATH) -os linux -arch arm64 -tag lifecycle:$(LIFECYCLE_IMAGE_TAG)
 
-build-linux-lifecycle: $(BUILD_DIR)/linux/lifecycle/lifecycle
+build-image-windows-amd64: build-windows-amd64 package-windows-amd64
+build-image-windows-amd64: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+windows.x86-64.tgz
+build-image-windows-amd64:
+	$(GOCMD) run ./tools/image/main.go -daemon -lifecyclePath $(ARCHIVE_PATH) -os windows -arch amd64 -tag lifecycle:$(LIFECYCLE_IMAGE_TAG)
+
+build-linux-amd64-lifecycle: $(BUILD_DIR)/linux-amd64/lifecycle/lifecycle
+
+build-linux-arm64-lifecycle: $(BUILD_DIR)/linux-arm64/lifecycle/lifecycle
 
 docker-compilation-image-linux:
 	docker build ./tools --build-arg from_image=$(LINUX_COMPILATION_IMAGE) --tag $(SOURCE_COMPILATION_IMAGE)
 
-
-$(BUILD_DIR)/linux/lifecycle/lifecycle: export GOOS:=linux
-$(BUILD_DIR)/linux/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
-$(BUILD_DIR)/linux/lifecycle/lifecycle: docker-compilation-image-linux
-$(BUILD_DIR)/linux/lifecycle/lifecycle: $(GOFILES)
-$(BUILD_DIR)/linux/lifecycle/lifecycle:
-	@echo "> Building lifecycle/lifecycle for linux..."
+$(BUILD_DIR)/linux-amd64/lifecycle/lifecycle: export GOOS:=linux
+$(BUILD_DIR)/linux-amd64/lifecycle/lifecycle: export GOARCH:=amd64
+$(BUILD_DIR)/linux-amd64/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+$(BUILD_DIR)/linux-amd64/lifecycle/lifecycle: docker-compilation-image-linux
+$(BUILD_DIR)/linux-amd64/lifecycle/lifecycle: $(GOFILES)
+$(BUILD_DIR)/linux-amd64/lifecycle/lifecycle:
+	@echo "> Building lifecycle/lifecycle for $(GOOS)/$(GOARCH)..."
 	mkdir -p $(OUT_DIR)
 	docker run \
 	  --workdir=/lifecycle \
@@ -76,21 +83,51 @@ $(BUILD_DIR)/linux/lifecycle/lifecycle:
 	  $(SOURCE_COMPILATION_IMAGE) \
 	  sh -c '$(GOENV) $(GOBUILD) -o /out/lifecycle -a ./cmd/lifecycle'
 
-build-linux-launcher: $(BUILD_DIR)/linux/lifecycle/launcher
+$(BUILD_DIR)/linux-arm64/lifecycle/lifecycle: export GOOS:=linux
+$(BUILD_DIR)/linux-arm64/lifecycle/lifecycle: export GOARCH:=arm64
+$(BUILD_DIR)/linux-arm64/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+$(BUILD_DIR)/linux-arm64/lifecycle/lifecycle: docker-compilation-image-linux
+$(BUILD_DIR)/linux-arm64/lifecycle/lifecycle: $(GOFILES)
+$(BUILD_DIR)/linux-arm64/lifecycle/lifecycle:
+	@echo "> Building lifecycle/lifecycle for $(GOOS)/$(GOARCH)..."
+	mkdir -p $(OUT_DIR)
+	docker run \
+	  --workdir=/lifecycle \
+	  --volume $(OUT_DIR):/out \
+	  --volume $(PWD):/lifecycle \
+	  --volume gocache:/go \
+	  $(SOURCE_COMPILATION_IMAGE) \
+	  sh -c '$(GOENV) $(GOBUILD) -o /out/lifecycle -a ./cmd/lifecycle'
 
-$(BUILD_DIR)/linux/lifecycle/launcher: export GOOS:=linux
-$(BUILD_DIR)/linux/lifecycle/launcher: OUT_DIR?=$(BUILD_DIR)/$(GOOS)/lifecycle
-$(BUILD_DIR)/linux/lifecycle/launcher: $(GOFILES)
-$(BUILD_DIR)/linux/lifecycle/launcher:
-	@echo "> Building lifecycle/launcher for linux..."
+build-linux-amd64-launcher: $(BUILD_DIR)/linux-amd64/lifecycle/launcher
+
+$(BUILD_DIR)/linux-amd64/lifecycle/launcher: export GOOS:=linux
+$(BUILD_DIR)/linux-amd64/lifecycle/launcher: export GOARCH:=amd64
+$(BUILD_DIR)/linux-amd64/lifecycle/launcher: OUT_DIR?=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+$(BUILD_DIR)/linux-amd64/lifecycle/launcher: $(GOFILES)
+$(BUILD_DIR)/linux-amd64/lifecycle/launcher:
+	@echo "> Building lifecycle/launcher for $(GOOS)/$(GOARCH)..."
 	mkdir -p $(OUT_DIR)
 	$(GOENV) $(GOBUILD) -o $(OUT_DIR)/launcher -a ./cmd/launcher
 	test $$(du -m $(OUT_DIR)/launcher|cut -f 1) -le 3
 
-build-linux-symlinks: export GOOS:=linux
-build-linux-symlinks: OUT_DIR?=$(BUILD_DIR)/$(GOOS)/lifecycle
-build-linux-symlinks:
-	@echo "> Creating phase symlinks for linux..."
+build-linux-arm64-launcher: $(BUILD_DIR)/linux-arm64/lifecycle/launcher
+
+$(BUILD_DIR)/linux-arm64/lifecycle/launcher: export GOOS:=linux
+$(BUILD_DIR)/linux-arm64/lifecycle/launcher: export GOARCH:=arm64
+$(BUILD_DIR)/linux-arm64/lifecycle/launcher: OUT_DIR?=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+$(BUILD_DIR)/linux-arm64/lifecycle/launcher: $(GOFILES)
+$(BUILD_DIR)/linux-arm64/lifecycle/launcher:
+	@echo "> Building lifecycle/launcher for $(GOOS)/$(GOARCH)..."
+	mkdir -p $(OUT_DIR)
+	$(GOENV) $(GOBUILD) -o $(OUT_DIR)/launcher -a ./cmd/launcher
+	test $$(du -m $(OUT_DIR)/launcher|cut -f 1) -le 3
+
+build-linux-amd64-symlinks: export GOOS:=linux
+build-linux-amd64-symlinks: export GOARCH:=amd64
+build-linux-amd64-symlinks: OUT_DIR?=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+build-linux-amd64-symlinks:
+	@echo "> Creating phase symlinks for $(GOOS)/$(GOARCH)..."
 	ln -sf lifecycle $(OUT_DIR)/detector
 	ln -sf lifecycle $(OUT_DIR)/analyzer
 	ln -sf lifecycle $(OUT_DIR)/restorer
@@ -99,27 +136,43 @@ build-linux-symlinks:
 	ln -sf lifecycle $(OUT_DIR)/rebaser
 	ln -sf lifecycle $(OUT_DIR)/creator
 
-build-windows-lifecycle: $(BUILD_DIR)/windows/lifecycle/lifecycle.exe
+build-linux-arm64-symlinks: export GOOS:=linux
+build-linux-arm64-symlinks: export GOARCH:=arm64
+build-linux-arm64-symlinks: OUT_DIR?=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+build-linux-arm64-symlinks:
+	@echo "> Creating phase symlinks for $(GOOS)/$(GOARCH)..."
+	ln -sf lifecycle $(OUT_DIR)/detector
+	ln -sf lifecycle $(OUT_DIR)/analyzer
+	ln -sf lifecycle $(OUT_DIR)/restorer
+	ln -sf lifecycle $(OUT_DIR)/builder
+	ln -sf lifecycle $(OUT_DIR)/exporter
+	ln -sf lifecycle $(OUT_DIR)/rebaser
+	ln -sf lifecycle $(OUT_DIR)/creator
 
-$(BUILD_DIR)/windows/lifecycle/lifecycle.exe: export GOOS:=windows
-$(BUILD_DIR)/windows/lifecycle/lifecycle.exe: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)$/lifecycle
-$(BUILD_DIR)/windows/lifecycle/lifecycle.exe: $(GOFILES)
-$(BUILD_DIR)/windows/lifecycle/lifecycle.exe:
-	@echo "> Building lifecycle/lifecycle for Windows..."
+build-windows-amd64-lifecycle: $(BUILD_DIR)/windows-amd64/lifecycle/lifecycle.exe
+
+$(BUILD_DIR)/windows-amd64/lifecycle/lifecycle.exe: export GOOS:=windows
+$(BUILD_DIR)/windows-amd64/lifecycle/lifecycle.exe: export GOARCH:=amd64
+$(BUILD_DIR)/windows-amd64/lifecycle/lifecycle.exe: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)-$(GOARCH)$/lifecycle
+$(BUILD_DIR)/windows-amd64/lifecycle/lifecycle.exe: $(GOFILES)
+$(BUILD_DIR)/windows-amd64/lifecycle/lifecycle.exe:
+	@echo "> Building lifecycle/lifecycle for $(GOOS)/$(GOARCH)..."
 	$(GOBUILD) -o $(OUT_DIR)$/lifecycle.exe -a .$/cmd$/lifecycle
 
-build-windows-launcher: $(BUILD_DIR)/windows/lifecycle/launcher.exe
+build-windows-amd64-launcher: $(BUILD_DIR)/windows-amd64/lifecycle/launcher.exe
 
-$(BUILD_DIR)/windows/lifecycle/launcher.exe: export GOOS:=windows
-$(BUILD_DIR)/windows/lifecycle/launcher.exe: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)$/lifecycle
-$(BUILD_DIR)/windows/lifecycle/launcher.exe: $(GOFILES)
-$(BUILD_DIR)/windows/lifecycle/launcher.exe:
-	@echo "> Building lifecycle/launcher for Windows..."
+$(BUILD_DIR)/windows-amd64/lifecycle/launcher.exe: export GOOS:=windows
+$(BUILD_DIR)/windows-amd64/lifecycle/launcher.exe: export GOARCH:=amd64
+$(BUILD_DIR)/windows-amd64/lifecycle/launcher.exe: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)-$(GOARCH)$/lifecycle
+$(BUILD_DIR)/windows-amd64/lifecycle/launcher.exe: $(GOFILES)
+$(BUILD_DIR)/windows-amd64/lifecycle/launcher.exe:
+	@echo "> Building lifecycle/launcher for $(GOOS)/$(GOARCH)..."
 	$(GOBUILD) -o $(OUT_DIR)$/launcher.exe -a .$/cmd$/launcher
 
-build-windows-symlinks: export GOOS:=windows
-build-windows-symlinks: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)$/lifecycle
-build-windows-symlinks:
+build-windows-amd64-symlinks: export GOOS:=windows
+build-windows-amd64-symlinks: export GOARCH:=amd64
+build-windows-amd64-symlinks: OUT_DIR?=$(BUILD_DIR)$/$(GOOS)-$(GOARCH)$/lifecycle
+build-windows-amd64-symlinks:
 	@echo "> Creating phase symlinks for Windows..."
 ifeq ($(OS),Windows_NT)
 	call del $(OUT_DIR)$/detector.exe
@@ -146,16 +199,17 @@ else
 	ln -sf lifecycle.exe $(OUT_DIR)$/creator.exe
 endif
 
-build-darwin: build-darwin-lifecycle build-darwin-launcher
+build-darwin-amd64: build-darwin-amd64-lifecycle build-darwin-amd64-launcher
 
-build-darwin-lifecycle: $(BUILD_DIR)/darwin/lifecycle/lifecycle
-$(BUILD_DIR)/darwin/lifecycle/lifecycle: export GOOS:=darwin
-$(BUILD_DIR)/darwin/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
-$(BUILD_DIR)/darwin/lifecycle/lifecycle: $(GOFILES)
-$(BUILD_DIR)/darwin/lifecycle/lifecycle:
-	@echo "> Building lifecycle for macos..."
+build-darwin-amd64-lifecycle: $(BUILD_DIR)/darwin-amd64/lifecycle/lifecycle
+$(BUILD_DIR)/darwin-amd64/lifecycle/lifecycle: export GOOS:=darwin
+$(BUILD_DIR)/darwin-amd64/lifecycle/lifecycle: export GOARCH:=amd64
+$(BUILD_DIR)/darwin-amd64/lifecycle/lifecycle: OUT_DIR:=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+$(BUILD_DIR)/darwin-amd64/lifecycle/lifecycle: $(GOFILES)
+$(BUILD_DIR)/darwin-amd64/lifecycle/lifecycle:
+	@echo "> Building lifecycle for darwin/amd64..."
 	$(GOENV) $(GOBUILD) -o $(OUT_DIR)/lifecycle -a ./cmd/lifecycle
-	@echo "> Creating lifecycle symlinks for macos..."
+	@echo "> Creating lifecycle symlinks for darwin/amd64..."
 	ln -sf lifecycle $(OUT_DIR)/detector
 	ln -sf lifecycle $(OUT_DIR)/analyzer
 	ln -sf lifecycle $(OUT_DIR)/restorer
@@ -163,12 +217,13 @@ $(BUILD_DIR)/darwin/lifecycle/lifecycle:
 	ln -sf lifecycle $(OUT_DIR)/exporter
 	ln -sf lifecycle $(OUT_DIR)/rebaser
 
-build-darwin-launcher: $(BUILD_DIR)/darwin/lifecycle/launcher
-$(BUILD_DIR)/darwin/lifecycle/launcher: export GOOS:=darwin
-$(BUILD_DIR)/darwin/lifecycle/launcher: OUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
-$(BUILD_DIR)/darwin/lifecycle/launcher: $(GOFILES)
-$(BUILD_DIR)/darwin/lifecycle/launcher:
-	@echo "> Building launcher for macos..."
+build-darwin-amd64-launcher: $(BUILD_DIR)/darwin-amd64/lifecycle/launcher
+$(BUILD_DIR)/darwin-amd64/lifecycle/launcher: export GOOS:=darwin
+$(BUILD_DIR)/darwin-amd64/lifecycle/launcher: export GOARCH:=amd64
+$(BUILD_DIR)/darwin-amd64/lifecycle/launcher: OUT_DIR:=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+$(BUILD_DIR)/darwin-amd64/lifecycle/launcher: $(GOFILES)
+$(BUILD_DIR)/darwin-amd64/lifecycle/launcher:
+	@echo "> Building launcher for darwin/amd64..."
 	mkdir -p $(OUT_DIR)
 	$(GOENV) $(GOBUILD) -o $(OUT_DIR)/launcher -a ./cmd/launcher
 	test $$(du -m $(OUT_DIR)/launcher|cut -f 1) -le 4
@@ -231,22 +286,33 @@ clean:
 	@echo "> Cleaning workspace..."
 	rm -rf $(BUILD_DIR)
 
-package: package-linux package-windows
+package: package-linux-amd64 package-linux-arm64 package-windows-amd64
 
-package-linux: GOOS:=linux
-package-linux: INPUT_DIR:=$(BUILD_DIR)/$(GOOS)/lifecycle
-package-linux: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64.tgz
-package-linux: PACKAGER=./tools/packager/main.go
-package-linux:
-	@echo "> Packaging lifecycle for $(GOOS)..."
+package-linux-amd64: GOOS:=linux
+package-linux-amd64: GOARCH:=amd64
+package-linux-amd64: INPUT_DIR:=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+package-linux-amd64: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64.tgz
+package-linux-amd64: PACKAGER=./tools/packager/main.go
+package-linux-amd64:
+	@echo "> Packaging lifecycle for $(GOOS)/$(GOARCH)..."
 	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH) -descriptorPath $(LIFECYCLE_DESCRIPTOR_PATH) -version $(LIFECYCLE_VERSION)
 
-package-windows: GOOS:=windows
-package-windows: INPUT_DIR:=$(BUILD_DIR)$/$(GOOS)$/lifecycle
-package-windows: ARCHIVE_PATH=$(BUILD_DIR)$/lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64.tgz
-package-windows: PACKAGER=.$/tools$/packager$/main.go
-package-windows:
-	@echo "> Packaging lifecycle for $(GOOS)..."
+package-linux-arm64: GOOS:=linux
+package-linux-arm64: GOARCH:=arm64
+package-linux-arm64: INPUT_DIR:=$(BUILD_DIR)/$(GOOS)-$(GOARCH)/lifecycle
+package-linux-arm64: ARCHIVE_PATH=$(BUILD_DIR)/lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).arm64.tgz
+package-linux-arm64: PACKAGER=./tools/packager/main.go
+package-linux-arm64:
+	@echo "> Packaging lifecycle for $(GOOS)/$(GOARCH)..."
+	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH) -descriptorPath $(LIFECYCLE_DESCRIPTOR_PATH) -version $(LIFECYCLE_VERSION)
+
+package-windows-amd64: GOOS:=windows
+package-windows-amd64: GOARCH:=amd64
+package-windows-amd64: INPUT_DIR:=$(BUILD_DIR)$/$(GOOS)-$(GOARCH)$/lifecycle
+package-windows-amd64: ARCHIVE_PATH=$(BUILD_DIR)$/lifecycle-v$(LIFECYCLE_VERSION)+$(GOOS).x86-64.tgz
+package-windows-amd64: PACKAGER=.$/tools$/packager$/main.go
+package-windows-amd64:
+	@echo "> Packaging lifecycle for $(GOOS)/$(GOARCH)..."
 	$(GOCMD) run $(PACKAGER) --inputDir $(INPUT_DIR) -archivePath $(ARCHIVE_PATH) -descriptorPath $(LIFECYCLE_DESCRIPTOR_PATH) -version $(LIFECYCLE_VERSION)
 
 # Ensure workdir is clean and build image from .git

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1,6 +1,7 @@
 package acceptance
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -33,11 +34,12 @@ func TestVersion(t *testing.T) {
 		h.AssertNil(t, os.RemoveAll(buildDir))
 	}()
 
-	outDir := filepath.Join(buildDir, runtime.GOOS, "lifecycle")
+	outDir := filepath.Join(buildDir, fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH), "lifecycle")
 	h.AssertNil(t, os.MkdirAll(outDir, 0755))
 
 	h.MakeAndCopyLifecycle(t,
 		runtime.GOOS,
+		runtime.GOARCH,
 		outDir,
 		"LIFECYCLE_VERSION=some-version",
 		"SCM_COMMIT="+expectedCommit,
@@ -153,5 +155,5 @@ func testVersion(t *testing.T, when spec.G, it spec.S) {
 }
 
 func lifecycleCmd(phase string, args ...string) *exec.Cmd {
-	return exec.Command(filepath.Join(buildDir, runtime.GOOS, "lifecycle", phase), args...) // #nosec G204
+	return exec.Command(filepath.Join(buildDir, fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH), "lifecycle", phase), args...) // #nosec G204
 }

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -33,7 +33,7 @@ var (
 	analyzeImage         = "lifecycle/acceptance/analyzer"
 	analyzerPath         = "/cnb/lifecycle/analyzer"
 	cacheFixtureDir      = filepath.Join("testdata", "analyzer", "cache-dir")
-	daemonOS             string
+	daemonOS, daemonArch string
 	noAuthRegistry       *ih.DockerRegistry
 	authRegistry         *ih.DockerRegistry
 	registryNetwork      string
@@ -45,6 +45,10 @@ func TestAnalyzer(t *testing.T) {
 	info, err := h.DockerCli(t).Info(context.TODO())
 	h.AssertNil(t, err)
 	daemonOS = info.OSType
+	daemonArch = info.Architecture
+	if daemonArch == "x86_64" {
+		daemonArch = "amd64"
+	}
 
 	// Setup registry
 
@@ -75,7 +79,7 @@ func TestAnalyzer(t *testing.T) {
 
 	// Setup test container
 
-	h.MakeAndCopyLifecycle(t, daemonOS, analyzerBinaryDir)
+	h.MakeAndCopyLifecycle(t, daemonOS, daemonArch, analyzerBinaryDir)
 	h.DockerBuild(t,
 		analyzeImage,
 		analyzeDockerContext,

--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -32,10 +32,11 @@ var (
 
 func TestDetector(t *testing.T) {
 	h.SkipIf(t, runtime.GOOS == "windows", "Detector acceptance tests are not yet supported on Windows")
+	h.SkipIf(t, runtime.GOARCH != "amd64", "Detector acceptance tests are not yet supported on non-amd64")
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	h.MakeAndCopyLifecycle(t, "linux", detectorBinaryDir)
+	h.MakeAndCopyLifecycle(t, "linux", "amd64", detectorBinaryDir)
 	h.DockerBuild(t,
 		detectImage,
 		detectDockerContext,

--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -25,6 +25,10 @@ func TestLauncher(t *testing.T) {
 	info, err := h.DockerCli(t).Info(context.TODO())
 	h.AssertNil(t, err)
 	daemonOS = info.OSType
+	daemonArch = info.Architecture
+	if daemonArch == "x86_64" {
+		daemonArch = "amd64"
+	}
 
 	launchDockerContext = filepath.Join("testdata", "launcher")
 	if daemonOS == "windows" {
@@ -33,7 +37,7 @@ func TestLauncher(t *testing.T) {
 		launcherBinaryDir = filepath.Join("testdata", "launcher", "linux", "container", "cnb", "lifecycle")
 	}
 
-	h.MakeAndCopyLauncher(t, daemonOS, launcherBinaryDir)
+	h.MakeAndCopyLauncher(t, daemonOS, daemonArch, launcherBinaryDir)
 
 	h.DockerBuild(t, launchImage, launchDockerContext, h.WithFlags("-f", filepath.Join(launchDockerContext, dockerfileName)))
 	defer h.DockerImageRemove(t, launchImage)

--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -27,10 +27,11 @@ var (
 
 func TestRestorer(t *testing.T) {
 	h.SkipIf(t, runtime.GOOS == "windows", "Restorer acceptance tests are not yet supported on Windows")
+	h.SkipIf(t, runtime.GOARCH != "amd64", "Restorer acceptance tests are not yet supported on non-amd64")
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	h.MakeAndCopyLifecycle(t, "linux", restorerBinaryDir)
+	h.MakeAndCopyLifecycle(t, "linux", "amd64", restorerBinaryDir)
 	h.DockerBuild(t, restorerImage, restoreDockerContext)
 	defer h.DockerImageRemove(t, restorerImage)
 

--- a/testhelpers/binaries.go
+++ b/testhelpers/binaries.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 )
 
-func MakeAndCopyLauncher(t *testing.T, goos, destDir string) {
+func MakeAndCopyLauncher(t *testing.T, goos, goarch, destDir string) {
 	buildDir, err := filepath.Abs(filepath.Join("..", "out"))
 	AssertNil(t, err)
 
-	cmd := exec.Command("make", fmt.Sprintf("build-%s-launcher", goos)) // #nosec G204
+	cmd := exec.Command("make", fmt.Sprintf("build-%s-%s-launcher", goos, goarch)) // #nosec G204
 
 	wd, err := os.Getwd()
 	AssertNil(t, err)
@@ -29,14 +29,14 @@ func MakeAndCopyLauncher(t *testing.T, goos, destDir string) {
 	t.Log("Building binaries: ", cmd.Args)
 	Run(t, cmd)
 
-	copyLauncher(t, filepath.Join(buildDir, goos, "lifecycle"), destDir)
+	copyLauncher(t, filepath.Join(buildDir, fmt.Sprintf("%s-%s", goos, goarch), "lifecycle"), destDir)
 }
 
-func MakeAndCopyLifecycle(t *testing.T, goos, destDir string, envs ...string) {
+func MakeAndCopyLifecycle(t *testing.T, goos, goarch, destDir string, envs ...string) {
 	buildDir, err := filepath.Abs(filepath.Join("..", "out"))
 	AssertNil(t, err)
 
-	cmd := exec.Command("make", "build-"+goos) // #nosec G204
+	cmd := exec.Command("make", fmt.Sprintf("build-%s-%s", goos, goarch)) // #nosec G204
 
 	wd, err := os.Getwd()
 	AssertNil(t, err)
@@ -49,10 +49,10 @@ func MakeAndCopyLifecycle(t *testing.T, goos, destDir string, envs ...string) {
 	)
 	cmd.Env = append(os.Environ(), envs...)
 
-	t.Log("Building binaries: ", cmd.Args)
+	t.Log("Building binaries:", cmd.Args)
 	Run(t, cmd)
 
-	copyLifecycle(t, filepath.Join(buildDir, goos, "lifecycle"), destDir)
+	copyLifecycle(t, filepath.Join(buildDir, fmt.Sprintf("%s-%s", goos, goarch), "lifecycle"), destDir)
 }
 
 func copyLauncher(t *testing.T, src, dst string) {

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -33,10 +33,10 @@ const (
 
 // commandline flags
 var (
-	lifecyclePath string      // path to lifecycle TGZ
-	tags          stringSlice // tag reference to write lifecycle image
-	targetOS      string      // operating system
-	useDaemon     bool        // export to docker daemon
+	lifecyclePath        string      // path to lifecycle TGZ
+	tags                 stringSlice // tag reference to write lifecycle image
+	targetOS, targetArch string      // operating system and CPU architecture
+	useDaemon            bool        // export to docker daemon
 )
 
 type stringSlice []string
@@ -54,6 +54,7 @@ func (s *stringSlice) Set(value string) error {
 func main() {
 	flag.StringVar(&lifecyclePath, "lifecyclePath", "", "path to lifecycle TGZ")
 	flag.StringVar(&targetOS, "os", runtime.GOOS, "operating system")
+	flag.StringVar(&targetArch, "arch", runtime.GOARCH, "CPU architecture")
 	flag.Var(&tags, "tag", "tag reference to write lifecycle image")
 	flag.BoolVar(&useDaemon, "daemon", false, "export to docker daemon")
 
@@ -81,6 +82,9 @@ func main() {
 		if info.OSType != targetOS {
 			log.Fatal("Target OS and daemon OS must match")
 		}
+		if info.Architecture != targetArch {
+			log.Fatal("Target architecture and daemon architecture must match")
+		}
 		err = pullImage(dockerClient, baseImage)
 		if err != nil {
 			log.Fatal("Failed to pull base image:", err)
@@ -91,7 +95,10 @@ func main() {
 		}
 	} else {
 		var err error
-		img, err = remote.NewImage(tags[0], authn.DefaultKeychain, remote.FromBaseImage(baseImage))
+		img, err = remote.NewImage(tags[0], authn.DefaultKeychain, remote.FromBaseImage(baseImage), remote.WithDefaultPlatform(imgutil.Platform{
+			Architecture: targetArch,
+			OS:           targetOS,
+		}))
 		if err != nil {
 			log.Fatal("Failed to create remote image:", err)
 		}


### PR DESCRIPTION
This PR makes make targets explicit about the GOARCH being used, in addition to the GOOS.

This changes `make build` to build for `linux/amd64`, `windows/amd64`, and newly, `linux/arm64`. Binaries are built to paths like `out/$GOOS-$GOARCH/lifecycle`, etc.

This also changes the CI image build process to build and attach the `amd64` binary to the build, and to include the `linux/arm64` image in the manifest list.

Acceptance tests were updated to build arch-specific binaries and to look for them in the new correct place.

Open questions:

- This PR doesn't currently change the fact that the `linux/amd64` image is pushed and tagged to `buildpacksio/lifecycle:$FOO-linux`, when it maybe should get pushed to `...linux-amd64`. We can push to both to avoid breaking people, if that's preferred.
- This PR doesn't touch the release processes in `.github/workflows/*release.yaml` -- if this PR lands and doesn't break CI, we can tackle the release changes then.

@natalieparellano 