### PR TITLE
Use sbom instead of bom as filename prefix for consistency

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -175,10 +175,10 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				buildpackStore.EXPECT().Lookup("A", "v1").Return(bpA, nil)
 				buildpackStore.EXPECT().Lookup("B", "v2").Return(bpB, nil)
 
-				bomFilePath1 := filepath.Join(layersDir, "launch.bom.cdx.json")
-				bomFilePath2 := filepath.Join(layersDir, "build.bom.cdx.json")
-				bomFilePath3 := filepath.Join(layersDir, "layer-b1.bom.cdx.json")
-				bomFilePath4 := filepath.Join(layersDir, "layer-b2.bom.cdx.json")
+				bomFilePath1 := filepath.Join(layersDir, "launch.sbom.cdx.json")
+				bomFilePath2 := filepath.Join(layersDir, "build.sbom.cdx.json")
+				bomFilePath3 := filepath.Join(layersDir, "layer-b1.sbom.cdx.json")
+				bomFilePath4 := filepath.Join(layersDir, "layer-b2.sbom.cdx.json")
 				h.Mkfile(t, `{"key": "some-bom-content-1"}`, bomFilePath1)
 				h.Mkfile(t, `{"key": "some-bom-content-2"}`, bomFilePath2)
 				h.Mkfile(t, `{"key": "some-bom-content-3"}`, bomFilePath3)
@@ -228,19 +228,19 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					t.Fatalf("Unexpected error:\n%s\n", err)
 				}
 
-				result := h.MustReadFile(t, filepath.Join(layersDir, "sbom", "launch", "A", "bom.cdx.json"))
+				result := h.MustReadFile(t, filepath.Join(layersDir, "sbom", "launch", "A", "sbom.cdx.json"))
 				h.AssertEq(t, string(result), `{"key": "some-bom-content-1"}`)
 
-				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "build", "A", "bom.cdx.json"))
+				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "build", "A", "sbom.cdx.json"))
 				h.AssertEq(t, string(result), `{"key": "some-bom-content-2"}`)
 
-				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "build", "B", "layer-b1", "bom.cdx.json"))
+				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "build", "B", "layer-b1", "sbom.cdx.json"))
 				h.AssertEq(t, string(result), `{"key": "some-bom-content-3"}`)
 
-				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "cache", "B", "layer-b1", "bom.cdx.json"))
+				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "cache", "B", "layer-b1", "sbom.cdx.json"))
 				h.AssertEq(t, string(result), `{"key": "some-bom-content-3"}`)
 
-				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "launch", "B", "layer-b2", "bom.cdx.json"))
+				result = h.MustReadFile(t, filepath.Join(layersDir, "sbom", "launch", "B", "layer-b2", "sbom.cdx.json"))
 				h.AssertEq(t, string(result), `{"key": "some-bom-content-4"}`)
 			})
 
@@ -250,8 +250,8 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				buildpackStore.EXPECT().Lookup("A", "v1").Return(bpA, nil)
 				buildpackStore.EXPECT().Lookup("B", "v2").Return(bpB, nil)
 
-				bomFilePath1 := filepath.Join(layersDir, "launch.bom.cdx.json")
-				bomFilePath2 := filepath.Join(layersDir, "layer-b.bom.some-unknown-format.json")
+				bomFilePath1 := filepath.Join(layersDir, "launch.sbom.cdx.json")
+				bomFilePath2 := filepath.Join(layersDir, "layer-b.sbom.some-unknown-format.json")
 				h.Mkfile(t, `{"key": "some-bom-content-a"}`, bomFilePath1)
 				h.Mkfile(t, `{"key": "some-bom-content-b"}`, bomFilePath2)
 

