### PR TITLE
Install cosign using official GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,9 +95,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.16'
-      - name: Install cosign
-        run: |
-          go install github.com/sigstore/cosign/cmd/cosign@latest
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v1.0.0
+        with:
+          cosign-release: 'v1.0.0'
       - name: Set version
         run: |
           echo "LIFECYCLE_VERSION=$(go run tools/version/main.go)" >> version.txt

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -17,9 +17,10 @@ jobs:
       - name: Install crane
         run: |
           go install github.com/google/go-containerregistry/cmd/crane@latest
-      - name: Install cosign
-        run: |
-          go install github.com/sigstore/cosign/cmd/cosign@latest
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v1.0.0
+        with:
+          cosign-release: 'v1.0.0'
       - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
See https://github.com/sigstore/cosign-installer

This downloads pre-built binaries from official sources, which should save some time since we can avoid building the binary ourselves.

@natalieparellano 