### PR TITLE
Fix: a buildpack and extension with the same ID can both detect

### DIFF
--- a/detector.go
+++ b/detector.go
@@ -164,7 +164,7 @@ func (d *Detector) detectOrder(order buildpack.Order, done, next []buildpack.Gro
 func (d *Detector) detectGroup(group buildpack.Group, done []buildpack.GroupElement, wg *sync.WaitGroup) ([]buildpack.GroupElement, []platform.BuildPlanEntry, error) {
 	for i, groupEl := range group.Group {
 		// Continue if element has already been processed.
-		if hasID(done, groupEl.ID) {
+		if hasIDForKind(done, groupEl.Kind(), groupEl.ID) {
 			continue
 		}
 
@@ -200,7 +200,7 @@ func (d *Detector) detectGroup(group buildpack.Group, done []buildpack.GroupElem
 		done = append(done, groupEl.WithAPI(descriptor.API).WithHomepage(descriptor.Info().Homepage))
 
 		// Run detect if element is a component buildpack or an extension.
-		key := groupEl.String()
+		key := fmt.Sprintf("%s %s", groupEl.Kind(), groupEl.String())
 		wg.Add(1)
 		go func(key string, bp buildpack.BuildModule) {
 			if _, ok := d.Runs.Load(key); !ok {
@@ -220,9 +220,9 @@ func (d *Detector) detectGroup(group buildpack.Group, done []buildpack.GroupElem
 	return d.Resolver.Resolve(done, d.Runs)
 }
 
-func hasID(bps []buildpack.GroupElement, id string) bool {
-	for _, bp := range bps {
-		if bp.ID == id {
+func hasIDForKind(els []buildpack.GroupElement, kind string, id string) bool {
+	for _, el := range els {
+		if el.Kind() == kind && el.ID == id {
 			return true
 		}
 	}
@@ -237,10 +237,11 @@ type DefaultResolver struct {
 // If any required buildpack in the group failed detection or a build plan cannot be resolved, it returns an error.
 func (r *DefaultResolver) Resolve(done []buildpack.GroupElement, detectRuns *sync.Map) ([]buildpack.GroupElement, []platform.BuildPlanEntry, error) {
 	var groupRuns []buildpack.DetectRun
-	for _, bp := range done {
-		t, ok := detectRuns.Load(bp.String())
+	for _, el := range done {
+		key := fmt.Sprintf("%s %s", el.Kind(), el.String())
+		t, ok := detectRuns.Load(key)
 		if !ok {
-			return nil, nil, errors.Errorf("missing detection of '%s'", bp)
+			return nil, nil, errors.Errorf("missing detection of '%s'", key)
 		}
 		run := t.(buildpack.DetectRun)
 		outputLogf := r.Logger.Debugf
@@ -252,11 +253,11 @@ func (r *DefaultResolver) Resolve(done []buildpack.GroupElement, detectRuns *syn
 		}
 
 		if len(run.Output) > 0 {
-			outputLogf("======== Output: %s ========", bp)
+			outputLogf("======== Output: %s ========", el)
 			outputLogf(string(run.Output))
 		}
 		if run.Err != nil {
-			outputLogf("======== Error: %s ========", bp)
+			outputLogf("======== Error: %s ========", el)
 			outputLogf(run.Err.Error())
 		}
 		groupRuns = append(groupRuns, run)
@@ -268,30 +269,30 @@ func (r *DefaultResolver) Resolve(done []buildpack.GroupElement, detectRuns *syn
 	detected := true
 	anyBuildpacksDetected := false
 	buildpackErr := false
-	for i, bp := range done {
+	for i, el := range done {
 		run := groupRuns[i]
 		switch run.Code {
 		case CodeDetectPass:
-			r.Logger.Debugf("pass: %s", bp)
-			results = append(results, detectResult{bp, run})
-			if !bp.Extension {
+			r.Logger.Debugf("pass: %s", el)
+			results = append(results, detectResult{el, run})
+			if !el.Extension {
 				anyBuildpacksDetected = true
 			}
 		case CodeDetectFail:
-			if bp.Optional {
-				r.Logger.Debugf("skip: %s", bp)
+			if el.Optional {
+				r.Logger.Debugf("skip: %s", el)
 			} else {
-				r.Logger.Debugf("fail: %s", bp)
+				r.Logger.Debugf("fail: %s", el)
 			}
-			detected = detected && bp.Optional
+			detected = detected && el.Optional
 		case -1:
-			r.Logger.Infof("err:  %s", bp)
+			r.Logger.Infof("err:  %s", el)
 			buildpackErr = true
-			detected = detected && bp.Optional
+			detected = detected && el.Optional
 		default:
-			r.Logger.Infof("err:  %s (%d)", bp, run.Code)
+			r.Logger.Infof("err:  %s (%d)", el, run.Code)
 			buildpackErr = true
-			detected = detected && bp.Optional
+			detected = detected && el.Optional
 		}
 	}
 	if !detected {
@@ -351,27 +352,27 @@ func (r *DefaultResolver) runTrial(i int, trial detectTrial) (depMap, detectTria
 		retry = false
 		deps = newDepMap(trial)
 
-		if err := deps.eachUnmetRequire(func(name string, bp buildpack.GroupElement) error {
+		if err := deps.eachUnmetRequire(func(name string, el buildpack.GroupElement) error {
 			retry = true
-			if !bp.Optional {
-				r.Logger.Debugf("fail: %s requires %s", bp, name)
+			if !el.Optional {
+				r.Logger.Debugf("fail: %s requires %s", el, name)
 				return ErrFailedDetection
 			}
-			r.Logger.Debugf("skip: %s requires %s", bp, name)
-			trial = trial.remove(bp)
+			r.Logger.Debugf("skip: %s requires %s", el, name)
+			trial = trial.remove(el)
 			return nil
 		}); err != nil {
 			return nil, nil, err
 		}
 
-		if err := deps.eachUnmetProvide(func(name string, bp buildpack.GroupElement) error {
+		if err := deps.eachUnmetProvide(func(name string, el buildpack.GroupElement) error {
 			retry = true
-			if !bp.Optional {
-				r.Logger.Debugf("fail: %s provides unused %s", bp, name)
+			if !el.Optional {
+				r.Logger.Debugf("fail: %s provides unused %s", el, name)
 				return ErrFailedDetection
 			}
-			r.Logger.Debugf("skip: %s provides unused %s", bp, name)
-			trial = trial.remove(bp)
+			r.Logger.Debugf("skip: %s provides unused %s", el, name)
+			trial = trial.remove(el)
 			return nil
 		}); err != nil {
 			return nil, nil, err
@@ -393,9 +394,9 @@ type detectResult struct {
 func (r *detectResult) options() []detectOption {
 	var out []detectOption
 	for i, sections := range append([]buildpack.PlanSections{r.PlanSections}, r.Or...) {
-		bp := r.GroupElement
-		bp.Optional = bp.Optional && i == len(r.Or)
-		out = append(out, detectOption{bp, sections})
+		el := r.GroupElement
+		el.Optional = el.Optional && i == len(r.Or)
+		out = append(out, detectOption{el, sections})
 	}
 	return out
 }
@@ -431,10 +432,10 @@ type detectOption struct {
 
 type detectTrial []detectOption
 
-func (ts detectTrial) remove(bp buildpack.GroupElement) detectTrial {
+func (ts detectTrial) remove(el buildpack.GroupElement) detectTrial {
 	var out detectTrial
 	for _, t := range ts {
-		if !t.GroupElement.Equals(bp) {
+		if !t.GroupElement.Equals(el) {
 			out = append(out, t)
 		}
 	}
@@ -462,26 +463,26 @@ func newDepMap(trial detectTrial) depMap {
 	return m
 }
 
-func (m depMap) provide(bp buildpack.GroupElement, provide buildpack.Provide) {
+func (m depMap) provide(el buildpack.GroupElement, provide buildpack.Provide) {
 	entry := m[provide.Name]
-	entry.extraProvides = append(entry.extraProvides, bp)
+	entry.extraProvides = append(entry.extraProvides, el)
 	m[provide.Name] = entry
 }
 
-func (m depMap) require(bp buildpack.GroupElement, require buildpack.Require) {
+func (m depMap) require(el buildpack.GroupElement, require buildpack.Require) {
 	entry := m[require.Name]
 	entry.Providers = append(entry.Providers, entry.extraProvides...)
 	entry.extraProvides = nil
 
 	if len(entry.Providers) == 0 {
-		entry.earlyRequires = append(entry.earlyRequires, bp)
+		entry.earlyRequires = append(entry.earlyRequires, el)
 	} else {
 		entry.Requires = append(entry.Requires, require)
 	}
 	m[require.Name] = entry
 }
 
-func (m depMap) eachUnmetProvide(f func(name string, bp buildpack.GroupElement) error) error {
+func (m depMap) eachUnmetProvide(f func(name string, el buildpack.GroupElement) error) error {
 	for name, entry := range m {
 		if len(entry.extraProvides) != 0 {
 			for _, bp := range entry.extraProvides {
@@ -494,11 +495,11 @@ func (m depMap) eachUnmetProvide(f func(name string, bp buildpack.GroupElement) 
 	return nil
 }
 
-func (m depMap) eachUnmetRequire(f func(name string, bp buildpack.GroupElement) error) error {
+func (m depMap) eachUnmetRequire(f func(name string, el buildpack.GroupElement) error) error {
 	for name, entry := range m {
 		if len(entry.earlyRequires) != 0 {
-			for _, bp := range entry.earlyRequires {
-				if err := f(name, bp); err != nil {
+			for _, el := range entry.earlyRequires {
+				if err := f(name, el); err != nil {
 					return err
 				}
 			}

--- a/detector_test.go
+++ b/detector_test.go
@@ -652,7 +652,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected error:\n%s\n", err)
 			}
 
-			bpARun, ok := detector.Runs.Load("A@v1")
+			bpARun, ok := detector.Runs.Load("Buildpack A@v1")
 			if !ok {
 				t.Fatalf("missing detection of '%s'", "A@v1")
 			}
@@ -676,7 +676,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected detect run:\n%s\n", s)
 			}
 
-			bpBRun, ok := detector.Runs.Load("B@v1")
+			bpBRun, ok := detector.Runs.Load("Buildpack B@v1")
 			if !ok {
 				t.Fatalf("missing detection of '%s'", "B@v1")
 			}
@@ -761,18 +761,18 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				bpA1 := testmock.NewMockBuildModule(mockCtrl)
 				bpB1 := testmock.NewMockBuildModule(mockCtrl)
-				extC1 := testmock.NewMockBuildModule(mockCtrl)
-				extD1 := testmock.NewMockBuildModule(mockCtrl)
+				extA1 := testmock.NewMockBuildModule(mockCtrl)
+				extB1 := testmock.NewMockBuildModule(mockCtrl)
 
 				// first group
 
-				// process C@v1
-				dirStore.EXPECT().Lookup(buildpack.KindExtension, "C", "v1").Return(extC1, nil)
-				extC1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
+				// process A@v1
+				dirStore.EXPECT().Lookup(buildpack.KindExtension, "A", "v1").Return(extA1, nil)
+				extA1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
 					API:       "0.9",
-					Extension: buildpack.Info{ID: "C", Version: "v1"},
+					Extension: buildpack.Info{ID: "A", Version: "v1"},
 				})
-				extC1.EXPECT().Detect(gomock.Any(), gomock.Any())
+				extA1.EXPECT().Detect(gomock.Any(), gomock.Any())
 
 				// process A@v1
 				dirStore.EXPECT().Lookup(buildpack.KindBuildpack, "A", "v1").Return(bpA1, nil)
@@ -784,7 +784,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// try resolve
 				firstGroup := []buildpack.GroupElement{
-					{ID: "C", Version: "v1", API: "0.9", Extension: true, Optional: true},
+					{ID: "A", Version: "v1", API: "0.9", Extension: true, Optional: true},
 					{ID: "A", Version: "v1", API: "0.8"},
 				}
 				firstResolve := resolver.EXPECT().Resolve(
@@ -798,13 +798,13 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// second group
 
-				// process D@v1
-				dirStore.EXPECT().Lookup(buildpack.KindExtension, "D", "v1").Return(extD1, nil)
-				extD1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
+				// process B@v1
+				dirStore.EXPECT().Lookup(buildpack.KindExtension, "B", "v1").Return(extB1, nil)
+				extB1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
 					API:       "0.9",
-					Extension: buildpack.Info{ID: "D", Version: "v1"},
+					Extension: buildpack.Info{ID: "B", Version: "v1"},
 				})
-				extD1.EXPECT().Detect(gomock.Any(), gomock.Any())
+				extB1.EXPECT().Detect(gomock.Any(), gomock.Any())
 
 				// process A@v1
 				dirStore.EXPECT().Lookup(buildpack.KindBuildpack, "A", "v1").Return(bpA1, nil)
@@ -815,7 +815,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// try resolve
 				secondGroup := []buildpack.GroupElement{
-					{ID: "D", Version: "v1", API: "0.9", Extension: true, Optional: true},
+					{ID: "B", Version: "v1", API: "0.9", Extension: true, Optional: true},
 					{ID: "A", Version: "v1", API: "0.8"},
 				}
 				secondResolve := resolver.EXPECT().Resolve(
@@ -851,11 +851,11 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// fourth group
 
-				// process C@v1
-				dirStore.EXPECT().Lookup(buildpack.KindExtension, "C", "v1").Return(extC1, nil)
-				extC1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
+				// process A@v1
+				dirStore.EXPECT().Lookup(buildpack.KindExtension, "A", "v1").Return(extA1, nil)
+				extA1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
 					API:       "0.9",
-					Extension: buildpack.Info{ID: "C", Version: "v1"},
+					Extension: buildpack.Info{ID: "A", Version: "v1"},
 				})
 
 				// process B@v1
@@ -868,7 +868,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// try resolve
 				fourthGroup := []buildpack.GroupElement{
-					{ID: "C", Version: "v1", API: "0.9", Extension: true, Optional: true},
+					{ID: "A", Version: "v1", API: "0.9", Extension: true, Optional: true},
 					{ID: "B", Version: "v1", API: "0.8"},
 				}
 				fourthResolve := resolver.EXPECT().Resolve(
@@ -882,11 +882,11 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// fifth group
 
-				// process D@v1
-				dirStore.EXPECT().Lookup(buildpack.KindExtension, "D", "v1").Return(extD1, nil)
-				extD1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
+				// process B@v1
+				dirStore.EXPECT().Lookup(buildpack.KindExtension, "B", "v1").Return(extB1, nil)
+				extB1.EXPECT().ConfigFile().Return(&buildpack.Descriptor{
 					API:       "0.9",
-					Extension: buildpack.Info{ID: "D", Version: "v1"},
+					Extension: buildpack.Info{ID: "B", Version: "v1"},
 				})
 
 				// process B@v1
@@ -898,7 +898,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 				// try resolve
 				fifthGroup := []buildpack.GroupElement{
-					{ID: "D", Version: "v1", API: "0.9", Extension: true, Optional: true},
+					{ID: "B", Version: "v1", API: "0.9", Extension: true, Optional: true},
 					{ID: "B", Version: "v1", API: "0.8"},
 				}
 				resolver.EXPECT().Resolve(
@@ -906,7 +906,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					detector.Runs,
 				).Return(
 					[]buildpack.GroupElement{
-						{ID: "D", Version: "v1", API: "0.9", Extension: true}, // optional removed
+						{ID: "B", Version: "v1", API: "0.9", Extension: true}, // optional removed
 						{ID: "B", Version: "v1", API: "0.8"},
 					},
 					[]platform.BuildPlanEntry{},
@@ -918,8 +918,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					{Group: []buildpack.GroupElement{{ID: "B", Version: "v1"}}},
 				}
 				orderExt := buildpack.Order{
-					{Group: []buildpack.GroupElement{{ID: "C", Version: "v1"}}},
-					{Group: []buildpack.GroupElement{{ID: "D", Version: "v1"}}},
+					{Group: []buildpack.GroupElement{{ID: "A", Version: "v1"}}},
+					{Group: []buildpack.GroupElement{{ID: "B", Version: "v1"}}},
 				}
 
 				detector.Order = lifecycle.PrependExtensions(orderBp, orderExt)
@@ -927,7 +927,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 
 				h.AssertEq(t, group.Group, []buildpack.GroupElement{{ID: "B", Version: "v1", API: "0.8"}})
-				h.AssertEq(t, group.GroupExtensions, []buildpack.GroupElement{{ID: "D", Version: "v1", API: "0.9"}})
+				h.AssertEq(t, group.GroupExtensions, []buildpack.GroupElement{{ID: "B", Version: "v1", API: "0.9"}})
 			})
 		})
 	})
@@ -966,10 +966,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				Code: 100,
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				Code: 100,
 			})
 
@@ -996,10 +996,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				}
 
 				detectRuns := &sync.Map{}
-				detectRuns.Store("A@v1", buildpack.DetectRun{
+				detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 					Code: 100,
 				})
-				detectRuns.Store("B@v1", buildpack.DetectRun{
+				detectRuns.Store("Extension B@v1", buildpack.DetectRun{
 					Code: 0,
 				})
 
@@ -1026,10 +1026,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				Code: 0,
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				Code: 127,
 			})
 
@@ -1054,10 +1054,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				Code: 0,
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				Code: 100,
 			})
 
@@ -1080,10 +1080,10 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				Code: 0,
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				Output: []byte("detect out: B@v1\ndetect err: B@v1"),
 				Code:   127,
 			})
@@ -1114,7 +1114,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1127,7 +1127,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Requires: []buildpack.Require{
@@ -1137,7 +1137,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("C@v2", buildpack.DetectRun{
+			detectRuns.Store("Buildpack C@v2", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1147,7 +1147,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("D@v2", buildpack.DetectRun{
+			detectRuns.Store("Buildpack D@v2", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1214,7 +1214,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1224,7 +1224,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 				},
 				Code: 100,
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Requires: []buildpack.Require{
@@ -1233,7 +1233,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("C@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack C@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1271,7 +1271,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1283,7 +1283,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1292,7 +1292,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("C@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack C@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Requires: []buildpack.Require{
@@ -1328,7 +1328,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Requires: []buildpack.Require{
@@ -1337,7 +1337,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1349,7 +1349,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("C@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack C@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1403,7 +1403,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			}
 
 			detectRuns := &sync.Map{}
-			detectRuns.Store("A@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack A@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1419,7 +1419,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("B@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack B@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Requires: []buildpack.Require{
@@ -1435,7 +1435,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("C@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack C@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{
@@ -1457,7 +1457,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			})
-			detectRuns.Store("D@v1", buildpack.DetectRun{
+			detectRuns.Store("Buildpack D@v1", buildpack.DetectRun{
 				BuildPlan: buildpack.BuildPlan{
 					PlanSections: buildpack.PlanSections{
 						Provides: []buildpack.Provide{


### PR DESCRIPTION
This was an oversight in #860. A buildpack and extension with the same ID when part of the same group should both be able to detect.