### PR TITLE
When restoring sbom files, silently ignore if the bp layers directory does not exist

### DIFF
--- a/internal/layer/sbom_restorer.go
+++ b/internal/layer/sbom_restorer.go
@@ -110,14 +110,20 @@ func (r *DefaultSBOMRestorer) restoreSBOMFunc(detectedBps []buildpack.GroupBuild
 			bpID      = matches[1]
 			layerName = matches[2]
 			fileName  = matches[3]
-			dest      = filepath.Join(r.layersDir, bpID, fmt.Sprintf("%s.%s", layerName, fileName))
+			destDir   = filepath.Join(r.layersDir, bpID)
 		)
+
+		// don't try to restore sbom files when the bp layers directory doesn't exist
+		// this can happen when there are sbom files for launch but the cache is empty
+		if _, err := os.Stat(destDir); os.IsNotExist(err) {
+			return nil
+		}
 
 		if !r.contains(detectedBps, bpID) {
 			return nil
 		}
 
-		return io2.Copy(path, dest)
+		return io2.Copy(path, filepath.Join(destDir, fmt.Sprintf("%s.%s", layerName, fileName)))
 	}
 }
 

--- a/internal/layer/sbom_restorer_test.go
+++ b/internal/layer/sbom_restorer_test.go
@@ -176,5 +176,16 @@ func testSBOMRestorer(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, sbomRestorer.RestoreToBuildpackLayers(detectedBps))
 			h.AssertPathDoesNotExist(t, filepath.Join(layersDir, "buildpack.id", "launch.sbom.cdx.json"))
 		})
+
+		when("the bp layers directory doesn't exist", func() {
+			it.Before(func() {
+				os.RemoveAll(filepath.Join(layersDir, "buildpack.id"))
+				os.RemoveAll(filepath.Join(layersDir, "escaped_buildpack_id"))
+			})
+
+			it("does not error", func() {
+				h.AssertNil(t, sbomRestorer.RestoreToBuildpackLayers(detectedBps))
+			})
+		})
 	})
 }


### PR DESCRIPTION
Fixes #831 