### PR TITLE
Get `make lint` to work out of the box with Go 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ install-mockgen:
 
 install-golangci-lint:
 	@echo "> Installing golangci-lint..."
-	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
+	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
 
 lint: install-golangci-lint
 	@echo "> Linting code..."

--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -185,7 +185,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 					it("command and args become shell-parsed tokens in a script", func() {
 						var val2 string
 						if runtime.GOOS == "windows" {
-							val2 = `"val with space"` //windows values with spaces must contain quotes
+							val2 = `"val with space"` // windows values with spaces must contain quotes
 						} else {
 							val2 = "val with space"
 						}

--- a/acceptance/variables_windows.go
+++ b/acceptance/variables_windows.go
@@ -19,7 +19,7 @@ var dockerSocketMount = []string{
 	"--user", "ContainerAdministrator",
 }
 
-//ctrPath equivalent to path.Join but converts to Windows slashes and drive prefix when needed
+// ctrPath equivalent to path.Join but converts to Windows slashes and drive prefix when needed
 func ctrPath(unixPathParts ...string) string {
 	unixPath := path.Join(unixPathParts...)
 	windowsPath := filepath.FromSlash(unixPath)

--- a/archive/extract_test.go
+++ b/archive/extract_test.go
@@ -57,8 +57,8 @@ func testExtract(t *testing.T, when spec.G, it spec.S) {
 				{"root/standarddir", os.ModeDir + 0755},
 				{"root/standarddir/somefile", 0644},
 				{"root/nonexistdirnotintar", os.ModeDir + os.FileMode(int(os.ModePerm)&^originalUmask)},
-				{"root/symlinkdir", os.ModeSymlink + 0777},  //symlink permissions are not preserved from archive
-				{"root/symlinkfile", os.ModeSymlink + 0777}, //symlink permissions are not preserved from archive
+				{"root/symlinkdir", os.ModeSymlink + 0777},  // symlink permissions are not preserved from archive
+				{"root/symlinkfile", os.ModeSymlink + 0777}, // symlink permissions are not preserved from archive
 			}
 		}
 	})

