### PR TITLE
Run image should be locked to a digest in analyzed.toml

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -293,7 +293,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					)
 
 					analyzedMD := assertAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))
-					h.AssertEq(t, analyzedMD.RunImage.Reference, analyzeRegFixtures.ReadOnlyRunImage)
+					h.AssertStringContains(t, analyzedMD.RunImage.Reference, analyzeRegFixtures.ReadOnlyRunImage+"@sha256:")
 				})
 			})
 
@@ -846,7 +846,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 								h.WithArgs(execArgs...),
 							)
 							analyzedMD := assertAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))
-							h.AssertStringContains(t, analyzedMD.Image.Reference, analyzeRegFixtures.ReadWriteAppImage)
+							h.AssertStringContains(t, analyzedMD.PreviousImage.Reference, analyzeRegFixtures.ReadWriteAppImage)
 						})
 					})
 
@@ -875,7 +875,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							)
 
 							analyzedMD := assertAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))
-							h.AssertStringContains(t, analyzedMD.Image.Reference, analyzeRegFixtures.ReadWriteAppImage)
+							h.AssertStringContains(t, analyzedMD.PreviousImage.Reference, analyzeRegFixtures.ReadWriteAppImage)
 						})
 					})
 				})
@@ -1060,7 +1060,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							h.WithArgs(execArgs...),
 						)
 						analyzedMD := assertAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))
-						h.AssertStringContains(t, analyzedMD.Image.Reference, analyzeRegFixtures.ReadWriteAppImage)
+						h.AssertStringContains(t, analyzedMD.PreviousImage.Reference, analyzeRegFixtures.ReadWriteAppImage)
 					})
 				})
 

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -316,7 +316,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					)
 
 					analyzedMD := assertAnalyzedMetadata(t, filepath.Join(copyDir, "analyzed.toml"))
-					h.AssertEq(t, analyzedMD.RunImage.Reference, analyzeRegFixtures.ReadOnlyRunImage)
+					h.AssertStringContains(t, analyzedMD.RunImage.Reference, analyzeRegFixtures.ReadOnlyRunImage+"@sha256:")
 				})
 
 				when("CNB_RUN_IMAGE not provided", func() {

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -172,7 +172,7 @@ func updateAnalyzedTOMLFixturesWithRegRepoName(t *testing.T, phaseTest *PhaseTes
 
 	placeHolderPath = filepath.Join("testdata", "exporter", "container", "layers", "some-analyzed.toml.placeholder")
 	analyzedMD = assertAnalyzedMetadata(t, placeHolderPath)
-	analyzedMD.Image = &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.SomeAppImage}
+	analyzedMD.PreviousImage = &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.SomeAppImage}
 	analyzedMD.RunImage = &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.ReadOnlyRunImage}
 	lifecycle.WriteTOML(strings.TrimSuffix(placeHolderPath, ".placeholder"), analyzedMD)
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -71,9 +71,9 @@ func testAnalyzerBuilder(platformAPI string) func(t *testing.T, when spec.G, it 
 			p, err := platform.NewPlatform(platformAPI)
 			h.AssertNil(t, err)
 			analyzer = &lifecycle.Analyzer{
-				Image:    image,
-				Logger:   &discardLogger,
-				Platform: p,
+				PreviousImage: image,
+				Logger:        &discardLogger,
+				Platform:      p,
 				Buildpacks: []buildpack.GroupBuildpack{
 					{ID: "metadata.buildpack", API: api.Buildpack.Latest().String()},
 					{ID: "no.cache.buildpack", API: api.Buildpack.Latest().String()},
@@ -130,7 +130,7 @@ func testAnalyzerBuilder(platformAPI string) func(t *testing.T, when spec.G, it 
 					md, err := analyzer.Analyze()
 					h.AssertNil(t, err)
 
-					h.AssertEq(t, md.Image.Reference, "s0m3D1g3sT")
+					h.AssertEq(t, md.PreviousImage.Reference, "s0m3D1g3sT")
 					h.AssertEq(t, md.Metadata, expectedAppMetadata)
 				})
 
@@ -164,7 +164,7 @@ func testAnalyzerBuilder(platformAPI string) func(t *testing.T, when spec.G, it 
 					md, err := analyzer.Analyze()
 					h.AssertNil(t, err)
 
-					h.AssertNil(t, md.Image)
+					h.AssertNil(t, md.PreviousImage)
 					h.AssertEq(t, md.Metadata, platform.LayersMetadata{})
 				})
 			})
@@ -192,6 +192,21 @@ func testAnalyzerBuilder(platformAPI string) func(t *testing.T, when spec.G, it 
 					md, err := analyzer.Analyze()
 					h.AssertNil(t, err)
 					h.AssertEq(t, md.Metadata, platform.LayersMetadata{})
+				})
+			})
+
+			when("run image is provided", func() {
+				it.Before(func() {
+					analyzer.RunImage = image
+				})
+
+				it("returns the run image digest in the analyzed metadata", func() {
+					expectRestoresLayerMetadataIfSupported()
+
+					md, err := analyzer.Analyze()
+					h.AssertNil(t, err)
+
+					h.AssertEq(t, md.RunImage.Reference, "s0m3D1g3sT")
 				})
 			})
 		})

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -212,23 +212,12 @@ func (a *analyzeCmd) Exec() error {
 }
 
 func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
