### PR TITLE
Update buildpack.toml to use sbom-formats

### DIFF
--- a/buildpack/descriptor.go
+++ b/buildpack/descriptor.go
@@ -27,7 +27,7 @@ type Info struct {
 	ID       string   `toml:"id"`
 	Name     string   `toml:"name"`
 	Version  string   `toml:"version"`
-	SBOM     []string `toml:"sbom,omitempty" json:"sbom,omitempty"`
+	SBOM     []string `toml:"sbom-formats,omitempty" json:"sbom-formats,omitempty"`
 }
 
 type Order []Group

--- a/buildpack/store_test.go
+++ b/buildpack/store_test.go
@@ -1,0 +1,40 @@
+package buildpack_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/buildpacks/lifecycle/buildpack"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestStore(t *testing.T) {
+	spec.Run(t, "Store", testStore, spec.Report(report.Terminal{}))
+}
+
+func testStore(t *testing.T, when spec.G, it spec.S) {
+	var store *buildpack.DirBuildpackStore
+
+	it.Before(func() {
+		var err error
+		store, err = buildpack.NewBuildpackStore(filepath.Join("testdata", "by-id"))
+		h.AssertNil(t, err)
+	})
+
+	when("Lookup", func() {
+		it("returns buildpack from buildpack.toml", func() {
+			bp, err := store.Lookup("A", "v1")
+			h.AssertNil(t, err)
+
+			config := bp.ConfigFile()
+			h.AssertEq(t, config.Buildpack.ID, "A")
+			h.AssertEq(t, config.Buildpack.Name, "Buildpack A")
+			h.AssertEq(t, config.Buildpack.Version, "v1")
+			h.AssertEq(t, config.Buildpack.Homepage, "Buildpack A Homepage")
+			h.AssertEq(t, config.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+		})
+	})
+}

--- a/buildpack/testdata/by-id/A/v1.clear/buildpack.toml
+++ b/buildpack/testdata/by-id/A/v1.clear/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.3"
+api = "0.7"
 
 [buildpack]
 id = "A"

--- a/buildpack/testdata/by-id/A/v1/buildpack.toml
+++ b/buildpack/testdata/by-id/A/v1/buildpack.toml
@@ -1,7 +1,8 @@
-api = "0.3"
+api = "0.7"
 
 [buildpack]
 id = "A"
 name = "Buildpack A"
 version = "v1"
 homepage = "Buildpack A Homepage"
+sbom-formats = ["application/vnd.cyclonedx+json"]


### PR DESCRIPTION
This change was suggested in the spec PR review.