--- a/buildpack/bom.go
+++ b/buildpack/bom.go
@@ -35,7 +35,7 @@ func (v *defaultBOMValidator) ValidateBOM(bp GroupBuildpack, bom []BOMEntry) ([]
 
 func (v *defaultBOMValidator) validateBOM(bom []BOMEntry) error {
 	if len(bom) > 0 {
-		v.logger.Warn("BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.bom.<ext>, launch.bom.<ext>, or build.bom.<ext>.")
+		v.logger.Warn("BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>.")
 	}
 	return nil
 }

--- a/buildpack/bomfile.go
+++ b/buildpack/bomfile.go
@@ -40,11 +40,11 @@ type BOMFile struct {
 func (b *BOMFile) Name() (string, error) {
 	switch b.mediaType() {
 	case mediaTypeCycloneDX:
-		return "bom.cdx.json", nil
+		return "sbom.cdx.json", nil
 	case mediaTypeSPDX:
-		return "bom.spdx.json", nil
+		return "sbom.spdx.json", nil
 	case mediaTypeSyft:
-		return "bom.syft.json", nil
+		return "sbom.syft.json", nil
 	default:
 		return "", errors.Errorf("unsupported bom format: '%s'", b.Path)
 	}
@@ -54,11 +54,11 @@ func (b *BOMFile) mediaType() string {
 	name := filepath.Base(b.Path)
 
 	switch {
-	case strings.HasSuffix(name, "bom.cdx.json"):
+	case strings.HasSuffix(name, ".sbom.cdx.json"):
 		return mediaTypeCycloneDX
-	case strings.HasSuffix(name, "bom.spdx.json"):
+	case strings.HasSuffix(name, ".sbom.spdx.json"):
 		return mediaTypeSPDX
-	case strings.HasSuffix(name, "bom.syft.json"):
+	case strings.HasSuffix(name, ".sbom.syft.json"):
 		return mediaTypeSyft
 	default:
 		return mediaTypeUnsupported
@@ -92,7 +92,7 @@ func validateMediaTypes(bp GroupBuildpack, bomfiles []BOMFile, sbomMediaTypes []
 
 func processBOMFiles(layersDir string, bp GroupBuildpack, pathToLayerMetadataFile map[string]layertypes.LayerMetadataFile, sbomMediaTypes []string) ([]BOMFile, error) {
 	var (
-		layerGlob = filepath.Join(layersDir, "*.bom.*.json")
+		layerGlob = filepath.Join(layersDir, "*.sbom.*.json")
 		files     []BOMFile
 	)
 

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -228,7 +228,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						}); s != "" {
 							t.Fatalf("Unexpected:\n%s\n", s)
 						}
-						assertLogEntry(t, logHandler, "BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.bom.<ext>, launch.bom.<ext>, or build.bom.<ext>.")
+						assertLogEntry(t, logHandler, "BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>.")
 					})
 				})
 
@@ -240,9 +240,9 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.Mkdir(t,
 						filepath.Join(layersDir, buildpackID))
 					h.Mkfile(t, `{"key": "some-bom-content"}`,
-						filepath.Join(layersDir, buildpackID, "launch.bom.cdx.json"),
-						filepath.Join(layersDir, buildpackID, "build.bom.cdx.json"),
-						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.cdx.json", layerName)))
+						filepath.Join(layersDir, buildpackID, "launch.sbom.cdx.json"),
+						filepath.Join(layersDir, buildpackID, "build.sbom.cdx.json"),
+						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.cdx.json", layerName)))
 
 					h.Mkdir(t,
 						filepath.Join(layersDir, buildpackID, layerName))
@@ -260,25 +260,25 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 								BuildpackID: buildpackID,
 								LayerName:   "",
 								LayerType:   buildpack.LayerTypeBuild,
-								Path:        filepath.Join(layersDir, buildpackID, "build.bom.cdx.json"),
+								Path:        filepath.Join(layersDir, buildpackID, "build.sbom.cdx.json"),
 							},
 							{
 								BuildpackID: buildpackID,
 								LayerName:   "",
 								LayerType:   buildpack.LayerTypeLaunch,
-								Path:        filepath.Join(layersDir, buildpackID, "launch.bom.cdx.json"),
+								Path:        filepath.Join(layersDir, buildpackID, "launch.sbom.cdx.json"),
 							},
 							{
 								BuildpackID: buildpackID,
 								LayerName:   layerName,
 								LayerType:   buildpack.LayerTypeBuild,
-								Path:        filepath.Join(layersDir, buildpackID, "some-layer.bom.cdx.json"),
+								Path:        filepath.Join(layersDir, buildpackID, "some-layer.sbom.cdx.json"),
 							},
 							{
 								BuildpackID: buildpackID,
 								LayerName:   layerName,
 								LayerType:   buildpack.LayerTypeCache,
-								Path:        filepath.Join(layersDir, buildpackID, "some-layer.bom.cdx.json"),
+								Path:        filepath.Join(layersDir, buildpackID, "some-layer.sbom.cdx.json"),
 							},
 						},
 					}, br)
@@ -292,13 +292,13 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.Mkdir(t,
 						filepath.Join(layersDir, buildpackID, layerName))
 					h.Mkfile(t, `{"key": "some-bom-content"}`,
-						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.cdx.json", layerName)),
-						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.spdx.json", layerName)),
-						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.syft.json", layerName)),
-						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.some-unknown-format.json", layerName)))
+						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.cdx.json", layerName)),
+						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.spdx.json", layerName)),
+						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.syft.json", layerName)),
+						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.some-unknown-format.json", layerName)))
 
 					_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
-					h.AssertError(t, err, fmt.Sprintf("unsupported bom format: '%s'", filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.some-unknown-format.json", layerName))))
+					h.AssertError(t, err, fmt.Sprintf("unsupported bom format: '%s'", filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.some-unknown-format.json", layerName))))
 				})
 
 				it("returns an error for any undeclared BOM media type", func() {
@@ -308,7 +308,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.Mkdir(t,
 						filepath.Join(layersDir, buildpackID))
 					h.Mkfile(t, `{"key": "some-bom-content"}`,
-						filepath.Join(layersDir, buildpackID, "launch.bom.spdx.json"))
+						filepath.Join(layersDir, buildpackID, "launch.sbom.spdx.json"))
 
 					_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
 					h.AssertError(t, err, "sbom type 'application/spdx+json' not declared for buildpack: 'A@v1'")
@@ -322,9 +322,9 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 					h.Mkdir(t,
 						filepath.Join(layersDir, buildpackID))
 					h.Mkfile(t, `{"key": "some-bom-content"}`,
-						filepath.Join(layersDir, buildpackID, "launch.bom.cdx.json"),
-						filepath.Join(layersDir, buildpackID, "build.bom.cdx.json"),
-						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.bom.cdx.json", layerName)))
+						filepath.Join(layersDir, buildpackID, "launch.sbom.cdx.json"),
+						filepath.Join(layersDir, buildpackID, "build.sbom.cdx.json"),
+						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.sbom.cdx.json", layerName)))
 
 					h.Mkdir(t,
 						filepath.Join(layersDir, buildpackID, layerName))


### PR DESCRIPTION
Updates to SBOM based on [spec discussion](https://github.com/buildpacks/spec/pull/269).

