### PR TITLE
WIP - Refactoring analyzer tests to use custom docker registry

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -216,6 +216,7 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 		"--build-arg", "fromImage="+containerBaseImage,
 	)
 	fixtures.readOnlyRegRunImage = testRegistry.SetReadOnly(someRunImageName)
+	fixtures.authRegRunImage = testRegistry.RepoName(someRunImageName)
 
 	// Daemon
 

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -54,7 +54,7 @@ type analyzeFixtures struct {
 	daemonCacheImage      string
 	readOnlyRegAppImage   string // read-only
 	readOnlyRegCacheImage string // read-only
-	inaccessibleImage	  string // no access at all
+	inaccessibleImage     string // no access at all
 }
 
 func TestAnalyzer(t *testing.T) {

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -27,12 +27,6 @@ import (
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
-const (
-	readWriteImage = "image-readable-writable"
-	onlyReadImage  = "image-readable"
-	noAccessImage  = "noAccessImage"
-)
-
 var (
 	analyzerBinaryDir    = filepath.Join("testdata", "analyzer", "analyze-image", "container", "cnb", "lifecycle")
 	analyzeDockerContext = filepath.Join("testdata", "analyzer", "analyze-image")
@@ -137,7 +131,7 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 		"--build-arg", "fromImage="+containerBaseImage,
 		"--build-arg", "metadata="+appMeta,
 	)
-	testRegistry.Add(someAppName, ih.NewImagePrivileges(readWriteImage))
+	testRegistry.Add(someAppName, ih.NewImagePrivileges(ih.Readable, ih.Writable))
 
 	someOtherAppName := "some-other-app-image-" + h.RandString(10)
 	fixtures.authRegOtherAppImage, _ = buildAuthRegistryImage(
@@ -148,7 +142,7 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 		"--build-arg", "fromImage="+containerBaseImage,
 		"--build-arg", "metadata="+appMeta,
 	)
-	testRegistry.Add(someOtherAppName, ih.NewImagePrivileges(readWriteImage))
+	testRegistry.Add(someOtherAppName, ih.NewImagePrivileges(ih.Readable, ih.Writable))
 
 	// setup read only images
 	someReadOnlyAppName := "some-readonly-app-image-" + h.RandString(10)
@@ -160,7 +154,7 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 		"--build-arg", "fromImage="+containerBaseImage,
 		"--build-arg", "metadata="+appMeta,
 	)
-	testRegistry.Add(someReadOnlyAppName, ih.NewImagePrivileges(onlyReadImage))
+	testRegistry.Add(someReadOnlyAppName, ih.NewImagePrivileges(ih.Readable))
 
 	someCacheName := "some-cache-image-" + h.RandString(10)
 	fixtures.authRegCacheImage, _ = buildAuthRegistryImage(
@@ -171,12 +165,12 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 		"--build-arg", "fromImage="+containerBaseImage,
 		"--build-arg", "metadata="+cacheMeta,
 	)
-	testRegistry.Add(someCacheName, ih.NewImagePrivileges(readWriteImage))
+	testRegistry.Add(someCacheName, ih.NewImagePrivileges(ih.Readable, ih.Writable))
 	fixtures.readOnlyRegCacheImage = testRegistry.RepoName(someCacheName)
 
 	// setup no access image
 	inaccessibleImage := "inaccessible-image"
-	testRegistry.Add(inaccessibleImage, ih.NewImagePrivileges(noAccessImage))
+	testRegistry.Add(inaccessibleImage, ih.NewImagePrivileges())
 	fixtures.inaccessibleImage = testRegistry.RepoName(inaccessibleImage)
 
 	// Daemon

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -253,6 +253,8 @@ func (a analyzeFixtures) removeAll(t *testing.T) {
 	h.DockerImageRemove(t, fixtures.readWriteAppImage)
 	h.DockerImageRemove(t, fixtures.readWriteCacheImage)
 	h.DockerImageRemove(t, fixtures.readWriteOtherAppImage)
+	h.DockerImageRemove(t, fixtures.someAppImage)
+	h.DockerImageRemove(t, fixtures.someCacheImage)
 }
 
 func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spec.S) {

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -48,7 +48,7 @@ var (
 type analyzeFixtures struct {
 	authRegAppImage       string // read and write access
 	authRegAuthConfig     string
-	authRegCacheImage     string // read-only
+	authRegCacheImage     string // read and write access
 	authRegOtherAppImage  string // read and write access
 	daemonAppImage        string
 	daemonCacheImage      string
@@ -162,7 +162,7 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 	)
 	testRegistry.Add(someReadOnlyAppName, ih.NewImagePrivileges(onlyReadImage))
 
-	someCacheName := "some-cache-image"
+	someCacheName := "some-cache-image-" + h.RandString(10)
 	fixtures.authRegCacheImage, _ = buildAuthRegistryImage(
 		t,
 		someCacheName,
@@ -171,7 +171,7 @@ func setupAnalyzeFixtures(t *testing.T) analyzeFixtures {
 		"--build-arg", "fromImage="+containerBaseImage,
 		"--build-arg", "metadata="+cacheMeta,
 	)
-	testRegistry.Add(someCacheName, ih.NewImagePrivileges(onlyReadImage))
+	testRegistry.Add(someCacheName, ih.NewImagePrivileges(readWriteImage))
 	fixtures.readOnlyRegCacheImage = testRegistry.RepoName(someCacheName)
 
 	// setup no access image

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/buildpacks/lifecycle
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/apex/log v1.9.0
-	github.com/buildpacks/imgutil v0.0.0-20210719153540-a83d74d568a7
-	github.com/docker/docker v20.10.7+incompatible
+	github.com/buildpacks/imgutil v0.0.0-20210818180451-66aea982d5dc
+	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.6
@@ -21,7 +21,5 @@ require (
 	google.golang.org/genproto v0.0.0-20210610141715-e7a9b787a5a4 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
-
-replace github.com/buildpacks/imgutil => github.com/jjbustamante/imgutil v0.0.0-20210817191209-1eb46031019f
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
-replace github.com/buildpacks/imgutil => github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4
+replace github.com/buildpacks/imgutil => github.com/jjbustamante/imgutil v0.0.0-20210810205516-1924767685e5
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
-replace github.com/buildpacks/imgutil => github.com/jjbustamante/imgutil v0.0.0-20210810205516-1924767685e5
+replace github.com/buildpacks/imgutil => github.com/jjbustamante/imgutil v0.0.0-20210817191209-1eb46031019f
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
 
+replace github.com/buildpacks/imgutil => github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4
+
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/buildpacks/imgutil v0.0.0-20210818180451-66aea982d5dc h1:0AyNL75M0OLaI2OrU5B8fwCCkB9Qd0sQpO2Dw178MBs=
+github.com/buildpacks/imgutil v0.0.0-20210818180451-66aea982d5dc/go.mod h1:ZfCbsFruoxG0vbEVMsX/afizEo4vn2e88Km7rJ1M2D8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -254,8 +256,9 @@ github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TT
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.7+incompatible h1:Z6O9Nhsjv+ayUEeI1IojKbYcsGdgYSNqxe1s2MYzUhQ=
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.8+incompatible h1:RVqD337BgQicVCzYrrlhLDWhq6OAD2PJDUg2LsEUvKM=
+github.com/docker/docker v20.10.8+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
@@ -449,8 +452,6 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jjbustamante/imgutil v0.0.0-20210817191209-1eb46031019f h1:mP9fcRmifFuCZh5irWfdr2MKJKTXdCQs2hdh04hd80U=
-github.com/jjbustamante/imgutil v0.0.0-20210817191209-1eb46031019f/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,6 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jjbustamante/imgutil v0.0.0-20210719153540-a83d74d568a7 h1:fL8VnzSXhbrpVj3EI68EffnnrXkUN2CCWbOodASzPnw=
-github.com/jjbustamante/imgutil v0.0.0-20210719153540-a83d74d568a7/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4 h1:c2TupsiuiQfXIbNuRTEZQt0H0u3aku8Bsn1UJCSsNGo=
 github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jjbustamante/imgutil v0.0.0-20210810205516-1924767685e5 h1:Juiqj/x7THXaj8E/5UzAct9sG5UGH/H5RJsvt92ryDQ=
-github.com/jjbustamante/imgutil v0.0.0-20210810205516-1924767685e5/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
+github.com/jjbustamante/imgutil v0.0.0-20210817191209-1eb46031019f h1:mP9fcRmifFuCZh5irWfdr2MKJKTXdCQs2hdh04hd80U=
+github.com/jjbustamante/imgutil v0.0.0-20210817191209-1eb46031019f/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,6 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildpacks/imgutil v0.0.0-20210719153540-a83d74d568a7 h1:RLQSFwioYuJtGx+1npBNPdcaNbkYXpN/6gUrFvSnkKo=
-github.com/buildpacks/imgutil v0.0.0-20210719153540-a83d74d568a7/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -451,6 +449,10 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+github.com/jjbustamante/imgutil v0.0.0-20210719153540-a83d74d568a7 h1:fL8VnzSXhbrpVj3EI68EffnnrXkUN2CCWbOodASzPnw=
+github.com/jjbustamante/imgutil v0.0.0-20210719153540-a83d74d568a7/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
+github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4 h1:c2TupsiuiQfXIbNuRTEZQt0H0u3aku8Bsn1UJCSsNGo=
+github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4 h1:c2TupsiuiQfXIbNuRTEZQt0H0u3aku8Bsn1UJCSsNGo=
-github.com/jjbustamante/imgutil v0.0.0-20210728202257-f17e488af4f4/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
+github.com/jjbustamante/imgutil v0.0.0-20210810205516-1924767685e5 h1:Juiqj/x7THXaj8E/5UzAct9sG5UGH/H5RJsvt92ryDQ=
+github.com/jjbustamante/imgutil v0.0.0-20210810205516-1924767685e5/go.mod h1:u67HqXr7QbMDRXn8plSamdI9LgYu1kODpIp0c6LoCDE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
### References

- This Pull Request is created after [PR #646](https://github.com/buildpacks/lifecycle/pull/646) was merged

### Context

After merging  [PR #646](https://github.com/buildpacks/lifecycle/pull/646) we agreed to refactor the analyzer tests and simplifying the number of docker registries we are using. 

### Description

- The PR removes the `authRegistry` and the `readOnlyRegistry` and replaces them with just 1 `testRegistry` that uses the `ImagePrivilges` approach implemented in  imgUtil repo [PR #126](https://github.com/buildpacks/imgutil/pull/126) to configure the registry to handle the required behaviors.

### Depends on

- This PR depends on imgUtil repo [PR #126](https://github.com/buildpacks/imgutil/pull/126)