### PR TITLE
Set process working directory from launch.toml

### DIFF
--- a/launch/bash.go
+++ b/launch/bash.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -31,6 +32,9 @@ func (b *BashShell) Launch(proc ShellProcess) error {
 		bashCommand = bashCommandWithTokens(len(proc.Args) + 1)
 	}
 	launcher += bashCommand
+	if err := os.Chdir(proc.WorkingDirectory); err != nil {
+		return errors.Wrap(err, "change to working directory")
+	}
 	if err := b.Exec("/bin/bash", append([]string{
 		"bash", "-c",
 		launcher, proc.Caller, proc.Command,

--- a/launch/bash_test.go
+++ b/launch/bash_test.go
@@ -21,14 +21,17 @@ func TestBash(t *testing.T) {
 
 func testBash(t *testing.T, when spec.G, it spec.S) {
 	var (
-		shell  launch.Shell
-		tmpDir string
+		shell      launch.Shell
+		tmpDir     string
+		workingDir string
 	)
 
 	it.Before(func() {
 		h.SkipIf(t, runtime.GOOS == "windows", "skip bash tests on windows")
 		var err error
 		tmpDir, err = ioutil.TempDir("", "shell-test")
+		h.AssertNil(t, err)
+		workingDir, err = os.Getwd()
 		h.AssertNil(t, err)
 		shell = &launch.BashShell{Exec: hl.SyscallExecWithStdout(t, tmpDir)}
 	})
@@ -50,6 +53,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 						Env: []string{
 							"SOME_VAR=some-val",
 						},
+						WorkingDirectory: workingDir,
 					}
 					process.Profiles = []string{
 						filepath.Join("testdata", "profiles", "print_argv0"),
@@ -100,6 +104,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 					Env: []string{
 						"SOME_VAR=some-val",
 					},
+					WorkingDirectory: workingDir,
 				}
 				err := shell.Launch(process)
 				h.AssertNil(t, err)
@@ -120,6 +125,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 					Env: []string{
 						"SOME_VAR=some-val",
 					},
+					WorkingDirectory: workingDir,
 				}
 				err := shell.Launch(process)
 				h.AssertNil(t, err)
@@ -151,6 +157,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 					Env: []string{
 						"SOME_VAR=some-val",
 					},
+					WorkingDirectory: workingDir,
 				}
 				err := shell.Launch(process)
 				h.AssertNil(t, err)
@@ -174,6 +181,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 						Env: []string{
 							"SOME_VAR=some-val",
 						},
+						WorkingDirectory: workingDir,
 					}
 					process.Profiles = []string{
 						filepath.Join("testdata", "profiles", "print_argv0"),
@@ -225,6 +233,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 					Env: []string{
 						"SOME_VAR=some-val",
 					},
+					WorkingDirectory: workingDir,
 				}
 				err := shell.Launch(process)
 				h.AssertNil(t, err)

--- a/launch/cmd.go
+++ b/launch/cmd.go
@@ -1,6 +1,8 @@
 package launch
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 )
 
@@ -16,6 +18,9 @@ func (c *CmdShell) Launch(proc ShellProcess) error {
 	}
 	commandTokens = append(commandTokens, proc.Command)
 	commandTokens = append(commandTokens, proc.Args...)
+	if err := os.Chdir(proc.WorkingDirectory); err != nil {
+		return errors.Wrap(err, "change to working directory")
+	}
 	if err := c.Exec("cmd",
 		append([]string{"cmd", "/q", "/v:on", "/s", "/c"}, commandTokens...), proc.Env,
 	); err != nil {

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -7,12 +7,13 @@ import (
 )
 
 type Process struct {
-	Type        string   `toml:"type" json:"type"`
-	Command     string   `toml:"command" json:"command"`
-	Args        []string `toml:"args" json:"args"`
-	Direct      bool     `toml:"direct" json:"direct"`
-	Default     bool     `toml:"default,omitempty" json:"default,omitempty"`
-	BuildpackID string   `toml:"buildpack-id" json:"buildpackID"`
+	Type             string   `toml:"type" json:"type"`
+	Command          string   `toml:"command" json:"command"`
+	Args             []string `toml:"args" json:"args"`
+	WorkingDirectory string   `toml:"working-directory" json:"working-directory,omitempty"`
+	Direct           bool     `toml:"direct" json:"direct"`
+	Default          bool     `toml:"default,omitempty" json:"default,omitempty"`
+	BuildpackID      string   `toml:"buildpack-id" json:"buildpackID"`
 }
 
 func (p Process) NoDefault() Process {

--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -68,6 +68,9 @@ func (l *Launcher) LaunchProcess(self string, proc Process) error {
 	if err := l.doExecD(proc.Type); err != nil {
 		return errors.Wrap(err, "exec.d")
 	}
+	if proc.WorkingDirectory == "" {
+		proc.WorkingDirectory = l.AppDir
+	}
 
 	if proc.Direct {
 		return l.launchDirect(proc)
@@ -82,6 +85,10 @@ func (l *Launcher) launchDirect(proc Process) error {
 	binary, err := exec.LookPath(proc.Command)
 	if err != nil {
 		return errors.Wrap(err, "path lookup")
+	}
+
+	if err := os.Chdir(proc.WorkingDirectory); err != nil {
+		return errors.Wrap(err, "change to working directory")
 	}
 
 	if err := l.Exec(binary,

--- a/launch/shell.go
+++ b/launch/shell.go
@@ -16,12 +16,13 @@ type Shell interface {
 }
 
 type ShellProcess struct {
-	Script   bool // Script indicates whether Command is a script or should be a token in a generated script
-	Args     []string
-	Command  string
-	Caller   string // Caller used to set argv0 for Bash profile scripts and is ignored in Cmd
-	Profiles []string
-	Env      []string
+	Script           bool // Script indicates whether Command is a script or should be a token in a generated script
+	Args             []string
+	Command          string
+	Caller           string // Caller used to set argv0 for Bash profile scripts and is ignored in Cmd
+	Profiles         []string
+	Env              []string
+	WorkingDirectory string
 }
 
 func (l *Launcher) launchWithShell(self string, proc Process) error {
@@ -34,12 +35,13 @@ func (l *Launcher) launchWithShell(self string, proc Process) error {
 		return err
 	}
 	return l.Shell.Launch(ShellProcess{
-		Script:   script,
-		Caller:   self,
-		Command:  proc.Command,
-		Args:     proc.Args,
-		Profiles: profs,
-		Env:      l.Env.List(),
+		Script:           script,
+		Caller:           self,
+		Command:          proc.Command,
+		Args:             proc.Args,
+		Profiles:         profs,
+		Env:              l.Env.List(),
+		WorkingDirectory: proc.WorkingDirectory,
 	})
 }
 


### PR DESCRIPTION
Resolves #557.

Chatted with @natalieparellano about this before the holidays as this being a small step towards [removing shell processes](https://github.com/buildpacks/rfcs/blob/main/text/0093-remove-shell-processes.md).