### PR TITLE
Error when previous bom is specified on buildpack API 0.7

### DIFF
--- a/buildpack/bom.go
+++ b/buildpack/bom.go
@@ -35,7 +35,7 @@ func (v *defaultBOMValidator) ValidateBOM(bp GroupBuildpack, bom []BOMEntry) ([]
 
 func (v *defaultBOMValidator) validateBOM(bom []BOMEntry) error {
 	if len(bom) > 0 {
-		v.logger.Warn("BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>.")
+		return errors.New("bom table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>")
 	}
 	return nil
 }

--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -267,6 +267,12 @@ func (b *Descriptor) readOutputFiles(bpLayersDir, bpPlanPath string, bpPlanIn Pl
 		}
 		br.MetRequires = names(bpPlanOut.Entries)
 
+		// set BOM files
+		br.BOMFiles, err = b.processBOMFiles(bpLayersDir, bpFromBpInfo, pathToLayerMetadataFile, logger)
+		if err != nil {
+			return BuildResult{}, err
+		}
+
 		// read launch.toml, return if not exists
 		if _, err := toml.DecodeFile(launchPath, &launchTOML); os.IsNotExist(err) {
 			return br, nil
@@ -291,11 +297,9 @@ func (b *Descriptor) readOutputFiles(bpLayersDir, bpPlanPath string, bpPlanIn Pl
 		br.MetRequires = names(bpPlanIn.filter(bpBuild.Unmet).Entries)
 
 		// set BOM files
-		if api.MustParse(b.API).AtLeast("0.7") {
-			br.BOMFiles, err = processBOMFiles(bpLayersDir, bpFromBpInfo, pathToLayerMetadataFile, b.Buildpack.SBOM)
-			if err != nil {
-				return BuildResult{}, err
-			}
+		br.BOMFiles, err = b.processBOMFiles(bpLayersDir, bpFromBpInfo, pathToLayerMetadataFile, logger)
+		if err != nil {
+			return BuildResult{}, err
 		}
 
 		// read launch.toml, return if not exists

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -238,9 +238,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.toml", layerName)))
 
 					br, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
-					if err != nil {
-						t.Fatalf("Unexpected error:\n%s\n", err)
-					}
+					h.AssertNil(t, err)
 
 					h.AssertEq(t, buildpack.BuildResult{
 						BOMFiles: []buildpack.BOMFile{
@@ -320,11 +318,11 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 						filepath.Join(layersDir, buildpackID, fmt.Sprintf("%s.toml", layerName)))
 
 					br, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
-					if err != nil {
-						t.Fatalf("Unexpected error:\n%s\n", err)
-					}
+					h.AssertNil(t, err)
 
 					h.AssertEq(t, len(br.BOMFiles), 0)
+					expected := "the following SBoM files will be ignored for buildpack api version < 0.7"
+					assertLogEntry(t, logHandler, expected)
 				})
 
 				it("should include labels", func() {

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -206,7 +206,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("there is a bom in launch.toml", func() {
-					it("should warn", func() {
+					it("should return error", func() {
 						h.Mkfile(t,
 							"[[bom]]\n"+
 								`name = "some-dep"`+"\n"+
@@ -215,20 +215,8 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 							filepath.Join(appDir, "launch-A-v1.toml"),
 						)
 
-						br, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
-						if err != nil {
-							t.Fatalf("Unexpected error:\n%s\n", err)
-						}
-
-						if s := cmp.Diff(br, buildpack.BuildResult{
-							BOM:       []buildpack.BOMEntry{},
-							Labels:    []buildpack.Label{},
-							Processes: []launch.Process{},
-							Slices:    []layers.Slice{},
-						}); s != "" {
-							t.Fatalf("Unexpected:\n%s\n", s)
-						}
-						assertLogEntry(t, logHandler, "BOM table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>.")
+						_, err := bpTOML.Build(buildpack.Plan{}, config, mockEnv)
+						h.AssertError(t, err, "bom table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>")
 					})
 				})
 


### PR DESCRIPTION
if you are on buildpack API version 0.7 and output old style bom information, return error 🛑 
if you are on buildpack API version <0.7 and output new style SBoM information, show warning ⚠️ 

<img width="925" alt="Screen Shot 2021-11-15 at 3 11 08 PM" src="https://user-images.githubusercontent.com/4236888/141848446-65091d4b-9a79-4893-868f-c967627fa175.png">

cc: @dmikusa-pivotal