### PR TITLE
Pass `platform` when executing `lifecycle` subcommands

### DIFF
--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -52,27 +52,27 @@ func main() {
 		if os.Args[1] == "-version" {
 			cmd.ExitWithVersion()
 		}
-		subcommand()
+		subcommand(platform)
 	}
 }
 
-func subcommand() {
+func subcommand(platform common.Platform) {
 	phase := filepath.Base(os.Args[1])
 	switch phase {
 	case "detect":
-		cmd.Run(&detectCmd{}, true)
+		cmd.Run(&detectCmd{detectArgs: detectArgs{platform: platform}}, true)
 	case "analyze":
-		cmd.Run(&analyzeCmd{}, true)
+		cmd.Run(&analyzeCmd{analyzeArgs: analyzeArgs{platform: platform}}, true)
 	case "restore":
-		cmd.Run(&restoreCmd{}, true)
+		cmd.Run(&restoreCmd{restoreArgs: restoreArgs{platform: platform}}, true)
 	case "build":
-		cmd.Run(&buildCmd{}, true)
+		cmd.Run(&buildCmd{buildArgs: buildArgs{platform: platform}}, true)
 	case "export":
-		cmd.Run(&exportCmd{}, true)
+		cmd.Run(&exportCmd{exportArgs: exportArgs{platform: platform}}, true)
 	case "rebase":
-		cmd.Run(&rebaseCmd{}, true)
+		cmd.Run(&rebaseCmd{platform: platform}, true)
 	case "create":
-		cmd.Run(&createCmd{}, true)
+		cmd.Run(&createCmd{platform: platform}, true)
 	default:
 		cmd.Exit(cmd.FailCode(cmd.CodeInvalidArgs, "unknown phase:", phase))
 	}


### PR DESCRIPTION
The `lifecycle <subcommand>` was not providing a platform, which was causing failures.

Before:
```
heroku@a6b654ba8d6e:/layers$ /cnb/lifecycle/lifecycle detect
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x9921c3]

goroutine 1 [running]:
main.(*detectCmd).Args(0xc000115d80, 0x0, 0xc0000a8020, 0x0, 0x0, 0x0, 0x80)
        /lifecycle/cmd/lifecycle/detector.go:52 +0x223
github.com/buildpacks/lifecycle/cmd.Run(0xb91620, 0xc000115d80, 0xad4a01)
        /lifecycle/cmd/command.go:55 +0x1ce
main.subcommand()
        /lifecycle/cmd/lifecycle/main.go:54 +0x2aa
main.main()
        /lifecycle/cmd/lifecycle/main.go:46 +0x26a
```
After:
```
heroku@a6b654ba8d6e:/layers$ /cnb/lifecycle/lifecycle detect
ERROR: No buildpack groups passed detection.
ERROR: failed to detect: buildpack(s) failed with err
```

https://buildpacks.slack.com/archives/CSFE49VGR/p1634058186133000 - Thread where issue was found/reported.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>