### PR TITLE
Don't run restorer tests for every buildpack api

### DIFF
--- a/restorer_test.go
+++ b/restorer_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestRestorer(t *testing.T) {
-	for _, buildpackAPI := range api.Buildpack.Supported {
-		buildpackAPIStr := buildpackAPI.String()
+	for _, buildpackAPIStr := range []string{"0.5", api.Buildpack.Latest().String()} {
 		for _, platformAPI := range api.Platform.Supported {
 			platformAPIStr := platformAPI.String()
 			spec.Run(


### PR DESCRIPTION
The only place the restorer uses the buildpack api is [here](https://github.com/buildpacks/lifecycle/blob/42be2d161b283c8f831f78a695df4c7c35782709/restorer.go#L48). It's probably not necessary to run the test suite for every combination of buildpack api & platform api (36 combinations) when there are only two modes of buildpack behavior.

To take it further, looking at the comment [here](https://github.com/buildpacks/lifecycle/blob/42be2d161b283c8f831f78a695df4c7c35782709/restorer.go#L56-L59), the edge case mentioned "the cache was cleared between builds and the analyzer that wrote the files is on a previous version of the lifecycle" is quite narrow and unlikely to occur given that the last lifecycle with the old behavior is several months old. I wonder if we could just have the restorer always look in the cache metadata to determine the layer type.