### PR TITLE
Read and store `io.buildpacks.id` in analyzer phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.tool-versions
 *.coverprofile
 *.test
 *~

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -166,14 +166,16 @@ func assertImageOSAndArch(t *testing.T, imageName string, phaseTest *PhaseTest) 
 }
 
 func updateAnalyzedTOMLFixturesWithRegRepoName(t *testing.T, phaseTest *PhaseTest) {
+	runImageID := &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.ReadOnlyRunImage}
+
 	placeHolderPath := filepath.Join("testdata", "exporter", "container", "layers", "analyzed.toml.placeholder")
 	analyzedMD := assertAnalyzedMetadata(t, placeHolderPath)
-	analyzedMD.RunImage = &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.ReadOnlyRunImage}
+	analyzedMD.RunImage = &platform.RunImageAnalyzedMetadata{ImageIdentifier: *runImageID}
 	encoding.WriteTOML(strings.TrimSuffix(placeHolderPath, ".placeholder"), analyzedMD)
 
 	placeHolderPath = filepath.Join("testdata", "exporter", "container", "layers", "some-analyzed.toml.placeholder")
 	analyzedMD = assertAnalyzedMetadata(t, placeHolderPath)
 	analyzedMD.PreviousImage = &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.SomeAppImage}
-	analyzedMD.RunImage = &platform.ImageIdentifier{Reference: phaseTest.targetRegistry.fixtures.ReadOnlyRunImage}
+	analyzedMD.RunImage = &platform.RunImageAnalyzedMetadata{ImageIdentifier: *runImageID}
 	encoding.WriteTOML(strings.TrimSuffix(placeHolderPath, ".placeholder"), analyzedMD)
 }

--- a/acceptance/testdata/cache-image/Dockerfile
+++ b/acceptance/testdata/cache-image/Dockerfile
@@ -5,3 +5,4 @@ FROM $fromImage
 ARG metadata
 
 LABEL io.buildpacks.lifecycle.cache.metadata=$metadata
+LABEL io.buildpacks.id=minimal

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -230,6 +230,23 @@ func testAnalyzerBuilder(platformAPI string) func(t *testing.T, when spec.G, it 
 
 					h.AssertEq(t, md.RunImage.Reference, "s0m3D1g3sT")
 				})
+
+				when("run image has io.buildpacks.id label", func() {
+					it.Before(func() {
+						h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.9"), "Platform API < 0.9 does not support io.buildpacks.id")
+						h.AssertNil(t, image.SetLabel("io.buildpacks.id", "minimal"))
+					})
+
+					it("returns the run image io.buildpacks.id label value in the analyzed metadata", func() {
+						expectRestoresLayerMetadataIfSupported()
+
+						md, err := analyzer.Analyze()
+						h.AssertNil(t, err)
+
+						h.AssertEq(t, md.RunImage.Reference, "s0m3D1g3sT")
+						h.AssertEq(t, md.RunImage.TargetID, "minimal")
+					})
+				})
 			})
 		})
 	}

--- a/api/apis.go
+++ b/api/apis.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	Platform  = newApisMustParse([]string{"0.3", "0.4", "0.5", "0.6", "0.7", "0.8"}, nil)
+	Platform  = newApisMustParse([]string{"0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"}, nil)
 	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.7"}, nil)
 )
 

--- a/platform/files.go
+++ b/platform/files.go
@@ -14,14 +14,19 @@ import (
 // analyzed.toml
 
 type AnalyzedMetadata struct {
-	PreviousImage *ImageIdentifier `toml:"image"`
-	Metadata      LayersMetadata   `toml:"metadata"`
-	RunImage      *ImageIdentifier `toml:"run-image,omitempty"`
+	PreviousImage *ImageIdentifier          `toml:"image"`
+	Metadata      LayersMetadata            `toml:"metadata"`
+	RunImage      *RunImageAnalyzedMetadata `toml:"run-image,omitempty"`
 }
 
 // FIXME: fix key names to be accurate in the daemon case
 type ImageIdentifier struct {
 	Reference string `toml:"reference"`
+}
+
+type RunImageAnalyzedMetadata struct {
+	ImageIdentifier
+	TargetID string `toml:"target-id,omitempty"`
 }
 
 // NOTE: This struct MUST be kept in sync with `LayersMetadataCompat`

--- a/platform/labels.go
+++ b/platform/labels.go
@@ -6,4 +6,5 @@ const (
 	ProjectMetadataLabel = "io.buildpacks.project.metadata"
 	StackIDLabel         = "io.buildpacks.stack.id"
 	MixinsLabel          = "io.buildpacks.stack.mixins"
+	BaseImageTargetLabel = "io.buildpacks.id"
 )


### PR DESCRIPTION
Implements #742

TODO:
- [ ] We need spec to land (See https://github.com/buildpacks/spec/issues/258)
