### PR TITLE
Automatically update lifecycle.toml when new apis are added

### DIFF
--- a/api/apis.go
+++ b/api/apis.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -10,8 +13,18 @@ var (
 )
 
 type APIs struct {
-	Supported  []*Version
-	Deprecated []*Version
+	Supported  List
+	Deprecated List
+}
+
+type List []*Version
+
+func (l List) String() string {
+	var els []string
+	for _, el := range l {
+		els = append(els, fmt.Sprintf("%q", el.String()))
+	}
+	return "[" + strings.Join(els, ", ") + "]"
 }
 
 // newApisMustParse calls NewApis and panics on error

--- a/lifecycle.toml
+++ b/lifecycle.toml
@@ -1,10 +1,10 @@
 [apis]
 [apis.buildpack]
-  deprecated = []
-  supported = ["0.2", "0.3", "0.4", "0.5", "0.6"]
+  deprecated = {{.apis_buildpack_deprecated}}
+  supported = {{.apis_buildpack_supported}}
 [apis.platform]
-  deprecated = []
-  supported = ["0.3", "0.4", "0.5", "0.6", "0.7"]
+  deprecated = {{.apis_platform_deprecated}}
+  supported = {{.apis_platform_supported}}
 
 # For backwards compatibility the minimum supported APIs are provided in RFC-0011 format
 # https://github.com/buildpacks/rfcs/blob/main/text/0011-lifecycle-descriptor.md

--- a/tools/packager/main.go
+++ b/tools/packager/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/archive"
 )
 
@@ -65,7 +66,13 @@ func doPackage() error {
 		return errors.Wrap(err, fmt.Sprintf("Failed to read descriptor file %s", descriptorPath))
 	}
 
-	descriptorContents, err := fillTemplate(templateContents, map[string]interface{}{"lifecycle_version": version})
+	descriptorContents, err := fillTemplate(templateContents, map[string]interface{}{
+		"lifecycle_version":         version,
+		"apis_buildpack_supported":  api.Buildpack.Supported.String(),
+		"apis_buildpack_deprecated": api.Buildpack.Deprecated.String(),
+		"apis_platform_supported":   api.Platform.Supported.String(),
+		"apis_platform_deprecated":  api.Platform.Deprecated.String(),
+	})
 	if err != nil {
 		return errors.Wrap(err, "Failed to fill template")
 	}


### PR DESCRIPTION
If we forget to update lifecycle.toml, this could cause some platform validations to fail.

To verify:
Manually edit api/apis.go to contain some new apis:
```
var (
	Platform  = newApisMustParse([]string{"0.3", "0.4", "0.5", "0.6", "0.7", "0.99"}, nil)
	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.99"}, nil)
)
```
Run `make clean build-linux-amd64 package-linux-amd64 && cd out && tar xzvf lifecycle-*+linux.x86-64.tgz && cat lifecycle.toml`

Before:
lifecycle.toml is not updated

After:
lifecycle.toml is updated