--- a/archive/reader.go
+++ b/archive/reader.go
@@ -39,6 +39,8 @@ func (tr *NormalizingTarReader) ExcludePaths(paths []string) {
 //  original Name
 func (tr *NormalizingTarReader) PrependDir(dir string) {
 	tr.headerOpts = append(tr.headerOpts, func(hdr *tar.Header) *tar.Header {
+		// Suppress gosec check for zip slip vulnerability, as we set dir in our code.
+		// #nosec G305
 		hdr.Name = filepath.Join(dir, hdr.Name)
 		return hdr
 	})

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -35,12 +35,12 @@ func Run(c Command, asSubcommand bool) {
 	c.DefineFlags()
 	if asSubcommand {
 		if err := flagSet.Parse(os.Args[2:]); err != nil {
-			//flagSet exits on error, we shouldn't get here
+			// flagSet exits on error, we shouldn't get here
 			Exit(err)
 		}
 	} else {
 		if err := flagSet.Parse(os.Args[1:]); err != nil {
-			//flagSet exits on error, we shouldn't get here
+			// flagSet exits on error, we shouldn't get here
 			Exit(err)
 		}
 	}

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -60,7 +60,7 @@ type exportArgs struct {
 
 	platform Platform
 
-	//construct if necessary before dropping privileges
+	// construct if necessary before dropping privileges
 	docker   client.CommonAPIClient
 	keychain authn.Keychain
 }

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -33,7 +33,7 @@ type rebaseCmd struct {
 
 	platform Platform
 
-	//set if necessary before dropping privileges
+	// set if necessary before dropping privileges
 	docker   client.CommonAPIClient
 	keychain authn.Keychain
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -16,7 +16,7 @@ const (
 
 func init() {
 	// TODO: uncomment when buildpacks/pack#493 (lifecycle containers with a tty) is implemented
-	//color.Disable(!terminal.IsTerminal(int(os.Stdout.Fd())))
+	// color.Disable(!terminal.IsTerminal(int(os.Stdout.Fd())))
 }
 
 var (

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1414,7 +1414,7 @@ func assertHasEntrypoint(t *testing.T, image *fakes.Image, entrypointPath string
 }
 
 func createTestLayer(id string, tmpDir string) (layers.Layer, error) {
-	tarPath := filepath.Join(tmpDir, "artifacts", strings.Replace(id, "/", "_", -1))
+	tarPath := filepath.Join(tmpDir, "artifacts", strings.ReplaceAll(id, "/", "_"))
 	f, err := os.Create(tarPath)
 	if err != nil {
 		return layers.Layer{}, err

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -8,17 +8,16 @@ linters:
     - deadcode
     - dogsled
     - errcheck
+    - exportloopref
     - gocritic
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - nakedret
-    - scopelint
+    - revive
     - staticcheck
     - structcheck
     - stylecheck
@@ -32,3 +31,15 @@ linters:
 linters-settings:
   goimports:
     local-prefixes: github.com/buildpacks/lifecycle
+  govet:
+    enable:
+      - fieldalignment
+
+
+issues:
+  exclude-rules:
+    # Ignore this minor optimization.
+    # See https://github.com/golang/go/issues/44877#issuecomment-794565908
+    - linters:
+        - govet
+      text: "pointer bytes could be"

--- a/image/image.go
+++ b/image/image.go
@@ -1,8 +1,6 @@
 package image
 
 import (
-	"fmt"
-
 	"github.com/buildpacks/imgutil/remote"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -57,7 +55,7 @@ func VerifyRegistryAccess(regInputs RegistryInputs, keychain authn.Keychain) err
 func verifyReadAccess(imageRef string, keychain authn.Keychain) error {
 	img, _ := remote.NewImage(imageRef, keychain)
 	if !img.CheckReadAccess() {
-		return errors.New(fmt.Sprintf("ensure registry read access to %s", imageRef))
+		return errors.Errorf("ensure registry read access to %s", imageRef)
 	}
 	return nil
 }
@@ -65,7 +63,7 @@ func verifyReadAccess(imageRef string, keychain authn.Keychain) error {
 func verifyReadWriteAccess(imageRef string, keychain authn.Keychain) error {
 	img, _ := remote.NewImage(imageRef, keychain)
 	if !img.CheckReadWriteAccess() {
-		return errors.New(fmt.Sprintf("ensure registry read/write access to %s", imageRef))
+		return errors.Errorf("ensure registry read/write access to %s", imageRef)
 	}
 	return nil
 }

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -45,7 +45,7 @@ type Buildpack struct {
 }
 
 func EscapeID(id string) string {
-	return strings.Replace(id, "/", "_", -1)
+	return strings.ReplaceAll(id, "/", "_")
 }
 
 func GetMetadataFilePath(layersDir string) string {

--- a/layer_metadata_restorer_test.go
+++ b/layer_metadata_restorer_test.go
@@ -388,12 +388,12 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 
 					files, err = ioutil.ReadDir(filepath.Join(layerDir, "metadata.buildpack"))
 					h.AssertNil(t, err)
-					//expect 1 file b/c of store.toml
+					// expect 1 file b/c of store.toml
 					h.AssertEq(t, len(files), 1)
 
 					files, err = ioutil.ReadDir(filepath.Join(layerDir, "no.cache.buildpack"))
 					h.AssertNil(t, err)
-					//expect 1 file b/c of store.toml
+					// expect 1 file b/c of store.toml
 					h.AssertEq(t, len(files), 1)
 				})
 

--- a/layers/factory.go
+++ b/layers/factory.go
@@ -76,7 +76,7 @@ func (f *Factory) writeLayer(id string, addEntries func(tw *archive.NormalizingT
 }
 
 func escape(id string) string {
-	return strings.Replace(id, "/", "_", -1)
+	return strings.ReplaceAll(id, "/", "_")
 }
 
 func parents(file string) ([]archive.PathInfo, error) {

--- a/layers/slices.go
+++ b/layers/slices.go
@@ -33,7 +33,7 @@ func (f *Factory) SliceLayers(dir string, slices []Slice) ([]Layer, error) {
 		return nil, err
 	}
 
-	//add one layer per slice
+	// add one layer per slice
 	for i, slice := range slices {
 		layerID := fmt.Sprintf("slice-%d", i+1)
 		layer, err := f.createLayerFromSlice(slice, sdir, layerID)
@@ -43,7 +43,7 @@ func (f *Factory) SliceLayers(dir string, slices []Slice) ([]Layer, error) {
 		sliceLayers = append(sliceLayers, layer)
 	}
 
-	//add remaining files in a single layer
+	// add remaining files in a single layer
 	layerID := fmt.Sprintf("slice-%d", len(slices)+1)
 	finalLayer, err := f.createLayerFromFiles(layerID, sdir, sdir.remainingFiles())
 	if err != nil {

--- a/rebaser.go
+++ b/rebaser.go
@@ -47,7 +47,7 @@ func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, add
 	}
 
 	if appStackID != newBaseStackID {
-		return RebaseReport{}, errors.New(fmt.Sprintf("incompatible stack: '%s' is not compatible with '%s'", newBaseStackID, appStackID))
+		return RebaseReport{}, fmt.Errorf("incompatible stack: '%s' is not compatible with '%s'", newBaseStackID, appStackID)
 	}
 
 	if err := validateMixins(appImage, newBaseImage); err != nil {

--- a/testhelpers/docker.go
+++ b/testhelpers/docker.go
@@ -49,7 +49,7 @@ func DockerRun(t *testing.T, image string, ops ...DockerCmdOp) string {
 	return Run(t, exec.Command("docker", append([]string{"run", "--rm"}, args...)...)) // #nosec G204
 }
 
-//DockerRunAndCopy runs a container and once stopped, outputCtrPath is copied to outputDir
+// DockerRunAndCopy runs a container and once stopped, outputCtrPath is copied to outputDir
 func DockerRunAndCopy(t *testing.T, containerName, outputDir, outputCtrPath, image string, ops ...DockerCmdOp) string {
 	ops = append(ops, WithFlags("--name", containerName))
 	args := formatArgs([]string{image}, ops...)
@@ -59,8 +59,8 @@ func DockerRunAndCopy(t *testing.T, containerName, outputDir, outputCtrPath, ima
 	return output
 }
 
-//DockerSeedRunAndCopy copies srcDir to container's srcCtrPath before container is started. Once stopped, outputCtrPath is copied to outputDir
-//On WCOW, only works when seeding to container directory (not a mounted volume)
+// DockerSeedRunAndCopy copies srcDir to container's srcCtrPath before container is started. Once stopped, outputCtrPath is copied to outputDir
+// On WCOW, only works when seeding to container directory (not a mounted volume)
 func DockerSeedRunAndCopy(t *testing.T, containerName, srcDir, srcCtrPath, outputDir, outputCtrPath, image string, ops ...DockerCmdOp) string {
 	ops = append(ops, WithFlags("--name", containerName))
 	args := formatArgs([]string{image}, ops...)
@@ -110,7 +110,7 @@ func PushImage(dockerCli dockercli.CommonAPIClient, ref string, auth string) err
 	return nil
 }
 
-//SeedDockerVolume only works with Linux daemons as Windows only mounts volumes for started containers
+// SeedDockerVolume only works with Linux daemons as Windows only mounts volumes for started containers
 func SeedDockerVolume(t *testing.T, srcPath string) string {
 	volumeName := "test-volume-" + RandString(10)
 	containerName := "test-volume-helper-" + RandString(10)

--- a/testhelpers/vars_darwin.go
+++ b/testhelpers/vars_darwin.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package testhelpers
 

--- a/testhelpers/vars_linux.go
+++ b/testhelpers/vars_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package testhelpers
 

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	layerPath, err := lifecycleLayer()
 	if err != nil {
-		log.Print("Failed to get the lifecycle layer:", err)
+		log.Fatal("Failed to get the lifecycle layer:", err)
 	}
 	if err := img.AddLayer(layerPath); err != nil {
 		log.Fatal("Failed to add layer:", err)


### PR DESCRIPTION
As a new contributor to lifecycle, when I cloned the code and ran `make all`, the lint step failed with `golangci-lint` segfaulting (I'm on Mac, fwiw). The version of golangci-lint we're pinned to (1.30.0) [does not support go 1.17](https://github.com/golangci/golangci-lint/issues/2197).

The goal of this PR is to get this step to work out of the box, which will smooth out the new contributor experience, while also bringing our linting up to date.

I've updated golagci-lint to the latest version (1.42.1). This update brought with it warnings about some of the tools it uses underneath being deprecated:

```
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref. 
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
```

I've swapped out the deprecated tools with their suggested replacements, and made code changes to pass the new lint checks.

Some lint errors will be fixed by #746 (related to goimports); I did not duplicate those fixes here, and ideally that PR would be merged before this one.

Most of the changes are pretty benign (e.g., ensure a space after `//`). The changes in tools/image/main.go were a little more involved, changing error handling to ensure that deferred actions run, so could use a good review. Perhaps avoiding the deferred cleanup on error was intentional, which would warrant a different fix (i.e., don't defer the cleanup; just perform it inline after a successful run).