### PR TITLE
Bump imgutil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildpacks/lifecycle
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/apex/log v1.9.0
-	github.com/buildpacks/imgutil v0.0.0-20210818180451-66aea982d5dc
+	github.com/buildpacks/imgutil v0.0.0-20211001201950-cf7ae41c3771
 	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildpacks/imgutil v0.0.0-20210818180451-66aea982d5dc h1:0AyNL75M0OLaI2OrU5B8fwCCkB9Qd0sQpO2Dw178MBs=
-github.com/buildpacks/imgutil v0.0.0-20210818180451-66aea982d5dc/go.mod h1:ZfCbsFruoxG0vbEVMsX/afizEo4vn2e88Km7rJ1M2D8=
+github.com/buildpacks/imgutil v0.0.0-20211001201950-cf7ae41c3771 h1:QhUkvEeYhnyj80genY7ktXVLttVc52zstwPTUDrImvE=
+github.com/buildpacks/imgutil v0.0.0-20211001201950-cf7ae41c3771/go.mod h1:ZfCbsFruoxG0vbEVMsX/afizEo4vn2e88Km7rJ1M2D8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
Picks up https://github.com/buildpacks/imgutil/commit/d200acdf41fe8ba59753141d5987766cf71fdca8 to enable better sparse images for `podman`. 

Signed-off-by: Natalie Arellano <narellano@vmware.com>