### PR TITLE
Fix pack acceptance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,6 +235,10 @@ jobs:
           path: 'pack'
           ref: 'main'
           fetch-depth: 0 # fetch all history for all branches and tags
+      - name: Set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - uses: actions/download-artifact@v2
         with:
           name: version
@@ -267,6 +271,10 @@ jobs:
           path: 'pack'
           ref: 'main'
           fetch-depth: 0 # fetch all history for all branches and tags
+      - name: Set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - name: Add runner IP to daemon insecure-registries and firewall
         shell: powershell
         run: |


### PR DESCRIPTION
We are currently seeing failures such as [here](https://github.com/buildpacks/lifecycle/actions/runs/1517187264) because pack upgraded to go 1.17 in the latest release and the runner only comes with 1.15 by default.