### PR TITLE
Allow new buildpack API to use new launch.toml format 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.coverprofile
 *.test
 *~
+.tool-versions
 /out
 
 acceptance/testdata/*/**/container/cnb/lifecycle/*

--- a/api/apis.go
+++ b/api/apis.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	Platform  = newApisMustParse([]string{"0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10"}, nil)
-	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10"}, nil)
+	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"}, nil)
 )
 
 type APIs struct {

--- a/api/apis.go
+++ b/api/apis.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	Platform  = newApisMustParse([]string{"0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10"}, nil)
-	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9"}, nil)
+	Buildpack = newApisMustParse([]string{"0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "0.10"}, nil)
 )
 
 type APIs struct {

--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -295,7 +295,7 @@ func (d *Descriptor) readOutputFilesBp(bpLayersDir, bpPlanPath string, bpPlanIn 
 		}
 
 		// read launch.toml, return if not exists
-		if _, err := toml.DecodeFile(launchPath, &launchTOML); os.IsNotExist(err) {
+		if err := DecodeLaunchTOML(launchPath, d.API, &launchTOML); os.IsNotExist(err) {
 			return br, nil
 		} else if err != nil {
 			return BuildResult{}, err
@@ -328,7 +328,7 @@ func (d *Descriptor) readOutputFilesBp(bpLayersDir, bpPlanPath string, bpPlanIn 
 		}
 
 		// read launch.toml, return if not exists
-		if _, err := toml.DecodeFile(launchPath, &launchTOML); os.IsNotExist(err) {
+		if err := DecodeLaunchTOML(launchPath, d.API, &launchTOML); os.IsNotExist(err) {
 			return br, nil
 		} else if err != nil {
 			return BuildResult{}, err
@@ -352,7 +352,6 @@ func (d *Descriptor) readOutputFilesBp(bpLayersDir, bpPlanPath string, bpPlanIn 
 	// set data from launch.toml
 	br.Labels = append([]Label{}, launchTOML.Labels...)
 	for i := range launchTOML.Processes {
-		launchTOML.Processes[i].BuildpackID = d.Info().ID
 		if api.MustParse(d.API).LessThan("0.8") {
 			if launchTOML.Processes[i].WorkingDirectory != "" {
 				logger.Warn(fmt.Sprintf("Warning: process working directory isn't supported in this buildpack api version. Ignoring working directory for process '%s'", launchTOML.Processes[i].Type))
@@ -360,7 +359,7 @@ func (d *Descriptor) readOutputFilesBp(bpLayersDir, bpPlanPath string, bpPlanIn 
 			}
 		}
 	}
-	br.Processes = append([]launch.Process{}, launchTOML.Processes...)
+	br.Processes = append([]launch.Process{}, launchTOML.ToLaunchProcessesForBuildpack(d.Info().ID)...)
 	br.Slices = append([]layers.Slice{}, launchTOML.Slices...)
 
 	return br, nil
@@ -385,7 +384,7 @@ func (d *Descriptor) readOutputFilesExt(extOutputDir string, extPlanIn Plan) (Bu
 	return br, nil
 }
 
-func overrideDefaultForOldBuildpacks(processes []launch.Process, bpAPI string, logger log.Logger) error {
+func overrideDefaultForOldBuildpacks(processes []ProcessEntry, bpAPI string, logger log.Logger) error {
 	if api.MustParse(bpAPI).AtLeast("0.6") {
 		return nil
 	}
@@ -402,7 +401,7 @@ func overrideDefaultForOldBuildpacks(processes []launch.Process, bpAPI string, l
 	return nil
 }
 
-func validateNoMultipleDefaults(processes []launch.Process) error {
+func validateNoMultipleDefaults(processes []ProcessEntry) error {
 	defaultType := ""
 	for _, process := range processes {
 		if process.Default && defaultType != "" {

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -907,7 +907,7 @@ func testBuild(kind string) func(t *testing.T, when spec.G, it spec.S) {
 									h.AssertEq(t, br.Processes[0].WorkingDirectory, "/working-directory")
 								})
 
-								it("does not allow multiple commands", func() {
+								it("does not allow commands as list of string", func() {
 									h.Mkfile(t,
 										"[[processes]]\n"+
 											`command = ["some-cmd"]`+"\n"+

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -882,7 +882,7 @@ func testBuild(kind string) func(t *testing.T, when spec.G, it spec.S) {
 									h.AssertEq(t, br.Processes[0].Direct, false)
 								})
 
-								it("allow setting a single command string", func() {
+								it("allows setting a single command string", func() {
 									h.Mkfile(t,
 										"[[processes]]\n"+
 											`command = "some-command"`,

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -822,7 +822,7 @@ func testBuild(kind string) func(t *testing.T, when spec.G, it spec.S) {
 									h.AssertError(t, err, "toml: incompatible types: TOML key \"processes.command\" has type string; destination has type slice")
 								})
 
-								it("writes extra commands as args before defined args", func() {
+								it("returns extra commands as args before defined args", func() {
 									h.Mkfile(t,
 										"[[processes]]\n"+
 											`command = ["some-cmd", "cmd-arg"]`+"\n"+
@@ -837,7 +837,7 @@ func testBuild(kind string) func(t *testing.T, when spec.G, it spec.S) {
 									h.AssertEq(t, br.Processes[0].Args[1], "first-arg")
 								})
 
-								it("writes direct=true for processes", func() {
+								it("returns direct=true for processes", func() {
 									h.Mkfile(t,
 										"[[processes]]\n"+
 											`command = ["some-cmd", "cmd-arg"]`+"\n"+
@@ -862,10 +862,10 @@ func testBuild(kind string) func(t *testing.T, when spec.G, it spec.S) {
 									h.AssertError(t, err, "process.direct is not supported on this buildpack version")
 								})
 
-								when("when bp api < .10", func() {
+								when("buildpack api < 0.9", func() {
 									it.Before(func() {
 										h.SkipIf(t, kind == buildpack.KindExtension, "")
-										descriptor.API = "0.9"
+										descriptor.API = "0.8"
 									})
 
 									it("allows setting direct", func() {

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -869,7 +869,7 @@ func testBuild(kind string) func(t *testing.T, when spec.G, it spec.S) {
 									})
 								})
 
-								it("allow setting direct", func() {
+								it("allows setting direct", func() {
 									h.Mkfile(t,
 										"[[processes]]\n"+
 											`command = "some-cmd"`+"\n"+

--- a/buildpack/files.go
+++ b/buildpack/files.go
@@ -5,6 +5,9 @@ package buildpack
 import (
 	"fmt"
 
+	"github.com/BurntSushi/toml"
+
+	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/launch"
 	"github.com/buildpacks/lifecycle/layers"
 )
@@ -14,8 +17,103 @@ import (
 type LaunchTOML struct {
 	BOM       []BOMEntry
 	Labels    []Label
-	Processes []launch.Process `toml:"processes"`
-	Slices    []layers.Slice   `toml:"slices"`
+	Processes []ProcessEntry `toml:"processes"`
+	Slices    []layers.Slice `toml:"slices"`
+}
+
+type ProcessEntry struct {
+	Type             string         `toml:"type" json:"type"`
+	Command          []string       `toml:"-"` // ignored
+	RawCommandValue  toml.Primitive `toml:"command" json:"command"`
+	Args             []string       `toml:"args" json:"args"`
+	Direct           *bool          `toml:"direct" json:"direct"`
+	Default          bool           `toml:"default,omitempty" json:"default,omitempty"`
+	WorkingDirectory string         `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+}
+
+// DecodeLaunchTOML reads a launch.toml file
+func DecodeLaunchTOML(launchPath string, bpAPI string, launchTOML *LaunchTOML) error {
+	// decode the common bits
+	md, err := toml.DecodeFile(launchPath, &launchTOML)
+	if err != nil {
+		return err
+	}
+
+	// decode the process.commands, which differ based on buildpack API
+	commandsAreStrings := api.MustParse(bpAPI).LessThan("0.10")
+
+	// processes are defined differently depending on API version
+	// and will be decoded into different values
+	for i, process := range launchTOML.Processes {
+		if commandsAreStrings {
+			var commandString string
+			if err = md.PrimitiveDecode(process.RawCommandValue, &commandString); err != nil {
+				return err
+			}
+			// legacy Direct defaults to false
+			if process.Direct == nil {
+				direct := false
+				launchTOML.Processes[i].Direct = &direct
+			}
+			launchTOML.Processes[i].Command = []string{commandString}
+		} else {
+			// direct is no longer allowed as a key
+			if process.Direct != nil {
+				return fmt.Errorf("process.direct is not supported on this buildpack version")
+			}
+			var command []string
+			if err = md.PrimitiveDecode(process.RawCommandValue, &command); err != nil {
+				return err
+			}
+			launchTOML.Processes[i].Command = command
+		}
+	}
+
+	return nil
+}
+
+// ToLaunchProcess converts a buildpack.ProcessEntry to a launch.Process
+func (p *ProcessEntry) ToLaunchProcess(bpID string) launch.Process {
+	// turn the command collection into a single command + args
+	// for the current platform API
+	// note: this will change once the platform API takes a collection of commands
+	var command string
+	if len(p.Command) > 0 {
+		command = p.Command[0]
+	}
+
+	var args []string
+	if len(p.Command) > 1 {
+		args = p.Command[1:]
+	}
+
+	// legacy processes will always have a value
+	// new processes will have a nil value but are always direct processes
+	var direct bool
+	if p.Direct == nil {
+		direct = true
+	} else {
+		direct = *p.Direct
+	}
+
+	return launch.Process{
+		Type:             p.Type,
+		Command:          command,
+		Args:             append(args, p.Args...),
+		Direct:           direct, // launch.Process requires a value
+		Default:          p.Default,
+		BuildpackID:      bpID,
+		WorkingDirectory: p.WorkingDirectory,
+	}
+}
+
+// converts launch.toml processes to launch.Processes
+func (lt LaunchTOML) ToLaunchProcessesForBuildpack(bpID string) []launch.Process {
+	var processes []launch.Process
+	for _, process := range lt.Processes {
+		processes = append(processes, process.ToLaunchProcess(bpID))
+	}
+	return processes
 }
 
 type BOMEntry struct {

--- a/buildpack/files.go
+++ b/buildpack/files.go
@@ -40,7 +40,7 @@ func DecodeLaunchTOML(launchPath string, bpAPI string, launchTOML *LaunchTOML) e
 	}
 
 	// decode the process.commands, which differ based on buildpack API
-	commandsAreStrings := api.MustParse(bpAPI).LessThan("0.10")
+	commandsAreStrings := api.MustParse(bpAPI).LessThan("0.9")
 
 	// processes are defined differently depending on API version
 	// and will be decoded into different values


### PR DESCRIPTION
- Buildpacks using the newer buildpack API must use the new launch.toml format
- The older format is still allowed on older buildpack API versions

Issue: https://github.com/buildpacks/lifecycle/issues/870