-	var (
-		img imgutil.Image
-		err error
-	)
-	if aa.useDaemon {
-		img, err = local.NewImage(
-			aa.previousImageRef,
-			aa.docker,
-			local.FromBaseImage(aa.previousImageRef),
-		)
-	} else {
-		img, err = remote.NewImage(
-			aa.previousImageRef,
-			aa.keychain,
-			remote.FromBaseImage(aa.previousImageRef),
-		)
+	previousImage, err := aa.localOrRemote(aa.previousImageRef)
+	if err != nil {
+		return platform.AnalyzedMetadata{}, cmd.FailErr(err, "get previous image")
 	}
+
+	runImage, err := aa.localOrRemote(aa.runImageRef)
 	if err != nil {
 		return platform.AnalyzedMetadata{}, cmd.FailErr(err, "get previous image")
 	}
@@ -238,22 +227,31 @@ func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
 		Cache:                 aa.platform06.cache,
 		Logger:                cmd.DefaultLogger,
 		Platform:              aa.platform,
-		Image:                 img,
+		PreviousImage:         previousImage,
+		RunImage:              runImage,
 		LayerMetadataRestorer: lifecycle.NewLayerMetadataRestorer(cmd.DefaultLogger, aa.layersDir, aa.platform06.skipLayers),
 	}).Analyze()
 	if err != nil {
 		return platform.AnalyzedMetadata{}, cmd.FailErrCode(err, aa.platform.CodeFor(cmd.AnalyzeError), "analyzer")
 	}
 
-	if aa.runImageRef != "" {
-		ref, err := name.ParseReference(aa.runImageRef, name.WeakValidation)
-		if err != nil {
-			return platform.AnalyzedMetadata{}, cmd.FailErrCode(err, aa.platform.CodeFor(cmd.AnalyzeError), "parse reference for run image")
-		}
-		analyzedMD.RunImage = &platform.ImageIdentifier{Reference: ref.String()}
+	return analyzedMD, nil
+}
+
+func (aa analyzeArgs) localOrRemote(fromImage string) (imgutil.Image, error) {
+	if aa.useDaemon {
+		return local.NewImage(
+			fromImage,
+			aa.docker,
+			local.FromBaseImage(fromImage),
+		)
 	}
 
-	return analyzedMD, nil
+	return remote.NewImage(
+		fromImage,
+		aa.keychain,
+		remote.FromBaseImage(fromImage),
+	)
 }
 
 func (a *analyzeCmd) platformAPIVersionGreaterThan06() bool {

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -219,8 +219,8 @@ func (e *exportCmd) registryImages() []string {
 	if !e.useDaemon {
 		registryImages = append(registryImages, e.imageNames...)
 		registryImages = append(registryImages, e.runImageRef)
-		if e.analyzedMD.Image != nil {
-			registryImages = append(registryImages, e.analyzedMD.Image.Reference)
+		if e.analyzedMD.PreviousImage != nil {
+			registryImages = append(registryImages, e.analyzedMD.PreviousImage.Reference)
 		}
 	}
 	return registryImages
@@ -326,9 +326,9 @@ func (ea exportArgs) initDaemonAppImage(analyzedMD platform.AnalyzedMetadata) (i
 		local.FromBaseImage(ea.runImageRef),
 	}
 
-	if analyzedMD.Image != nil {
-		cmd.DefaultLogger.Debugf("Reusing layers from image with id '%s'", analyzedMD.Image.Reference)
-		opts = append(opts, local.WithPreviousImage(analyzedMD.Image.Reference))
+	if analyzedMD.PreviousImage != nil {
+		cmd.DefaultLogger.Debugf("Reusing layers from image with id '%s'", analyzedMD.PreviousImage.Reference)
+		opts = append(opts, local.WithPreviousImage(analyzedMD.PreviousImage.Reference))
 	}
 
 	var appImage imgutil.Image
@@ -361,17 +361,17 @@ func (ea exportArgs) initRemoteAppImage(analyzedMD platform.AnalyzedMetadata) (i
 		remote.FromBaseImage(ea.runImageRef),
 	}
 
-	if analyzedMD.Image != nil {
-		cmd.DefaultLogger.Infof("Reusing layers from image '%s'", analyzedMD.Image.Reference)
+	if analyzedMD.PreviousImage != nil {
+		cmd.DefaultLogger.Infof("Reusing layers from image '%s'", analyzedMD.PreviousImage.Reference)
 		// ensure previous image is on same registry as output image
-		analyzedRegistry, err := parseRegistry(analyzedMD.Image.Reference)
+		analyzedRegistry, err := parseRegistry(analyzedMD.PreviousImage.Reference)
 		if err != nil {
 			return nil, "", cmd.FailErr(err, "parse analyzed registry")
 		}
 		if analyzedRegistry != ea.targetRegistry {
 			return nil, "", fmt.Errorf("analyzed image is on a different registry %s from the exported image %s", analyzedRegistry, ea.targetRegistry)
 		}
-		opts = append(opts, remote.WithPreviousImage(analyzedMD.Image.Reference))
+		opts = append(opts, remote.WithPreviousImage(analyzedMD.PreviousImage.Reference))
 	}
 
 	appImage, err := remote.NewImage(

--- a/platform/files.go
+++ b/platform/files.go
@@ -15,9 +15,9 @@ import (
 // analyzed.toml
 
 type AnalyzedMetadata struct {
-	Image    *ImageIdentifier `toml:"image"`
-	Metadata LayersMetadata   `toml:"metadata"`
-	RunImage *ImageIdentifier `toml:"run-image,omitempty"`
+	PreviousImage *ImageIdentifier `toml:"image"`
+	Metadata      LayersMetadata   `toml:"metadata"`
+	RunImage      *ImageIdentifier `toml:"run-image,omitempty"`
 }
 
 // FIXME: fix key names to be accurate in the daemon case


### PR DESCRIPTION
Signed-off-by: Natalie Arellano <narellano@vmware.com>