### PR TITLE
If there are is no sbom layer in the cache, still copy sbom files for launch

### DIFF
--- a/restorer.go
+++ b/restorer.go
@@ -98,12 +98,11 @@ func (r *Restorer) Restore(cache Cache) error {
 
 	if r.Platform.API().AtLeast("0.8") {
 		g.Go(func() error {
-			if cacheMeta.BOM.SHA == "" {
-				return nil
-			}
-			r.Logger.Infof("Restoring data for sbom from cache")
-			if err := r.SBOMRestorer.RestoreFromCache(cache, cacheMeta.BOM.SHA); err != nil {
-				return err
+			if cacheMeta.BOM.SHA != "" {
+				r.Logger.Infof("Restoring data for sbom from cache")
+				if err := r.SBOMRestorer.RestoreFromCache(cache, cacheMeta.BOM.SHA); err != nil {
+					return err
+				}
 			}
 			return r.SBOMRestorer.RestoreToBuildpackLayers(r.Buildpacks)
 		})

--- a/restorer_test.go
+++ b/restorer_test.go
@@ -74,6 +74,9 @@ func testRestorerBuilder(buildpackAPI, platformAPI string) func(t *testing.T, wh
 
 				mockCtrl = gomock.NewController(t)
 				sbomRestorer = ltestmock.NewMockSBOMRestorer(mockCtrl)
+				if api.MustParse(platformAPI).AtLeast("0.8") {
+					sbomRestorer.EXPECT().RestoreToBuildpackLayers(gomock.Any()).AnyTimes()
+				}
 
 				restorer = &lifecycle.Restorer{
 					LayersDir: layersDir,
@@ -659,7 +662,6 @@ func testRestorerBuilder(buildpackAPI, platformAPI string) func(t *testing.T, wh
 
 				it("restores the SBOM layer from the cache", func() {
 					sbomRestorer.EXPECT().RestoreFromCache(testCache, "some-digest")
-					sbomRestorer.EXPECT().RestoreToBuildpackLayers(restorer.Buildpacks)
 					err := restorer.Restore(testCache)
 					h.AssertNil(t, err)
 				})


### PR DESCRIPTION
...that were restored from the previous image.

Found this bug while verifying #794 