### PR TITLE
Turn go modules off with ENV

### DIFF
--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.17 as builder
 
 COPY exec.d/ /go/src/exec.d
-RUN cd ./src/exec.d && go build -o /go/helper
+RUN GO111MODULE=off go build -o helper ./src/exec.d
 
 FROM ubuntu:bionic
 

--- a/acceptance/testdata/launcher/Dockerfile.windows
+++ b/acceptance/testdata/launcher/Dockerfile.windows
@@ -1,14 +1,15 @@
 FROM golang:1.17-nanoserver-1809
 
 COPY exec.d/ /go/src/exec.d
-WORKDIR /go/src/exec.d
-RUN go build -o helper.exe
+WORKDIR /go/src
+ENV GO111MODULE=off
+RUN go build -o helper.exe exec.d
 
 COPY windows/container /
 
 RUN mkdir c:\layers\0.6_buildpack\some_layer\exec.d\exec.d-checker
-RUN copy c:\go\src\exec.d\helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\helper.exe
-RUN copy c:\go\src\exec.d\helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\exec.d-checker\helper.exe
+RUN copy helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\helper.exe
+RUN copy helper.exe c:\layers\0.6_buildpack\some_layer\exec.d\exec.d-checker\helper.exe
 
 ENV PATH="c:\cnb\process;c:\cnb\lifecycle;C:\Windows\system32;C:\Windows;"
 

--- a/acceptance/testdata/launcher/exec.d/go.mod
+++ b/acceptance/testdata/launcher/exec.d/go.mod
@@ -1,3 +1,0 @@
-module github.com/buildpacks/lifecycle/acceptance/testdata/launcher/exec.d
-
-go 1.17


### PR DESCRIPTION
As a follow up to https://github.com/buildpacks/lifecycle/pull/839/files#r837649174 - this is the way to do it. This way feels slightly better, so as to avoid a bunch of go.mod files in our source which might cause confusion.