### PR TITLE
Don't print header when failed to parse

### DIFF
--- a/auth/env_keychain.go
+++ b/auth/env_keychain.go
@@ -59,7 +59,7 @@ func (k *ResolvedKeychain) Resolve(resource authn.Resource) (authn.Authenticator
 	if ok {
 		authConfig, err := authHeaderToConfig(header)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parsing auth header '%s'", header)
+			return nil, errors.Wrap(err, "parsing auth header")
 		}
 
 		return &providedAuth{config: authConfig}, nil
@@ -118,10 +118,11 @@ func buildAuthMap(keychain authn.Keychain, images ...string) map[string]string {
 			continue
 		}
 
-		registryAuths[reference.Context().Registry.Name()], err = authConfigToHeader(authConfig)
+		header, err := authConfigToHeader(authConfig)
 		if err != nil {
 			continue
 		}
+		registryAuths[reference.Context().Registry.Name()] = header
 	}
 
 	return registryAuths
@@ -176,7 +177,7 @@ func authHeaderToConfig(header string) (*authn.AuthConfig, error) {
 		}, nil
 	}
 
-	return nil, errors.Errorf("unknown auth type from header: %s", header)
+	return nil, errors.New("unknown auth type from header")
 }
 
 // ReferenceForRepoName returns a reference and an authenticator for a given image name and keychain.

--- a/auth/env_keychain_test.go
+++ b/auth/env_keychain_test.go
@@ -193,6 +193,7 @@ func testEnvKeychain(t *testing.T, when spec.G, it spec.S) {
 
 						_, err = resolvedKeychain.Resolve(registry)
 						h.AssertNotNil(t, err)
+						h.AssertStringContains(t, err.Error(), "parsing auth header")
 						h.AssertStringDoesNotContain(t, err.Error(), "Some Bad Header")
 					})
 				})

--- a/auth/env_keychain_test.go
+++ b/auth/env_keychain_test.go
@@ -155,6 +155,7 @@ func testEnvKeychain(t *testing.T, when spec.G, it spec.S) {
 				resolvedKeychain = auth.ResolvedKeychain{Auths: map[string]string{
 					"basic-registry.com":  "Basic some-basic-auth=",
 					"bearer-registry.com": "Bearer some-bearer-auth=",
+					"bad-header.com":      "Some Bad Header",
 				}}
 			})
 
@@ -183,6 +184,17 @@ func testEnvKeychain(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, header, &authn.AuthConfig{RegistryToken: "some-bearer-auth="})
+				})
+
+				when("error parsing header", func() {
+					it("doesn't print the header in the error message", func() {
+						registry, err := name.NewRegistry("bad-header.com", name.WeakValidation)
+						h.AssertNil(t, err)
+
+						_, err = resolvedKeychain.Resolve(registry)
+						h.AssertNotNil(t, err)
+						h.AssertStringDoesNotContain(t, err.Error(), "Some Bad Header")
+					})
 				})
 			})
 


### PR DESCRIPTION
Fixes #661 

Signed-off-by: Natalie Arellano <narellano@vmware.com>