### PR TITLE
Add new build constraints format.

### DIFF
--- a/acceptance/creator_test.go
+++ b/acceptance/creator_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance

--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance

--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -1,3 +1,4 @@
+//go:build acceptance
 // +build acceptance
 
 package acceptance

--- a/acceptance/testdata/launcher/exec.d/fd_unix.go
+++ b/acceptance/testdata/launcher/exec.d/fd_unix.go
@@ -1,4 +1,5 @@
-//+build linux darwin
+//go:build linux || darwin
+// +build linux darwin
 
 package main
 

--- a/acceptance/variables_unix.go
+++ b/acceptance/variables_unix.go
@@ -1,4 +1,5 @@
-//+build linux darwin
+//go:build linux || darwin
+// +build linux darwin
 
 package acceptance
 

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package archive

--- a/cmd/flags_unix.go
+++ b/cmd/flags_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package cmd

--- a/launch/exec_d_unix.go
+++ b/launch/exec_d_unix.go
@@ -1,4 +1,5 @@
-//+build linux darwin
+//go:build linux || darwin
+// +build linux darwin
 
 package launch
 

--- a/launch/launcher_unix.go
+++ b/launch/launcher_unix.go
@@ -1,4 +1,5 @@
-//+build linux darwin
+//go:build linux || darwin
+// +build linux darwin
 
 package launch
 

--- a/launch/testdata/cmd/execd/fd_unix.go
+++ b/launch/testdata/cmd/execd/fd_unix.go
@@ -1,4 +1,5 @@
-//+build linux darwin
+//go:build linux || darwin
+// +build linux darwin
 
 package main
 

--- a/launch/testhelpers/syscall_unix.go
+++ b/launch/testhelpers/syscall_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package testhelpers

--- a/launch/testhelpers/syscall_windows.go
+++ b/launch/testhelpers/syscall_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package testhelpers

--- a/layers/layers_unix_test.go
+++ b/layers/layers_unix_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package layers_test

--- a/lifecycle_unix_test.go
+++ b/lifecycle_unix_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package lifecycle_test

--- a/priv/sock_unix.go
+++ b/priv/sock_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package priv

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package priv


### PR DESCRIPTION
`make format` made these changes automatically.
For more context on the build constraint format change, see:
https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md

Signed-off-by: Mikey Boldt <mboldt@vmware.com>