### PR TITLE
Upgrade to go 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
       - name: Install jq
         run: |
           mkdir -p deps/bin
@@ -42,7 +42,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
       - name: Test
         run: |
           make format || true
@@ -59,7 +59,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
       - name: Add runner IP to daemon insecure-registries and firewall
         shell: powershell
         run: |
@@ -107,7 +107,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
       - name: Install Cosign
         uses: sigstore/cosign-installer@v1.0.0
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
       - name: Install crane
         run: |
           go install github.com/google/go-containerregistry/cmd/crane@latest

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,7 @@ LDFLAGS+=-X 'github.com/buildpacks/lifecycle/cmd.Version=$(LIFECYCLE_VERSION)'
 GOBUILD:=go build $(GOFLAGS) -ldflags "$(LDFLAGS)"
 GOTEST=$(GOCMD) test $(GOFLAGS)
 BUILD_DIR?=$(PWD)$/out
-LINUX_COMPILATION_IMAGE?=golang:1.16-alpine
-WINDOWS_COMPILATION_IMAGE?=golang:1.16-windowsservercore-1809
+WINDOWS_COMPILATION_IMAGE?=golang:1.17-windowsservercore-1809
 SOURCE_COMPILATION_IMAGE?=lifecycle-img
 BUILD_CTR?=lifecycle-ctr
 DOCKER_CMD?=make test

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,8 +1,7 @@
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d
-
 
 FROM ubuntu:bionic
 

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.17 as builder
 
 COPY exec.d/ /go/src/exec.d
-RUN GO111MODULE=off go build -o helper ./src/exec.d
+RUN cd ./src/exec.d && go build -o /go/helper
 
 FROM ubuntu:bionic
 

--- a/acceptance/testdata/launcher/Dockerfile.windows
+++ b/acceptance/testdata/launcher/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM golang:1.16-nanoserver-1809
+FROM golang:1.17-nanoserver-1809
 
 COPY exec.d/ /go/src/exec.d
 WORKDIR /go/src

--- a/acceptance/testdata/launcher/Dockerfile.windows
+++ b/acceptance/testdata/launcher/Dockerfile.windows
@@ -1,14 +1,14 @@
 FROM golang:1.17-nanoserver-1809
 
 COPY exec.d/ /go/src/exec.d
-WORKDIR /go/src
-RUN go build -o helper.exe exec.d
+WORKDIR /go/src/exec.d
+RUN go build -o helper.exe
 
 COPY windows/container /
 
 RUN mkdir c:\layers\0.6_buildpack\some_layer\exec.d\exec.d-checker
-RUN copy helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\helper.exe
-RUN copy helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\exec.d-checker\helper.exe
+RUN copy c:\go\src\exec.d\helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\helper.exe
+RUN copy c:\go\src\exec.d\helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\exec.d-checker\helper.exe
 
 ENV PATH="c:\cnb\process;c:\cnb\lifecycle;C:\Windows\system32;C:\Windows;"
 

--- a/acceptance/testdata/launcher/exec.d/go.mod
+++ b/acceptance/testdata/launcher/exec.d/go.mod
@@ -1,0 +1,3 @@
+module github.com/buildpacks/lifecycle/acceptance/testdata/launcher/exec.d
+
+go 1.17

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,34 @@ require (
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 )
 
-go 1.16
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/containerd/containerd v1.5.8 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.10.1 // indirect
+	github.com/docker/cli v20.10.12+incompatible // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker-credential-helpers v0.6.4 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/vbatts/tar-split v0.11.2 // indirect
+	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
+	google.golang.org/grpc v1.43.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+)
+
+go 1.17
 
 replace github.com/containerd/containerd => github.com/containerd/containerd v1.5.10

--- a/launch/exec_d_windows.go
+++ b/launch/exec_d_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"golang.org/x/sys/windows"
 )
@@ -14,6 +15,9 @@ func setHandle(cmd *exec.Cmd, f *os.File) error {
 	handle := f.Fd()
 	if err := windows.SetHandleInformation(windows.Handle(handle), windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT); err != nil {
 		return err
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		AdditionalInheritedHandles: []syscall.Handle{syscall.Handle(handle)},
 	}
 
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%#x", EnvExecDHandle, handle))


### PR DESCRIPTION
Now that go 1.18 is out, go 1.16 is no longer supported.

Fixes https://github.com/buildpacks/lifecycle/issues/838