### PR TITLE
Refactor: remove redundant acceptance tests

### DIFF
--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -102,7 +102,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("no buildpack group passed detection", func() {
-		it("errors", func() {
+		it("errors and exits with the expected code", func() {
 			command := exec.Command(
 				"docker",
 				"run",
@@ -123,7 +123,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("there is a buildpack group that pass detection", func() {
+	when("there is a buildpack group that passes detection", func() {
 		var copyDir, containerName string
 
 		it.Before(func() {
@@ -140,7 +140,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			os.RemoveAll(copyDir)
 		})
 
-		it("writes group.toml and plan.toml", func() {
+		it("writes group.toml and plan.toml at the default locations", func() {
 			h.DockerRunAndCopy(t,
 				containerName,
 				copyDir,
@@ -191,7 +191,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			os.RemoveAll(copyDir)
 		})
 
-		it("writes group.toml and plan.toml in the right location and with the right names", func() {
+		it("writes group.toml and plan.toml in the right locations and with the right names", func() {
 			h.DockerRunAndCopy(t,
 				containerName,
 				copyDir,
@@ -316,151 +316,6 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("-order is not provided", func() {
-		var copyDir, containerName, expectedOrderTOMLPath, otherOrderTOMLPath string
-
-		it.Before(func() {
-			containerName = "test-container-" + h.RandString(10)
-			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
-			h.AssertNil(t, err)
-
-			simpleOrderTOML := filepath.Join("testdata", "detector", "container", "cnb", "orders", "simple_order.toml")
-			expectedOrderTOMLPath, err = filepath.Abs(simpleOrderTOML)
-			h.AssertNil(t, err)
-
-			alwaysDetectOrderTOML := filepath.Join("testdata", "detector", "container", "cnb", "orders", "always_detect_order.toml")
-			otherOrderTOMLPath, err = filepath.Abs(alwaysDetectOrderTOML)
-			h.AssertNil(t, err)
-		})
-
-		it.After(func() {
-			if h.DockerContainerExists(t, containerName) {
-				h.Run(t, exec.Command("docker", "rm", containerName))
-			}
-			os.RemoveAll(copyDir)
-		})
-
-		when("/cnb/order.toml and /layers/order.toml are present", func() {
-			it("prefers /layers/order.toml", func() {
-				h.DockerRunAndCopy(t,
-					containerName,
-					copyDir,
-					"/layers",
-					detectImage,
-					h.WithFlags("--user", userID,
-						"--volume", expectedOrderTOMLPath+":/layers/order.toml",
-						"--volume", otherOrderTOMLPath+":/cnb/order.toml",
-						"--env", "CNB_ORDER_PATH=",
-						"--env", "CNB_PLATFORM_API="+latestPlatformAPI,
-					),
-					h.WithArgs("-log-level=debug"),
-				)
-
-				// check group.toml
-				foundGroupTOML := filepath.Join(copyDir, "layers", "group.toml")
-				var buildpackGroup buildpack.Group
-				_, err := toml.DecodeFile(foundGroupTOML, &buildpackGroup)
-				h.AssertNil(t, err)
-				h.AssertEq(t, buildpackGroup.Group[0].ID, "simple_buildpack")
-				h.AssertEq(t, buildpackGroup.Group[0].Version, "simple_buildpack_version")
-			})
-		})
-
-		when("only /cnb/order.toml is present", func() {
-			it("processes /cnb/order.toml", func() {
-				h.DockerRunAndCopy(t,
-					containerName,
-					copyDir,
-					"/layers",
-					detectImage,
-					h.WithFlags("--user", userID,
-						"--volume", expectedOrderTOMLPath+":/cnb/order.toml",
-						"--env", "CNB_ORDER_PATH=",
-						"--env", "CNB_PLATFORM_API="+latestPlatformAPI,
-					),
-					h.WithArgs("-log-level=debug"),
-				)
-
-				// check group.toml
-				foundGroupTOML := filepath.Join(copyDir, "layers", "group.toml")
-				var buildpackGroup buildpack.Group
-				_, err := toml.DecodeFile(foundGroupTOML, &buildpackGroup)
-				h.AssertNil(t, err)
-				h.AssertEq(t, buildpackGroup.Group[0].ID, "simple_buildpack")
-				h.AssertEq(t, buildpackGroup.Group[0].Version, "simple_buildpack_version")
-			})
-		})
-
-		when("only /layers/order.toml is present", func() {
-			it("processes /layers/order.toml", func() {
-				h.DockerRunAndCopy(t,
-					containerName,
-					copyDir,
-					"/layers",
-					detectImage,
-					h.WithFlags("--user", userID,
-						"--volume", expectedOrderTOMLPath+":/layers/order.toml",
-						"--env", "CNB_ORDER_PATH=",
-						"--env", "CNB_PLATFORM_API="+latestPlatformAPI,
-					),
-					h.WithArgs("-log-level=debug"),
-				)
-
-				// check group.toml
-				foundGroupTOML := filepath.Join(copyDir, "layers", "group.toml")
-				var buildpackGroup buildpack.Group
-				_, err := toml.DecodeFile(foundGroupTOML, &buildpackGroup)
-				h.AssertNil(t, err)
-				h.AssertEq(t, buildpackGroup.Group[0].ID, "simple_buildpack")
-				h.AssertEq(t, buildpackGroup.Group[0].Version, "simple_buildpack_version")
-			})
-		})
-
-		when("platform api < 0.6", func() {
-			when("/cnb/order.toml and /layers/order.toml are present", func() {
-				it("only processes /cnb/order.toml", func() {
-					h.DockerRunAndCopy(t,
-						containerName,
-						copyDir,
-						"/layers",
-						detectImage,
-						h.WithFlags("--user", userID,
-							"--volume", expectedOrderTOMLPath+":/cnb/order.toml",
-							"--volume", otherOrderTOMLPath+":/layers/order.toml",
-							"--env", "CNB_PLATFORM_API=0.5",
-							"--env", "CNB_ORDER_PATH=",
-						),
-						h.WithArgs("-log-level=debug"),
-					)
-
-					// check group.toml
-					foundGroupTOML := filepath.Join(copyDir, "layers", "group.toml")
-					var buildpackGroup buildpack.Group
-					_, err := toml.DecodeFile(foundGroupTOML, &buildpackGroup)
-					h.AssertNil(t, err)
-					h.AssertEq(t, buildpackGroup.Group[0].ID, "simple_buildpack")
-					h.AssertEq(t, buildpackGroup.Group[0].Version, "simple_buildpack_version")
-				})
-			})
-
-			when("only /layers/order.toml is present", func() {
-				it("errors", func() {
-					command := exec.Command("docker", "run",
-						"--user", userID,
-						"--volume", otherOrderTOMLPath+":/layers/order.toml",
-						"--env", "CNB_PLATFORM_API=0.5",
-						"--env", "CNB_ORDER_PATH=",
-						"--rm", detectImage)
-					output, err := command.CombinedOutput()
-					h.AssertNotNil(t, err)
-					expected := "failed to initialize detector: reading buildpack order file: open /cnb/order.toml: no such file or directory"
-					h.AssertStringContains(t, string(output), expected)
-				})
-			})
-		})
-	})
-
 	when("-order contains extensions", func() {
 		var containerName, copyDir, orderPath string
 
@@ -540,7 +395,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 	when("platform api < 0.6", func() {
 		when("no buildpack group passed detection", func() {
-			it("errors", func() {
+			it("errors and exits with the expected code", func() {
 				command := exec.Command(
 					"docker",
 					"run",

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestAnalyzer(t *testing.T) {
+	spec.Run(t, "unit-new-analyzer/", testAnalyzerFactory, spec.Parallel(), spec.Report(report.Terminal{}))
 	for _, api := range api.Platform.Supported {
-		spec.Run(t, "unit-new-analyzer/"+api.String(), testAnalyzerFactory, spec.Parallel(), spec.Report(report.Terminal{}))
 		spec.Run(t, "unit-analyzer/"+api.String(), testAnalyzer(api.String()), spec.Parallel(), spec.Report(report.Terminal{}))
 	}
 }


### PR DESCRIPTION
With #635 and #634 we added unit tests that cover some of the things we're currently testing in acceptance.