### PR TITLE
Log analyzing phase where API >= 0.7

### DIFF
--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -175,6 +175,7 @@ func (c *createCmd) Exec() error {
 		plan       platform.BuildPlan
 	)
 	if c.platform.API().AtLeast("0.7") {
+		cmd.DefaultLogger.Phase("ANALYZING")
 		analyzerFactory := lifecycle.NewAnalyzerFactory(
 			c.platform.API(),
 			&cmd.APIVerifier{},


### PR DESCRIPTION
When the API is at least 0.7 the analyzing step should log the string
ANALYZING for the end-user

fixes #876 