### PR TITLE
Add default value for CustomPlatform

### DIFF
--- a/extender/kaniko/dockerfile_applier.go
+++ b/extender/kaniko/dockerfile_applier.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/GoogleContainerTools/kaniko/pkg/config"
 	"github.com/GoogleContainerTools/kaniko/pkg/executor"
+	"github.com/containerd/containerd/platforms"
 
 	"github.com/buildpacks/lifecycle/extender"
 )
@@ -46,6 +47,7 @@ func (a *DockerfileApplier) ApplyBuild(dockerfiles []extender.Dockerfile, baseIm
 			RegistryOptions: config.RegistryOptions{SkipTLSVerify: true}, // TODO: remove eventually
 			SnapshotMode:    "full",
 			SrcContext:      a.workDir,
+			CustomPlatform:  platforms.DefaultString(),
 		}
 
 		if err := doKaniko(dockerfile.Path, opts, logger); err != nil {
@@ -75,6 +77,7 @@ func (a *DockerfileApplier) ApplyRun(dockerfiles []extender.Dockerfile, baseImag
 			RegistryOptions: config.RegistryOptions{SkipTLSVerify: true}, // TODO: remove eventually
 			SnapshotMode:    "full",
 			SrcContext:      a.workDir,
+			CustomPlatform:  platforms.DefaultString(),
 		}
 
 		if err := doKaniko(dockerfile.Path, opts, logger); err != nil {


### PR DESCRIPTION
CustomPlatform doesn't work quite like the other Kaniko options. 

Internally it must always have a value, normally achieved by this bit of code.. 
https://github.com/GoogleContainerTools/kaniko/blob/3589382378b89f6868623efdeb33da338195526e/cmd/warmer/cmd/root.go#L91-L97

The extender seems to bypass that code, leading to that option not having a value at runtime, which leads to failures if any Dockerfile parsed by the extender tries to pull a new image (eg, if it tries to use FROM to reference a new image). 

```
time="2022-02-17T18:34:55Z" level=info msg="Retrieving image manifest redhat/ubi8-minimal:latest"
time="2022-02-17T18:34:55Z" level=info msg="Retrieving image redhat/ubi8-minimal:latest from registry index.docker.io"
time="2022-02-17T18:34:55Z" level=error msg="Error parsing the serverURL" error="docker-credential-ecr-login can only be used with Amazon Elastic Container Registry." serverURL=index.docker.io
ERROR: no child with platform  in index redhat/ubi8-minimal:latest
```

Note the empty platform name between 'with platform' and 'in index'. 

This PR sets the CustomPlatform to have the same default as the kaniko code above has. 

This does not address if CustomPlatform should be exposed by the extender, it merely ensures the default platform is set appropriately.,