### PR TITLE
Organize analyze inputs

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -8,7 +8,7 @@ import (
 
 // Command defines the interface for running the lifecycle phases
 type Command interface {
-	// DefineFlags defines flags
+	// DefineFlags defines the flags that are considered valid and reads their values (if provided)
 	DefineFlags()
 
 	// Args validates arguments and flags, and fills in default values

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -11,7 +11,7 @@ type Command interface {
 	// DefineFlags defines flags
 	DefineFlags()
 
-	// Args validates arguments and flags
+	// Args validates arguments and flags, and fills in default values
 	Args(nargs int, args []string) error
 
 	// Privileges validates the needed privileges

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -23,88 +23,86 @@ import (
 )
 
 type analyzeCmd struct {
-	//flags: inputs
-	analyzeArgs
-	stackPath string
-	uid, gid  int
-
-	//flags: paths to write data
-	analyzedPath string
+	analyzeInputsForCreator
+	additionalTags  cmd.StringSlice
+	analyzedPath    string
+	cacheImageRef   string
+	legacyCacheDir  string
+	legacyGroupPath string
+	outputImageRef  string
+	stackPath       string
+	uid, gid        int
 }
 
-type analyzeArgs struct {
-	cacheImageRef    string
+// Inputs needed when run by creator
+type analyzeInputsForCreator struct {
 	layersDir        string
-	outputImageRef   string
 	previousImageRef string
 	runImageRef      string
+	legacySkipLayers bool
 	useDaemon        bool
 
-	additionalTags cmd.StringSlice
-	docker         client.CommonAPIClient // construct if necessary before dropping privileges
-	keychain       authn.Keychain
-	platform       Platform
-	platform06     analyzeArgsPlatform06
-}
-
-type analyzeArgsPlatform06 struct {
-	cacheDir   string // not needed when run by creator
-	groupPath  string // not needed when run by creator
-	skipLayers bool
-	cache      lifecycle.Cache
-	group      buildpack.Group
+	docker      client.CommonAPIClient // construct if necessary before dropping privileges
+	keychain    authn.Keychain         // construct if necessary before dropping privileges
+	legacyCache lifecycle.Cache
+	legacyGroup buildpack.Group
+	platform    Platform
 }
 
 func (a *analyzeCmd) DefineFlags() {
 	cmd.FlagAnalyzedPath(&a.analyzedPath)
 	cmd.FlagCacheImage(&a.cacheImageRef)
+	cmd.FlagGID(&a.gid)
 	cmd.FlagLayersDir(&a.layersDir)
+	cmd.FlagUID(&a.uid)
+	cmd.FlagUseDaemon(&a.useDaemon)
 	if a.platformAPIVersionGreaterThan06() {
 		cmd.FlagPreviousImage(&a.previousImageRef)
 		cmd.FlagRunImage(&a.runImageRef)
 		cmd.FlagStackPath(&a.stackPath)
 		cmd.FlagTags(&a.additionalTags)
 	} else {
-		cmd.FlagCacheDir(&a.platform06.cacheDir)
-		cmd.FlagGroupPath(&a.platform06.groupPath)
-		cmd.FlagSkipLayers(&a.platform06.skipLayers)
+		cmd.FlagCacheDir(&a.legacyCacheDir)
+		cmd.FlagGroupPath(&a.legacyGroupPath)
+		cmd.FlagSkipLayers(&a.legacySkipLayers)
 	}
-	cmd.FlagUseDaemon(&a.useDaemon)
-	cmd.FlagUID(&a.uid)
-	cmd.FlagGID(&a.gid)
 }
 
 func (a *analyzeCmd) Args(nargs int, args []string) error {
+	// define args
 	if nargs != 1 {
 		return cmd.FailErrCode(fmt.Errorf("received %d arguments, but expected 1", nargs), cmd.CodeInvalidArgs, "parse arguments")
 	}
-
-	if args[0] == "" {
-		return cmd.FailErrCode(errors.New("image argument is required"), cmd.CodeInvalidArgs, "parse arguments")
-	}
 	a.outputImageRef = args[0]
 
-	if a.restoresLayerMetadata() {
-		if a.cacheImageRef == "" && a.platform06.cacheDir == "" {
-			cmd.DefaultLogger.Warn("Not restoring cached layer metadata, no cache flag specified.")
-		}
+	// validate args
+	if a.outputImageRef == "" {
+		return cmd.FailErrCode(errors.New("image argument is required"), cmd.CodeInvalidArgs, "parse arguments")
 	}
 
-	targetRegistry, err := parseRegistry(a.outputImageRef)
-	if err != nil {
-		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "parse target registry")
+	// fill in values
+	if a.analyzedPath == cmd.PlaceholderAnalyzedPath {
+		a.analyzedPath = cmd.DefaultAnalyzedPath(a.platform.API().String(), a.layersDir)
+	}
+
+	if a.legacyGroupPath == cmd.PlaceholderGroupPath {
+		a.legacyGroupPath = cmd.DefaultGroupPath(a.platform.API().String(), a.layersDir)
 	}
 
 	if a.previousImageRef == "" {
 		a.previousImageRef = a.outputImageRef
-	} else if !a.useDaemon {
-		previousRegistry, err := parseRegistry(a.previousImageRef)
-		if err != nil {
-			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "parse previous registry")
+	}
+
+	// validate flags
+	if a.restoresLayerMetadata() {
+		if a.cacheImageRef == "" && a.legacyCacheDir == "" {
+			cmd.DefaultLogger.Warn("Not restoring cached layer metadata, no cache flag specified.")
 		}
-		if previousRegistry != targetRegistry {
-			err := fmt.Errorf("previous image is on a different registry %s from the exported image %s", previousRegistry, targetRegistry)
-			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate registry")
+	}
+
+	if !a.useDaemon {
+		if err := a.ensurePreviousAndTargetHaveSameRegistry(); err != nil {
+			return errors.Wrap(err, "ensuring images are on same registry")
 		}
 	}
 
@@ -112,27 +110,8 @@ func (a *analyzeCmd) Args(nargs int, args []string) error {
 		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate image tag(s)")
 	}
 
-	if a.analyzedPath == cmd.PlaceholderAnalyzedPath {
-		a.analyzedPath = cmd.DefaultAnalyzedPath(a.platform.API().String(), a.layersDir)
-	}
-
-	if a.platform06.groupPath == cmd.PlaceholderGroupPath {
-		a.platform06.groupPath = cmd.DefaultGroupPath(a.platform.API().String(), a.layersDir)
-	}
-
-	if a.supportsRunImage() {
-		stackMD, err := readStack(a.stackPath)
-		if err != nil {
-			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "parse stack metadata")
-		}
-
-		if err := a.validateRunImageInput(); err != nil {
-			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "validate run image input")
-		}
-
-		if err := a.populateRunImage(stackMD, targetRegistry); err != nil {
-			return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "populate run image")
-		}
+	if err := a.populateRunImageIfNeeded(); err != nil {
+		return cmd.FailErrCode(err, cmd.CodeInvalidArgs, "populate run image")
 	}
 
 	return nil
@@ -165,7 +144,7 @@ func (a *analyzeCmd) Privileges() error {
 			return cmd.FailErr(err)
 		}
 	}
-	if err := priv.EnsureOwner(a.uid, a.gid, a.layersDir, a.platform06.cacheDir); err != nil {
+	if err := priv.EnsureOwner(a.uid, a.gid, a.layersDir, a.legacyCacheDir); err != nil {
 		return cmd.FailErr(err, "chown volumes")
 	}
 	if err := priv.RunAs(a.uid, a.gid); err != nil {
@@ -174,10 +153,10 @@ func (a *analyzeCmd) Privileges() error {
 	return nil
 }
 
-func (aa *analyzeArgs) registryImages() []string {
+func (a *analyzeCmd) registryImages() []string {
 	var registryImages []string
-	registryImages = append(registryImages, aa.ReadableRegistryImages()...)
-	return append(registryImages, aa.WriteableRegistryImages()...)
+	registryImages = append(registryImages, a.ReadableRegistryImages()...)
+	return append(registryImages, a.WriteableRegistryImages()...)
 }
 
 func (a *analyzeCmd) Exec() error {
@@ -187,19 +166,19 @@ func (a *analyzeCmd) Exec() error {
 		cacheStore lifecycle.Cache
 	)
 	if a.restoresLayerMetadata() {
-		group, err = buildpack.ReadGroup(a.platform06.groupPath)
+		group, err = buildpack.ReadGroup(a.legacyGroupPath)
 		if err != nil {
 			return cmd.FailErr(err, "read buildpack group")
 		}
 		if err := verifyBuildpackApis(group); err != nil {
 			return err
 		}
-		cacheStore, err = initCache(a.cacheImageRef, a.platform06.cacheDir, a.keychain)
+		cacheStore, err = initCache(a.cacheImageRef, a.legacyCacheDir, a.keychain)
 		if err != nil {
 			return cmd.FailErr(err, "initialize cache")
 		}
-		a.platform06.group = group
-		a.platform06.cache = cacheStore
+		a.legacyGroup = group
+		a.legacyCache = cacheStore
 	}
 
 	analyzedMD, err := a.analyze()
@@ -214,7 +193,7 @@ func (a *analyzeCmd) Exec() error {
 	return nil
 }
 
-func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
+func (aa analyzeInputsForCreator) analyze() (platform.AnalyzedMetadata, error) {
 	previousImage, err := aa.localOrRemote(aa.previousImageRef)
 	if err != nil {
 		return platform.AnalyzedMetadata{}, cmd.FailErr(err, "get previous image")
@@ -226,13 +205,13 @@ func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
 	}
 
 	analyzedMD, err := (&lifecycle.Analyzer{
-		Buildpacks:            aa.platform06.group.Group,
-		Cache:                 aa.platform06.cache,
+		Buildpacks:            aa.legacyGroup.Group,
+		Cache:                 aa.legacyCache,
 		Logger:                cmd.DefaultLogger,
 		Platform:              aa.platform,
 		PreviousImage:         previousImage,
 		RunImage:              runImage,
-		LayerMetadataRestorer: layer.NewMetadataRestorer(cmd.DefaultLogger, aa.layersDir, aa.platform06.skipLayers),
+		LayerMetadataRestorer: layer.NewMetadataRestorer(cmd.DefaultLogger, aa.layersDir, aa.legacySkipLayers),
 		SBOMRestorer:          layer.NewSBOMRestorer(aa.layersDir, cmd.DefaultLogger),
 	}).Analyze()
 	if err != nil {
@@ -242,7 +221,7 @@ func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
 	return analyzedMD, nil
 }
 
-func (aa analyzeArgs) localOrRemote(fromImage string) (imgutil.Image, error) {
+func (aa analyzeInputsForCreator) localOrRemote(fromImage string) (imgutil.Image, error) {
 	if fromImage == "" {
 		return nil, nil
 	}
@@ -274,39 +253,61 @@ func (a *analyzeCmd) supportsRunImage() bool {
 	return a.platformAPIVersionGreaterThan06()
 }
 
-func (a *analyzeCmd) validateRunImageInput() error {
-	if !a.supportsRunImage() && a.runImageRef != "" {
-		return errors.New("-run-image is unsupported")
-	}
-	return nil
-}
-
-func (a *analyzeCmd) populateRunImage(stackMD platform.StackMetadata, targetRegistry string) error {
+func (a *analyzeCmd) populateRunImageIfNeeded() error {
 	if !a.supportsRunImage() || a.runImageRef != "" {
 		return nil
 	}
 
-	var err error
+	targetRegistry, err := parseRegistry(a.outputImageRef)
+	if err != nil {
+		return err
+	}
+
+	stackMD, err := readStack(a.stackPath)
+	if err != nil {
+		return err
+	}
+
 	a.runImageRef, err = stackMD.BestRunImageMirror(targetRegistry)
 	if err != nil {
 		return errors.New("-run-image is required when there is no stack metadata available")
 	}
+
 	return nil
 }
 
-func (aa *analyzeArgs) ReadableRegistryImages() []string {
+func (a *analyzeCmd) ensurePreviousAndTargetHaveSameRegistry() error {
+	if a.previousImageRef == a.outputImageRef {
+		return nil
+	}
+	targetRegistry, err := parseRegistry(a.outputImageRef)
+	if err != nil {
+		return err
+	}
+	previousRegistry, err := parseRegistry(a.previousImageRef)
+	if err != nil {
+		return err
+	}
+	if previousRegistry != targetRegistry {
+		return fmt.Errorf("previous image is on a different registry %s from the exported image %s", previousRegistry, targetRegistry)
+	}
+	return nil
+}
+
+func (a *analyzeCmd) ReadableRegistryImages() []string {
 	var readableImages []string
-	if !aa.useDaemon {
-		readableImages = appendNotEmpty(readableImages, aa.previousImageRef, aa.runImageRef)
+	if !a.useDaemon {
+		readableImages = appendNotEmpty(readableImages, a.previousImageRef, a.runImageRef)
 	}
 	return readableImages
 }
-func (aa *analyzeArgs) WriteableRegistryImages() []string {
+
+func (a *analyzeCmd) WriteableRegistryImages() []string {
 	var writeableImages []string
-	writeableImages = appendNotEmpty(writeableImages, aa.cacheImageRef)
-	if !aa.useDaemon {
-		writeableImages = appendNotEmpty(writeableImages, aa.outputImageRef)
-		writeableImages = appendNotEmpty(writeableImages, aa.additionalTags...)
+	writeableImages = appendNotEmpty(writeableImages, a.cacheImageRef)
+	if !a.useDaemon {
+		writeableImages = appendNotEmpty(writeableImages, a.outputImageRef)
+		writeableImages = appendNotEmpty(writeableImages, a.additionalTags...)
 	}
 	return writeableImages
 }

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -23,7 +23,7 @@ import (
 )
 
 type analyzeCmd struct {
-	analyzeInputsForCreator
+	analyzeArgs
 	additionalTags  cmd.StringSlice
 	analyzedPath    string
 	cacheImageRef   string
@@ -34,8 +34,8 @@ type analyzeCmd struct {
 	uid, gid        int
 }
 
-// Inputs needed when run by creator
-type analyzeInputsForCreator struct {
+// analyzeArgs contains inputs needed when run by creator.
+type analyzeArgs struct {
 	layersDir        string
 	previousImageRef string
 	runImageRef      string
@@ -49,6 +49,7 @@ type analyzeInputsForCreator struct {
 	platform    Platform
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (a *analyzeCmd) DefineFlags() {
 	cmd.FlagAnalyzedPath(&a.analyzedPath)
 	cmd.FlagCacheImage(&a.cacheImageRef)
@@ -68,8 +69,9 @@ func (a *analyzeCmd) DefineFlags() {
 	}
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (a *analyzeCmd) Args(nargs int, args []string) error {
-	// define args
+	// read args
 	if nargs != 1 {
 		return cmd.FailErrCode(fmt.Errorf("received %d arguments, but expected 1", nargs), cmd.CodeInvalidArgs, "parse arguments")
 	}
@@ -193,7 +195,7 @@ func (a *analyzeCmd) Exec() error {
 	return nil
 }
 
-func (aa analyzeInputsForCreator) analyze() (platform.AnalyzedMetadata, error) {
+func (aa analyzeArgs) analyze() (platform.AnalyzedMetadata, error) {
 	previousImage, err := aa.localOrRemote(aa.previousImageRef)
 	if err != nil {
 		return platform.AnalyzedMetadata{}, cmd.FailErr(err, "get previous image")
@@ -221,7 +223,7 @@ func (aa analyzeInputsForCreator) analyze() (platform.AnalyzedMetadata, error) {
 	return analyzedMD, nil
 }
 
-func (aa analyzeInputsForCreator) localOrRemote(fromImage string) (imgutil.Image, error) {
+func (aa analyzeArgs) localOrRemote(fromImage string) (imgutil.Image, error) {
 	if fromImage == "" {
 		return nil, nil
 	}

--- a/cmd/lifecycle/builder.go
+++ b/cmd/lifecycle/builder.go
@@ -31,6 +31,7 @@ type buildArgs struct {
 	platform Platform
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (b *buildCmd) DefineFlags() {
 	cmd.FlagBuildpacksDir(&b.buildpacksDir)
 	cmd.FlagGroupPath(&b.groupPath)
@@ -40,6 +41,7 @@ func (b *buildCmd) DefineFlags() {
 	cmd.FlagPlatformDir(&b.platformDir)
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (b *buildCmd) Args(nargs int, args []string) error {
 	if nargs != 0 {
 		return cmd.FailErrCode(errors.New("received unexpected arguments"), cmd.CodeInvalidArgs, "parse arguments")

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -47,6 +47,7 @@ type createCmd struct {
 	stackMD        platform.StackMetadata
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (c *createCmd) DefineFlags() {
 	cmd.FlagAppDir(&c.appDir)
 	cmd.FlagBuildpacksDir(&c.buildpacksDir)
@@ -70,6 +71,7 @@ func (c *createCmd) DefineFlags() {
 	cmd.FlagProcessType(&c.processType)
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (c *createCmd) Args(nargs int, args []string) error {
 	if nargs != 1 {
 		return cmd.FailErrCode(fmt.Errorf("received %d arguments, but expected 1", nargs), cmd.CodeInvalidArgs, "parse arguments")
@@ -167,7 +169,7 @@ func (c *createCmd) Exec() error {
 	)
 	if c.platform.API().AtLeast("0.7") {
 		cmd.DefaultLogger.Phase("ANALYZING")
-		analyzedMD, err = analyzeInputsForCreator{
+		analyzedMD, err = analyzeArgs{
 			docker:           c.docker,
 			keychain:         c.keychain,
 			layersDir:        c.layersDir,
@@ -207,7 +209,7 @@ func (c *createCmd) Exec() error {
 		}
 
 		cmd.DefaultLogger.Phase("ANALYZING")
-		analyzedMD, err = analyzeInputsForCreator{
+		analyzedMD, err = analyzeArgs{
 			docker:           c.docker,
 			keychain:         c.keychain,
 			layersDir:        c.layersDir,

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -167,13 +167,10 @@ func (c *createCmd) Exec() error {
 	)
 	if c.platform.API().AtLeast("0.7") {
 		cmd.DefaultLogger.Phase("ANALYZING")
-		analyzedMD, err = analyzeArgs{
-			additionalTags:   c.additionalTags,
-			cacheImageRef:    c.cacheImageRef,
+		analyzedMD, err = analyzeInputsForCreator{
 			docker:           c.docker,
 			keychain:         c.keychain,
 			layersDir:        c.layersDir,
-			outputImageRef:   c.outputImageRef,
 			platform:         c.platform,
 			previousImageRef: c.previousImageRef,
 			runImageRef:      c.runImageRef,
@@ -210,18 +207,16 @@ func (c *createCmd) Exec() error {
 		}
 
 		cmd.DefaultLogger.Phase("ANALYZING")
-		analyzedMD, err = analyzeArgs{
+		analyzedMD, err = analyzeInputsForCreator{
 			docker:           c.docker,
 			keychain:         c.keychain,
 			layersDir:        c.layersDir,
-			previousImageRef: c.previousImageRef,
+			legacyCache:      cacheStore,
+			legacyGroup:      group,
+			legacySkipLayers: c.skipRestore,
 			platform:         c.platform,
+			previousImageRef: c.previousImageRef,
 			useDaemon:        c.useDaemon,
-			platform06: analyzeArgsPlatform06{
-				skipLayers: c.skipRestore,
-				group:      group,
-				cache:      cacheStore,
-			},
 		}.analyze()
 		if err != nil {
 			return err

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -32,6 +32,7 @@ type detectArgs struct {
 	platform Platform
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (d *detectCmd) DefineFlags() {
 	cmd.FlagBuildpacksDir(&d.buildpacksDir)
 	cmd.FlagAppDir(&d.appDir)
@@ -42,6 +43,7 @@ func (d *detectCmd) DefineFlags() {
 	cmd.FlagPlanPath(&d.planPath)
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (d *detectCmd) Args(nargs int, args []string) error {
 	if nargs != 0 {
 		return cmd.FailErrCode(errors.New("received unexpected arguments"), cmd.CodeInvalidArgs, "parse arguments")

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -64,6 +64,7 @@ type exportArgs struct {
 	keychain authn.Keychain
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (e *exportCmd) DefineFlags() {
 	cmd.FlagAnalyzedPath(&e.analyzedPath)
 	cmd.FlagAppDir(&e.appDir)
@@ -85,6 +86,7 @@ func (e *exportCmd) DefineFlags() {
 	cmd.DeprecatedFlagRunImage(&e.deprecatedRunImageRef)
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (e *exportCmd) Args(nargs int, args []string) error {
 	if nargs == 0 {
 		return cmd.FailErrCode(errors.New("at least one image argument is required"), cmd.CodeInvalidArgs, "parse arguments")

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -32,7 +32,7 @@ func main() {
 	case "detector":
 		cmd.Run(&detectCmd{detectArgs: detectArgs{platform: p}}, false)
 	case "analyzer":
-		cmd.Run(&analyzeCmd{analyzeArgs: analyzeArgs{platform: p}}, false)
+		cmd.Run(&analyzeCmd{analyzeInputsForCreator: analyzeInputsForCreator{platform: p}}, false)
 	case "restorer":
 		cmd.Run(&restoreCmd{restoreArgs: restoreArgs{platform: p}}, false)
 	case "builder":
@@ -60,7 +60,7 @@ func subcommand(platform Platform) {
 	case "detect":
 		cmd.Run(&detectCmd{detectArgs: detectArgs{platform: platform}}, true)
 	case "analyze":
-		cmd.Run(&analyzeCmd{analyzeArgs: analyzeArgs{platform: platform}}, true)
+		cmd.Run(&analyzeCmd{analyzeInputsForCreator: analyzeInputsForCreator{platform: platform}}, true)
 	case "restore":
 		cmd.Run(&restoreCmd{restoreArgs: restoreArgs{platform: platform}}, true)
 	case "build":

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -32,7 +32,7 @@ func main() {
 	case "detector":
 		cmd.Run(&detectCmd{detectArgs: detectArgs{platform: p}}, false)
 	case "analyzer":
-		cmd.Run(&analyzeCmd{analyzeInputsForCreator: analyzeInputsForCreator{platform: p}}, false)
+		cmd.Run(&analyzeCmd{analyzeArgs: analyzeArgs{platform: p}}, false)
 	case "restorer":
 		cmd.Run(&restoreCmd{restoreArgs: restoreArgs{platform: p}}, false)
 	case "builder":
@@ -60,7 +60,7 @@ func subcommand(platform Platform) {
 	case "detect":
 		cmd.Run(&detectCmd{detectArgs: detectArgs{platform: platform}}, true)
 	case "analyze":
-		cmd.Run(&analyzeCmd{analyzeInputsForCreator: analyzeInputsForCreator{platform: platform}}, true)
+		cmd.Run(&analyzeCmd{analyzeArgs: analyzeArgs{platform: platform}}, true)
 	case "restore":
 		cmd.Run(&restoreCmd{restoreArgs: restoreArgs{platform: platform}}, true)
 	case "build":

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -37,6 +37,7 @@ type rebaseCmd struct {
 	keychain authn.Keychain
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (r *rebaseCmd) DefineFlags() {
 	cmd.FlagGID(&r.gid)
 	cmd.FlagReportPath(&r.reportPath)
@@ -47,6 +48,7 @@ func (r *rebaseCmd) DefineFlags() {
 	cmd.DeprecatedFlagRunImage(&r.deprecatedRunImageRef)
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (r *rebaseCmd) Args(nargs int, args []string) error {
 	if nargs == 0 {
 		return cmd.FailErrCode(errors.New("at least one image argument is required"), cmd.CodeInvalidArgs, "parse arguments")

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -36,6 +36,7 @@ type restoreArgs struct {
 	keychain authn.Keychain
 }
 
+// DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (r *restoreCmd) DefineFlags() {
 	cmd.FlagCacheDir(&r.cacheDir)
 	cmd.FlagCacheImage(&r.cacheImageTag)
@@ -49,6 +50,7 @@ func (r *restoreCmd) DefineFlags() {
 	}
 }
 
+// Args validates arguments and flags, and fills in default values.
 func (r *restoreCmd) Args(nargs int, args []string) error {
 	if nargs > 0 {
 		return cmd.FailErrCode(errors.New("received unexpected Args"), cmd.CodeInvalidArgs, "parse arguments")


### PR DESCRIPTION
cmd/lifecycle/analyzer.go is hard to make changes to, for a few reasons:

* there are several nested structs: `analyzeCmd`, `analyzeArgs`, and `platform06` and it's not obvious where to add new fields
* a lot of branching logic in `analyzeCmd.Args()`

This PR tries to address these problems by:
* Removing the `platform06` struct and moving its fields to the other structs, but with the prefix `legacy`
* ~Making clear where fields belong by renaming `analyzeArgs` -> `analyzeInputsForCreator`~
* Cleaning up a few fields that creator was providing without needing to
* Moving some logic from `analyzeCmd.Args()` into helper functions

If we like this pattern I could make similar changes for other phases if needed.