### PR TITLE
Fix: Output ANALYZING phase heading

### DIFF
--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -175,6 +175,7 @@ func (c *createCmd) Exec() error {
 		plan       platform.BuildPlan
 	)
 	if c.platform.API().AtLeast("0.7") {
+		cmd.DefaultLogger.Phase("ANALYZING")
 		analyzerFactory := lifecycle.NewAnalyzerFactory(
 			c.platform.API(),
 			&cmd.APIVerifier{},


### PR DESCRIPTION
On newer platform API versions, the lifecycle is not printing an expected ANALYZING step header.