### PR TITLE
Buildpack api 0.7 is not supported

### DIFF
--- a/acceptance/testdata/detector/container/cnb/custom_buildpacks/always_detect_buildpack/always_detect_buildpack_version/buildpack.toml
+++ b/acceptance/testdata/detector/container/cnb/custom_buildpacks/always_detect_buildpack/always_detect_buildpack_version/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.7"
+api = "0.6"
 [buildpack]
     id = "always_detect_buildpack"
     version = "always_detect_buildpack_version"

--- a/api/apis.go
+++ b/api/apis.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	Platform  = newApisMustParse([]string{"0.3", "0.4", "0.5", "0.6", "0.7"}, nil)
-	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.7"}, nil)
+	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6"}, nil)
 )
 
 type APIs struct {


### PR DESCRIPTION
We missed this when backing out asset packages.

Signed-off-by: Natalie Arellano <narellano@vmware.com>