### PR TITLE
Builder should warn if newer buildpacks write a bom in *.toml

### DIFF
--- a/buildpack/bom.go
+++ b/buildpack/bom.go
@@ -1,0 +1,96 @@
+package buildpack
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/buildpacks/lifecycle/api"
+)
+
+type BOMValidator interface {
+	ValidateBOM([]BOMEntry) error
+}
+
+func NewBOMValidator(bpAPI string, logger Logger) BOMValidator {
+	switch {
+	case api.MustParse(bpAPI).LessThan("0.5"):
+		return &LegacyBOMValidator{}
+	case api.MustParse(bpAPI).LessThan("0.7"):
+		return &StrictBOMValidator{}
+	default:
+		return &DefaultBOMValidator{Logger: logger}
+	}
+}
+
+type DefaultBOMValidator struct {
+	Logger Logger
+}
+
+func (v *DefaultBOMValidator) ValidateBOM(bom []BOMEntry) error {
+	if len(bom) > 0 {
+		v.Logger.Warn("BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.bom.<ext>, launch.bom.<ext>, or build.bom.<ext>.")
+	}
+	return nil
+}
+
+type LegacyBOMValidator struct{}
+
+func (v *LegacyBOMValidator) ValidateBOM(bom []BOMEntry) error {
+	for _, entry := range bom {
+		if version, ok := entry.Metadata["version"]; ok {
+			metadataVersion := fmt.Sprintf("%v", version)
+			if entry.Version != "" && entry.Version != metadataVersion {
+				return errors.New("top level version does not match metadata version")
+			}
+		}
+	}
+	return nil
+}
+
+type StrictBOMValidator struct{}
+
+func (v *StrictBOMValidator) ValidateBOM(bom []BOMEntry) error {
+	for _, entry := range bom {
+		if entry.Version != "" {
+			return fmt.Errorf("bom entry '%s' has a top level version which is not allowed. The buildpack should instead set metadata.version", entry.Name)
+		}
+	}
+	return nil
+}
+
+type BOMHandler interface {
+	HandleBOM(GroupBuildpack, []BOMEntry) []BOMEntry
+}
+
+func NewBOMHandler(bpAPI string) BOMHandler {
+	switch {
+	case api.MustParse(bpAPI).LessThan("0.5"):
+		return &LegacyBOMHandler{}
+	case api.MustParse(bpAPI).LessThan("0.7"):
+		return &StrictBOMHandler{}
+	default:
+		return &DefaultBOMHandler{}
+	}
+}
+
+type DefaultBOMHandler struct{}
+
+func (h *DefaultBOMHandler) HandleBOM(_ GroupBuildpack, _ []BOMEntry) []BOMEntry {
+	return []BOMEntry{}
+}
+
+type LegacyBOMHandler struct{}
+
+func (h *LegacyBOMHandler) HandleBOM(buildpack GroupBuildpack, bom []BOMEntry) []BOMEntry {
+	bom = WithBuildpack(buildpack, bom)
+	for i := range bom {
+		bom[i].convertVersionToMetadata()
+	}
+	return bom
+}
+
+type StrictBOMHandler struct{}
+
+func (h *StrictBOMHandler) HandleBOM(buildpack GroupBuildpack, bom []BOMEntry) []BOMEntry {
+	return WithBuildpack(buildpack, bom)
+}

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -180,42 +180,12 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("build result", func() {
-				it("should get bom entries from launch.toml and unmet requires from build.toml", func() {
+				it("should get unmet requires from build.toml", func() {
 					bpPlan := buildpack.Plan{
 						Entries: []buildpack.Require{
-							{
-								Name:    "some-deprecated-bp-replace-version-dep",
-								Version: "some-version-orig", // top-level version is deprecated in buildpack API 0.3
-							},
-							{
-								Name:     "some-dep",
-								Metadata: map[string]interface{}{"version": "v1"},
-							},
-							{
-								Name:     "some-replace-version-dep",
-								Metadata: map[string]interface{}{"version": "some-version-orig"},
-							},
-							{
-								Name: "some-unmet-dep",
-							},
+							{Name: "some-dep"}, {Name: "some-other-dep"}, {Name: "some-unmet-dep"},
 						},
 					}
-
-					h.Mkfile(t,
-						"[[bom]]\n"+
-							`name = "some-deprecated-bp-replace-version-dep"`+"\n"+
-							"[bom.metadata]\n"+
-							`version = "some-version-new"`+"\n"+
-							"[[bom]]\n"+
-							`name = "some-dep"`+"\n"+
-							"[bom.metadata]\n"+
-							`version = "v1"`+"\n"+
-							"[[bom]]\n"+
-							`name = "some-replace-version-dep"`+"\n"+
-							"[bom.metadata]\n"+
-							`version = "some-version-new"`+"\n",
-						filepath.Join(appDir, "launch-A-v1.toml"),
-					)
 
 					h.Mkfile(t,
 						"[[unmet]]\n"+
@@ -229,36 +199,37 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					}
 
 					if s := cmp.Diff(br, buildpack.BuildResult{
-						BOM: []buildpack.BOMEntry{
-							{
-								Require: buildpack.Require{
-									Name:     "some-deprecated-bp-replace-version-dep",
-									Metadata: map[string]interface{}{"version": "some-version-new"},
-								},
-								Buildpack: buildpack.GroupBuildpack{ID: "A", Version: "v1"}, // no api, no homepage
-							},
-							{
-								Require: buildpack.Require{
-									Name:     "some-dep",
-									Metadata: map[string]interface{}{"version": "v1"},
-								},
-								Buildpack: buildpack.GroupBuildpack{ID: "A", Version: "v1"}, // no api, no homepage
-							},
-							{
-								Require: buildpack.Require{
-									Name:     "some-replace-version-dep",
-									Metadata: map[string]interface{}{"version": "some-version-new"},
-								},
-								Buildpack: buildpack.GroupBuildpack{ID: "A", Version: "v1"}, // no api, no homepage
-							},
-						},
-						Labels:      []buildpack.Label{},
-						MetRequires: []string{"some-deprecated-bp-replace-version-dep", "some-dep", "some-replace-version-dep"},
-						Processes:   []launch.Process{},
-						Slices:      []layers.Slice{},
+						MetRequires: []string{"some-dep", "some-other-dep"},
 					}); s != "" {
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
+				})
+
+				when("there is a bom in launch.toml", func() {
+					it("should warn", func() {
+						h.Mkfile(t,
+							"[[bom]]\n"+
+								`name = "some-dep"`+"\n"+
+								"[bom.metadata]\n"+
+								`version = "some-version"`+"\n",
+							filepath.Join(appDir, "launch-A-v1.toml"),
+						)
+
+						br, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
+						if err != nil {
+							t.Fatalf("Unexpected error:\n%s\n", err)
+						}
+
+						if s := cmp.Diff(br, buildpack.BuildResult{
+							BOM:       []buildpack.BOMEntry{},
+							Labels:    []buildpack.Label{},
+							Processes: []launch.Process{},
+							Slices:    []layers.Slice{},
+						}); s != "" {
+							t.Fatalf("Unexpected:\n%s\n", s)
+						}
+						assertLogEntry(t, logHandler, "BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.bom.<ext>, launch.bom.<ext>, or build.bom.<ext>.")
+					})
 				})
 
 				it("should include labels", func() {
@@ -278,7 +249,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					}
 
 					if s := cmp.Diff(br, buildpack.BuildResult{
-						BOM: nil,
+						BOM: []buildpack.BOMEntry{},
 						Labels: []buildpack.Label{
 							{Key: "some-key", Value: "some-value"},
 							{Key: "some-other-key", Value: "some-other-value"},
@@ -309,7 +280,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							t.Fatalf("Unexpected error:\n%s\n", err)
 						}
 						if s := cmp.Diff(br, buildpack.BuildResult{
-							BOM:         nil,
+							BOM:         []buildpack.BOMEntry{},
 							Labels:      []buildpack.Label{},
 							MetRequires: nil,
 							Processes: []launch.Process{
@@ -336,7 +307,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					}
 
 					if s := cmp.Diff(br, buildpack.BuildResult{
-						BOM:         nil,
+						BOM:         []buildpack.BOMEntry{},
 						Labels:      []buildpack.Label{},
 						MetRequires: nil,
 						Processes:   []launch.Process{},
@@ -503,34 +474,6 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						t.Fatalf("Incorrect error: %s\n", err)
 					}
 				})
-			})
-
-			it("should error when the launch bom has a top level version", func() {
-				mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), "TEST_ENV=Av1"), nil)
-				h.Mkfile(t,
-					"[[bom]]\n"+
-						`name = "some-dep"`+"\n"+
-						`version = "some-version"`+"\n",
-					filepath.Join(appDir, "launch-A-v1.toml"),
-				)
-				_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
-				h.AssertNotNil(t, err)
-				expected := "top level version which is not allowed"
-				h.AssertStringContains(t, err.Error(), expected)
-			})
-
-			it("should error when the build bom has a top level version", func() {
-				mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), "TEST_ENV=Av1"), nil)
-				h.Mkfile(t,
-					"[[bom]]\n"+
-						`name = "some-dep"`+"\n"+
-						`version = "some-version"`+"\n",
-					filepath.Join(appDir, "build-A-v1.toml"),
-				)
-				_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
-				h.AssertNotNil(t, err)
-				expected := "top level version which is not allowed"
-				h.AssertStringContains(t, err.Error(), expected)
 			})
 
 			when("invalid unmet entries", func() {
@@ -928,6 +871,123 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					expected := "Types table isn't supported in this buildpack api version. The launch, build and cache flags should be in the top level. Ignoring the values in the types table."
 					assertLogEntry(t, logHandler, expected)
 				})
+			})
+		})
+
+		when("buildpack api < 0.7", func() {
+			it.Before(func() {
+				bpTOML.API = "0.6"
+			})
+
+			it("should get bom entries from launch.toml and unmet requires from build.toml", func() {
+				mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), "TEST_ENV=Av1"), nil)
+
+				bpPlan := buildpack.Plan{
+					Entries: []buildpack.Require{
+						{
+							Name:    "some-deprecated-bp-replace-version-dep",
+							Version: "some-version-orig", // top-level version is deprecated in buildpack API 0.3
+						},
+						{
+							Name:     "some-dep",
+							Metadata: map[string]interface{}{"version": "v1"},
+						},
+						{
+							Name:     "some-replace-version-dep",
+							Metadata: map[string]interface{}{"version": "some-version-orig"},
+						},
+						{
+							Name: "some-unmet-dep",
+						},
+					},
+				}
+
+				h.Mkfile(t,
+					"[[bom]]\n"+
+						`name = "some-deprecated-bp-replace-version-dep"`+"\n"+
+						"[bom.metadata]\n"+
+						`version = "some-version-new"`+"\n"+
+						"[[bom]]\n"+
+						`name = "some-dep"`+"\n"+
+						"[bom.metadata]\n"+
+						`version = "v1"`+"\n"+
+						"[[bom]]\n"+
+						`name = "some-replace-version-dep"`+"\n"+
+						"[bom.metadata]\n"+
+						`version = "some-version-new"`+"\n",
+					filepath.Join(appDir, "launch-A-v1.toml"),
+				)
+
+				h.Mkfile(t,
+					"[[unmet]]\n"+
+						`name = "some-unmet-dep"`+"\n",
+					filepath.Join(appDir, "build-A-v1.toml"),
+				)
+
+				br, err := bpTOML.Build(bpPlan, config, mockEnv)
+				if err != nil {
+					t.Fatalf("Unexpected error:\n%s\n", err)
+				}
+
+				if s := cmp.Diff(br, buildpack.BuildResult{
+					BOM: []buildpack.BOMEntry{
+						{
+							Require: buildpack.Require{
+								Name:     "some-deprecated-bp-replace-version-dep",
+								Metadata: map[string]interface{}{"version": "some-version-new"},
+							},
+							Buildpack: buildpack.GroupBuildpack{ID: "A", Version: "v1"}, // no api, no homepage
+						},
+						{
+							Require: buildpack.Require{
+								Name:     "some-dep",
+								Metadata: map[string]interface{}{"version": "v1"},
+							},
+							Buildpack: buildpack.GroupBuildpack{ID: "A", Version: "v1"}, // no api, no homepage
+						},
+						{
+							Require: buildpack.Require{
+								Name:     "some-replace-version-dep",
+								Metadata: map[string]interface{}{"version": "some-version-new"},
+							},
+							Buildpack: buildpack.GroupBuildpack{ID: "A", Version: "v1"}, // no api, no homepage
+						},
+					},
+					Labels:      []buildpack.Label{},
+					MetRequires: []string{"some-deprecated-bp-replace-version-dep", "some-dep", "some-replace-version-dep"},
+					Processes:   []launch.Process{},
+					Slices:      []layers.Slice{},
+				}); s != "" {
+					t.Fatalf("Unexpected:\n%s\n", s)
+				}
+			})
+
+			it("should error when the launch bom has a top level version", func() {
+				mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), "TEST_ENV=Av1"), nil)
+				h.Mkfile(t,
+					"[[bom]]\n"+
+						`name = "some-dep"`+"\n"+
+						`version = "some-version"`+"\n",
+					filepath.Join(appDir, "launch-A-v1.toml"),
+				)
+				_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
+				h.AssertNotNil(t, err)
+				expected := "top level version which is not allowed"
+				h.AssertStringContains(t, err.Error(), expected)
+			})
+
+			it("should error when the build bom has a top level version", func() {
+				mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), "TEST_ENV=Av1"), nil)
+				h.Mkfile(t,
+					"[[bom]]\n"+
+						`name = "some-dep"`+"\n"+
+						`version = "some-version"`+"\n",
+					filepath.Join(appDir, "build-A-v1.toml"),
+				)
+				_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
+				h.AssertNotNil(t, err)
+				expected := "top level version which is not allowed"
+				h.AssertStringContains(t, err.Error(), expected)
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Natalie Arellano <narellano@vmware.com>