### PR TITLE
Set env vars for positional args in build and detect

### DIFF
--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -19,6 +19,11 @@ import (
 	"github.com/buildpacks/lifecycle/layers"
 )
 
+const (
+	EnvLayersDir  = "CNB_LAYERS_DIR"
+	EnvBpPlanPath = "CNB_BP_PLAN_PATH"
+)
+
 type BuildEnv interface {
 	AddRootDir(baseDir string) error
 	AddEnvDir(envDir string, defaultAction env.ActionType) error
@@ -185,6 +190,13 @@ func (b *Descriptor) runBuildCmd(bpLayersDir, bpPlanPath string, config BuildCon
 		}
 	}
 	cmd.Env = append(cmd.Env, EnvBuildpackDir+"="+b.Dir)
+	if api.MustParse(b.API).AtLeast("0.8") {
+		cmd.Env = append(cmd.Env,
+			EnvLayersDir+"="+bpLayersDir,
+			EnvPlatformDir+"="+config.PlatformDir,
+			EnvBpPlanPath+"="+bpPlanPath,
+		)
+	}
 
 	if err := cmd.Run(); err != nil {
 		return NewError(err, ErrTypeBuildpack)

--- a/buildpack/detect.go
+++ b/buildpack/detect.go
@@ -14,7 +14,11 @@ import (
 	"github.com/buildpacks/lifecycle/api"
 )
 
-const EnvBuildpackDir = "CNB_BUILDPACK_DIR"
+const (
+	EnvBuildpackDir  = "CNB_BUILDPACK_DIR"
+	EnvPlatformDir   = "CNB_PLATFORM_DIR"
+	EnvBuildPlanPath = "CNB_BUILD_PLAN_PATH"
+)
 
 type Logger interface {
 	Debug(msg string)
@@ -75,6 +79,14 @@ func (b *Descriptor) Detect(config *DetectConfig, bpEnv BuildEnv) DetectRun {
 		}
 	}
 	cmd.Env = append(cmd.Env, EnvBuildpackDir+"="+b.Dir)
+
+	if api.MustParse(b.API).AtLeast("0.8") {
+		cmd.Env = append(
+			cmd.Env,
+			EnvPlatformDir+"="+platformDir,
+			EnvBuildPlanPath+"="+planPath,
+		)
+	}
 
 	if err := cmd.Run(); err != nil {
 		if err, ok := err.(*exec.ExitError); ok {

--- a/buildpack/detect_test.go
+++ b/buildpack/detect_test.go
@@ -145,6 +145,48 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 
+		it("should set CNB_PLATFORM_DIR in the environment", func() {
+			mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), someEnv), nil)
+
+			bpTOML.Detect(&detectConfig, mockEnv)
+
+			env := rdappfile("detect-env-cnb-platform-dir-A-v1")
+			h.AssertEq(t, env, platformDir)
+		})
+
+		it("should set CNB_BUILD_PLAN_PATH in the environment", func() {
+			mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), someEnv), nil)
+
+			bpTOML.Detect(&detectConfig, mockEnv)
+
+			env := rdappfile("detect-env-cnb-build-plan-path-A-v1")
+			if env == "unset" {
+				t.Fatal("expected CNB_BUILD_PLAN_PATH to be set")
+			}
+		})
+
+		when("buildpack api < 0.8", func() {
+			it.Before(func() {
+				bpTOML.API = "0.7"
+			})
+
+			it("should not set environment variables for positional arguments", func() {
+				mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), someEnv), nil)
+
+				bpTOML.Detect(&detectConfig, mockEnv)
+
+				for _, file := range []string{
+					"detect-env-cnb-platform-dir-A-v1",
+					"detect-env-cnb-build-plan-path-A-v1",
+				} {
+					contents := rdappfile(file)
+					if contents != "unset" {
+						t.Fatalf("Expected %s to be unset; got %s", file, contents)
+					}
+				}
+			})
+		})
+
 		it("should fail and print the output if the buildpack plan file has a bad format", func() {
 			mockEnv.EXPECT().WithPlatform(platformDir).Return(append(os.Environ(), someEnv), nil)
 

--- a/buildpack/testdata/buildpack/bin/build
+++ b/buildpack/testdata/buildpack/bin/build
@@ -15,6 +15,9 @@ echo "build out: ${bp_id}@${bp_version}"
 
 echo "TEST_ENV: ${TEST_ENV}" > "build-info-${bp_id}-${bp_version}"
 echo -n "${CNB_BUILDPACK_DIR:-unset}" > "build-env-cnb-buildpack-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_LAYERS_DIR:-unset}" > "build-env-cnb-layers-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_PLATFORM_DIR:-unset}" > "build-env-cnb-platform-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_BP_PLAN_PATH:-unset}" > "build-env-cnb-bp-plan-path-${bp_id}-${bp_version}"
 
 cp -a "$platform_dir/env" "build-env-${bp_id}-${bp_version}"
 

--- a/buildpack/testdata/buildpack/bin/build.bat
+++ b/buildpack/testdata/buildpack/bin/build.bat
@@ -17,8 +17,15 @@ for /f "tokens=* USEBACKQ" %%F in (`type %bp_dir%\buildpack.toml ^| yj -t ^| jq 
 echo build out: %bp_id%@%bp_version%
 echo build err: %bp_id%@%bp_version%>&2
 
+if not defined CNB_LAYERS_DIR ( set CNB_LAYERS_DIR="unset" )
+if not defined CNB_PLATFORM_DIR ( set CNB_PLATFORM_DIR="unset" )
+if not defined CNB_BP_PLAN_PATH ( set CNB_BP_PLAN_PATH="unset" )
+
 echo TEST_ENV: %TEST_ENV%> build-info-%bp_id%-%bp_version%
 call :echon %CNB_BUILDPACK_DIR%> build-env-cnb-buildpack-dir-%bp_id%-%bp_version%
+call :echon %CNB_LAYERS_DIR%> build-env-cnb-layers-dir-%bp_id%-%bp_version%
+call :echon %CNB_PLATFORM_DIR%> build-env-cnb-platform-dir-%bp_id%-%bp_version%
+call :echon %CNB_BP_PLAN_PATH%> build-env-cnb-bp-plan-path-%bp_id%-%bp_version%
 
 mkdir build-env-%bp_id%-%bp_version%
 xcopy /e /q %platform_dir%\env build-env-%bp_id%-%bp_version% >nul

--- a/buildpack/testdata/buildpack/bin/detect
+++ b/buildpack/testdata/buildpack/bin/detect
@@ -15,6 +15,8 @@ echo "detect out: ${bp_id}@${bp_version}"
 ls -1 "$platform_dir/env" > "detect-env-${bp_id}-${bp_version}"
 echo -n "$ENV_TYPE" > "detect-env-type-${bp_id}-${bp_version}"
 echo -n "${CNB_BUILDPACK_DIR:-unset}" > "detect-env-cnb-buildpack-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_PLATFORM_DIR:-unset}" > "detect-env-cnb-platform-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_BUILD_PLAN_PATH:-unset}" > "detect-env-cnb-build-plan-path-${bp_id}-${bp_version}"
 
 if [[ -f detect-plan-${bp_id}-${bp_version}.toml ]]; then
   cat "detect-plan-${bp_id}-${bp_version}.toml" > "$plan_path"

--- a/buildpack/testdata/buildpack/bin/detect.bat
+++ b/buildpack/testdata/buildpack/bin/detect.bat
@@ -15,9 +15,14 @@ for /f "tokens=* USEBACKQ" %%F in (`type %bp_dir%\buildpack.toml ^| yj -t ^| jq 
 echo detect out: %bp_id%@%bp_version%
 call :echon detect err: %bp_id%@%bp_version%>&2
 
+if not defined CNB_PLATFORM_DIR ( set CNB_PLATFORM_DIR="unset" )
+if not defined CNB_BUILD_PLAN_PATH ( set CNB_BUILD_PLAN_PATH="unset" )
+
 dir /b %platform_dir%\env > detect-env-%bp_id%-%bp_version%
 call :echon %ENV_TYPE%> detect-env-type-%bp_id%-%bp_version%
 call :echon %CNB_BUILDPACK_DIR%> detect-env-cnb-buildpack-dir-%bp_id%-%bp_version%
+call :echon %CNB_PLATFORM_DIR%> detect-env-cnb-platform-dir-%bp_id%-%bp_version%
+call :echon %CNB_BUILD_PLAN_PATH%> detect-env-cnb-build-plan-path-%bp_id%-%bp_version%
 
 if exist detect-plan-%bp_id%-%bp_version%.toml (
   type detect-plan-%bp_id%-%bp_version%.toml > %plan_path%


### PR DESCRIPTION
As described in RFC 100, set the following environment variables when
running buildpack executables, which correspond to their positional
arguments.

In `detect`:

- CNB_PLATFORM_DIR
- CNB_BUILD_PLAN_PATH

In `build`:

- CNB_LAYERS_DIR
- CNB_PLATFORM_DIR
- CNB_BP_PLAN_PATH

Fixes #806.
Fixes #807.

Signed-off-by: Mikey Boldt <mboldt@vmware.com>