### PR TITLE
Don't print warnings about run image for older platform apis

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -357,6 +357,29 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 						})
 					})
 				})
+
+				when("older platform", func() {
+					it("does not print log warnings", func() {
+						h.SkipIf(t, api.MustParse(platformAPI).AtLeast("0.7"), "Platform API >= 0.7 accepts run image")
+
+						output := h.DockerRunAndCopy(t,
+							containerName,
+							copyDir,
+							ctrPath("/layers/analyzed.toml"),
+							analyzeImage,
+							h.WithFlags(
+								"--env", "CNB_PLATFORM_API="+platformAPI,
+								"--env", "CNB_REGISTRY_AUTH="+analyzeRegAuthConfig,
+								"--env", "CNB_RUN_IMAGE="+analyzeRegFixtures.ReadOnlyRunImage,
+								"--network", analyzeRegNetwork,
+							),
+							h.WithArgs(ctrPath(analyzerPath), analyzeRegFixtures.SomeAppImage),
+						)
+
+						h.AssertStringDoesNotContain(t, output, `no stack metadata found at path ''`)
+						h.AssertStringDoesNotContain(t, output, `Previous image with name "" not found`)
+					})
+				})
 			})
 		})
 

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -120,17 +120,19 @@ func (a *analyzeCmd) Args(nargs int, args []string) error {
 		a.platform06.groupPath = cmd.DefaultGroupPath(a.platform.API(), a.layersDir)
 	}
 
-	stackMD, err := readStack(a.stackPath)
-	if err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "parse stack metadata")
-	}
+	if a.supportsRunImage() {
+		stackMD, err := readStack(a.stackPath)
+		if err != nil {
+			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "parse stack metadata")
+		}
 
-	if err := a.validateRunImageInput(); err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate run image input")
-	}
+		if err := a.validateRunImageInput(); err != nil {
+			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate run image input")
+		}
 
-	if err := a.populateRunImage(stackMD, targetRegistry); err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "populate run image")
+		if err := a.populateRunImage(stackMD, targetRegistry); err != nil {
+			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "populate run image")
+		}
 	}
 
 	return nil
@@ -240,6 +242,10 @@ func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
 }
 
 func (aa analyzeArgs) localOrRemote(fromImage string) (imgutil.Image, error) {
+	if fromImage == "" {
+		return nil, nil
+	}
+
 	if aa.useDaemon {
 		return local.NewImage(
 			fromImage,


### PR DESCRIPTION
Fixes https://github.com/buildpacks/lifecycle/issues/754

This bug is really pointing to an ever-more-urgent need to refactor aspects of the `cmd` package, but I am holding off on that for now.