### PR TITLE
Warn when legacy bom is specified on buildpack API 0.7

### DIFF
--- a/buildpack/bom.go
+++ b/buildpack/bom.go
@@ -35,13 +35,20 @@ func (v *defaultBOMValidator) ValidateBOM(bp GroupBuildpack, bom []BOMEntry) ([]
 
 func (v *defaultBOMValidator) validateBOM(bom []BOMEntry) error {
 	if len(bom) > 0 {
-		return errors.New("bom table isn't supported in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>")
+		v.logger.Warn("BOM table is deprecated in this buildpack api version. The BOM should be written to <layer>.sbom.<ext>, launch.sbom.<ext>, or build.sbom.<ext>.")
 	}
+
+	for _, entry := range bom {
+		if entry.Version != "" {
+			return fmt.Errorf("bom entry '%s' has a top level version which is not allowed. The buildpack should instead set metadata.version", entry.Name)
+		}
+	}
+
 	return nil
 }
 
-func (v *defaultBOMValidator) processBOM(_ GroupBuildpack, _ []BOMEntry) []BOMEntry {
-	return []BOMEntry{}
+func (v *defaultBOMValidator) processBOM(buildpack GroupBuildpack, bom []BOMEntry) []BOMEntry {
+	return WithBuildpack(buildpack, bom)
 }
 
 type v05To06BOMValidator struct{}

--- a/buildpack/bomfile.go
+++ b/buildpack/bomfile.go
@@ -90,13 +90,18 @@ func validateMediaTypes(bp GroupBuildpack, bomfiles []BOMFile, sbomMediaTypes []
 	return nil
 }
 
+func sbomGlob(layersDir string) (matches []string, err error) {
+	layerGlob := filepath.Join(layersDir, "*.sbom.*.json")
+	matches, err = filepath.Glob(layerGlob)
+	return
+}
+
 func (b *Descriptor) processBOMFiles(layersDir string, bp GroupBuildpack, bpLayers map[string]LayerMetadataFile, logger Logger) ([]BOMFile, error) {
 	var (
-		layerGlob = filepath.Join(layersDir, "*.sbom.*.json")
-		files     []BOMFile
+		files []BOMFile
 	)
 
-	matches, err := filepath.Glob(layerGlob)
+	matches, err := sbomGlob(layersDir)
 	if err != nil {
 		return nil, err
 	}

--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -241,7 +241,7 @@ func (b *Descriptor) readOutputFiles(bpLayersDir, bpPlanPath string, bpPlanIn Pl
 	var launchTOML LaunchTOML
 	launchPath := filepath.Join(bpLayersDir, "launch.toml")
 
-	bomValidator := NewBOMValidator(b.API, logger)
+	bomValidator := NewBOMValidator(b.API, bpLayersDir, logger)
 
 	var err error
 	if api.MustParse(b.API).LessThan("0.5") {


### PR DESCRIPTION
as opposed to throwing an error. This allows for non-breaking platform migration from legacy bom table to sbom format

This commit partially reverts 880a801db2d4bfbb39671a66f7aadd96c0231e37