### PR TITLE
Use repository owner from GitHub Actions context

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -30,7 +30,7 @@ jobs:
           script: |
             return github.actions
               .listRepoWorkflows({
-                 owner: "buildpacks",
+                 owner: "${{ github.repository_owner }}",
                  repo: "lifecycle",
               })
               .then(workflows_result => {
@@ -44,7 +44,7 @@ jobs:
               })
               .then(workflow_id => {
                 return github.actions.listWorkflowRunsForRepo({
-                  owner: "buildpacks",
+                  owner: "${{ github.repository_owner }}",
                   repo: "lifecycle",
                   workflow_id: workflow_id,
                   branch: "release/${{ env.LIFECYCLE_VERSION }}",
@@ -62,7 +62,7 @@ jobs:
               })
               .then(workflow_runid => {
                 return github.actions.listWorkflowRunArtifacts({
-                  owner: "buildpacks",
+                  owner: "${{ github.repository_owner }}",
                   repo: "lifecycle",
                   run_id: workflow_runid
                 })


### PR DESCRIPTION
This should make it slightly easier to run these workflows in a fork.

Unfortunately it [doesn't look like there's an easy context value for just the repo name](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context), so this might still be difficult for people who have a fork with a different name.