### PR TITLE
Allow storing multiple commands instead of a single string

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
           if (Test-Path C:\ProgramData\docker\config\daemon.json) {
             $config=(Get-Content C:\ProgramData\docker\config\daemon.json | ConvertFrom-json)
           }
-          $config."insecure-registries" = @("$IPAddress/32")
+          $config | Add-Member -Force -Name "insecure-registries" -value @("$IPAddress/32") -MemberType NoteProperty
           ConvertTo-json $config | Out-File -Encoding ASCII C:\ProgramData\docker\config\daemon.json
 
           Restart-Service docker
@@ -294,7 +294,7 @@ jobs:
           if (Test-Path C:\ProgramData\docker\config\daemon.json) {
             $config=(Get-Content C:\ProgramData\docker\config\daemon.json | ConvertFrom-json)
           }
-          $config."insecure-registries" = @("$IPAddress/32")
+          $config | Add-Member -Force -Name "insecure-registries" -value @("$IPAddress/32") -MemberType NoteProperty
           ConvertTo-json $config | Out-File -Encoding ASCII C:\ProgramData\docker\config\daemon.json
 
           Restart-Service docker

--- a/builder_test.go
+++ b/builder_test.go
@@ -38,6 +38,7 @@ func TestBuilder(t *testing.T) {
 //go:generate mockgen -package testmock -destination testmock/dir_store.go github.com/buildpacks/lifecycle DirStore
 //go:generate mockgen -package testmock -destination testmock/build_module.go github.com/buildpacks/lifecycle/buildpack BuildModule
 
+// RawCommandValue should be ignored because it is a toml.Primitive that has not been exported.
 var processCmpOpts = []cmp.Option{
 	cmpopts.IgnoreFields(launch.Process{}, "RawCommandValue"),
 }

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -36,6 +36,7 @@ func TestBuild(t *testing.T) {
 	}
 }
 
+// RawCommandValue should be ignored because it is a toml.Primitive that has not been exported.
 var processCmpOpts = []cmp.Option{
 	cmpopts.IgnoreFields(launch.Process{}, "RawCommandValue"),
 }

--- a/buildpack/files.go
+++ b/buildpack/files.go
@@ -74,14 +74,6 @@ func DecodeLaunchTOML(launchPath string, bpAPI string, launchTOML *LaunchTOML) e
 
 // ToLaunchProcess converts a buildpack.ProcessEntry to a launch.Process
 func (p *ProcessEntry) ToLaunchProcess(bpID string) launch.Process {
-	// turn the command collection into a single command + args
-	// for the current platform API
-	// note: this will change once the platform API takes a collection of commands
-	var command string
-	if len(p.Command) > 0 {
-		command = p.Command[0]
-	}
-
 	var args []string
 	if len(p.Command) > 1 {
 		args = p.Command[1:]
@@ -98,7 +90,7 @@ func (p *ProcessEntry) ToLaunchProcess(bpID string) launch.Process {
 
 	return launch.Process{
 		Type:             p.Type,
-		Command:          command,
+		Command:          []string{p.Command[0]},
 		Args:             append(args, p.Args...),
 		Direct:           direct, // launch.Process requires a value
 		Default:          p.Default,

--- a/cmd/launcher/cli/launcher.go
+++ b/cmd/launcher/cli/launcher.go
@@ -26,7 +26,7 @@ func RunLaunch() error {
 	p := platform.NewPlatform(platformAPI)
 
 	var md launch.Metadata
-	if err := launch.DecodeLaunchMetadataTOML(launch.GetMetadataFilePath(cmd.EnvOrDefault(platform.EnvLayersDir, platform.DefaultLayersDir)), p.API(), &md); err != nil {
+	if err := launch.DecodeLaunchMetadataTOML(launch.GetMetadataFilePath(cmd.EnvOrDefault(platform.EnvLayersDir, platform.DefaultLayersDir)), &md); err != nil {
 		return cmd.FailErr(err, "read metadata")
 	}
 	if err := verifyBuildpackAPIs(md.Buildpacks); err != nil {

--- a/cmd/launcher/cli/launcher.go
+++ b/cmd/launcher/cli/launcher.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/heroku/color"
 
 	"github.com/buildpacks/lifecycle/api"
@@ -27,7 +26,7 @@ func RunLaunch() error {
 	p := platform.NewPlatform(platformAPI)
 
 	var md launch.Metadata
-	if _, err := toml.DecodeFile(launch.GetMetadataFilePath(cmd.EnvOrDefault(platform.EnvLayersDir, platform.DefaultLayersDir)), &md); err != nil {
+	if err := launch.DecodeLaunchMetadataTOML(launch.GetMetadataFilePath(cmd.EnvOrDefault(platform.EnvLayersDir, platform.DefaultLayersDir)), p.API(), &md); err != nil {
 		return cmd.FailErr(err, "read metadata")
 	}
 	if err := verifyBuildpackAPIs(md.Buildpacks); err != nil {

--- a/exporter.go
+++ b/exporter.go
@@ -87,10 +87,9 @@ func (e *Exporter) Export(opts ExportOptions) (platform.ExportReport, error) {
 	meta.Stack = opts.Stack
 
 	buildMD := &platform.BuildMetadata{}
-	if _, err := toml.DecodeFile(launch.GetMetadataFilePath(opts.LayersDir), buildMD); err != nil {
+	if err := platform.DecodeBuildMetadataTOML(launch.GetMetadataFilePath(opts.LayersDir), e.PlatformAPI, buildMD); err != nil {
 		return platform.ExportReport{}, errors.Wrap(err, "read build metadata")
 	}
-	buildMD.PlatformAPI = e.PlatformAPI
 
 	// buildpack-provided layers
 	if err := e.addBuildpackLayers(opts, &meta); err != nil {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -109,7 +109,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				Processes: []launch.Process{
 					{
 						Type:        "some-process-type",
-						Command:     "/some/command",
+						Command:     []string{"/some/command"},
 						Args:        []string{"some", "command", "args"},
 						Direct:      true,
 						BuildpackID: "buildpack.id",
@@ -1134,7 +1134,7 @@ version = "4.5.6"
 								Processes: []launch.Process{
 									{
 										Type:        "some-process-type",
-										Command:     "/some/command",
+										Command:     []string{"/some/command"},
 										Args:        []string{"some", "command", "args"},
 										Direct:      true,
 										BuildpackID: "buildpack.id",

--- a/launch/decode_test.go
+++ b/launch/decode_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
-	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/launch"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
@@ -24,16 +23,13 @@ func TestDecodeMetadataTOML(t *testing.T) {
 func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 	when("DecodeLaunchMetadataTOML", func() {
 		var (
-			tmpDir     string
-			apiVersion *api.Version
+			tmpDir string
 		)
 
 		it.Before(func() {
 			var err error
 			tmpDir, err = ioutil.TempDir("", "test-decode-metadata-toml")
 			h.AssertNil(t, err)
-
-			apiVersion = api.MustParse("0.11")
 		})
 
 		it.After(func() {
@@ -56,7 +52,7 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 
 			metadata := launch.Metadata{}
 
-			h.AssertNil(t, launch.DecodeLaunchMetadataTOML(path, apiVersion, &metadata))
+			h.AssertNil(t, launch.DecodeLaunchMetadataTOML(path, &metadata))
 			h.AssertEq(t, metadata.Processes[0].Command[0], "some-cmd")
 			h.AssertEq(t, metadata.Processes[0].Command[1], "more")
 
@@ -64,11 +60,7 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, metadata.Processes[1].Command[1], "other more")
 		})
 
-		when("api < 0.11", func() {
-			it.Before(func() {
-				apiVersion = api.MustParse("0.10")
-			})
-
+		when("string commands", func() {
 			it("decodes string commands into command array", func() {
 				path := filepath.Join(tmpDir, "launch.toml")
 				h.Mkfile(t,
@@ -85,7 +77,7 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 
 				metadata := launch.Metadata{}
 
-				h.AssertNil(t, launch.DecodeLaunchMetadataTOML(path, apiVersion, &metadata))
+				h.AssertNil(t, launch.DecodeLaunchMetadataTOML(path, &metadata))
 				h.AssertEq(t, metadata.Processes[0].Command[0], "some-cmd")
 				h.AssertEq(t, metadata.Processes[1].Command[0], "other cmd with spaces")
 			})

--- a/launch/decode_test.go
+++ b/launch/decode_test.go
@@ -33,7 +33,7 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 			tmpDir, err = ioutil.TempDir("", "test-decode-metadata-toml")
 			h.AssertNil(t, err)
 
-			apiVersion = api.MustParse("0.10")
+			apiVersion = api.MustParse("0.11")
 		})
 
 		it.After(func() {
@@ -64,9 +64,9 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, metadata.Processes[1].Command[1], "other more")
 		})
 
-		when("api < 0.10", func() {
+		when("api < 0.11", func() {
 			it.Before(func() {
-				apiVersion = api.MustParse("0.9")
+				apiVersion = api.MustParse("0.10")
 			})
 
 			it("decodes string commands into command array", func() {

--- a/launch/decode_test.go
+++ b/launch/decode_test.go
@@ -1,0 +1,94 @@
+package launch_test
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/launch"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+func TestDecodeMetadataTOML(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	spec.Run(t, "DecodeMetadataTOML", testDecodeMetataTOML, spec.Sequential(), spec.Report(report.Terminal{}))
+}
+
+func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
+	when("DecodeLaunchMetadataTOML", func() {
+		var (
+			tmpDir     string
+			apiVersion *api.Version
+		)
+
+		it.Before(func() {
+			var err error
+			tmpDir, err = ioutil.TempDir("", "test-decode-metadata-toml")
+			h.AssertNil(t, err)
+
+			apiVersion = api.MustParse("0.11")
+		})
+
+		it.After(func() {
+			h.AssertNil(t, os.RemoveAll(tmpDir))
+		})
+
+		it("decodes array commands into command array", func() {
+			path := filepath.Join(tmpDir, "launch.toml")
+			h.Mkfile(t,
+				`[[processes]]`+"\n"+
+					`type = "some-type"`+"\n"+
+					`command = ["some-cmd", "more"]`+"\n"+
+					`default = true`+"\n"+
+					`[[processes]]`+"\n"+
+					`type = "web"`+"\n"+
+					`command = ["other cmd with spaces", "other more"]`+"\n",
+				// default is false and therefore doesn't appear
+				filepath.Join(tmpDir, "launch.toml"),
+			)
+
+			metadata := launch.Metadata{}
+
+			h.AssertNil(t, launch.DecodeLaunchMetadataTOML(path, apiVersion, &metadata))
+			h.AssertEq(t, metadata.Processes[0].Command[0], "some-cmd")
+			h.AssertEq(t, metadata.Processes[0].Command[1], "more")
+
+			h.AssertEq(t, metadata.Processes[1].Command[0], "other cmd with spaces")
+			h.AssertEq(t, metadata.Processes[1].Command[1], "other more")
+		})
+
+		when("api < 0.10", func() {
+			it.Before(func() {
+				apiVersion = api.MustParse("0.9")
+			})
+
+			it("decodes string commands into command array", func() {
+				path := filepath.Join(tmpDir, "launch.toml")
+				h.Mkfile(t,
+					`[[processes]]`+"\n"+
+						`type = "some-type"`+"\n"+
+						`command = "some-cmd"`+"\n"+
+						`default = true`+"\n"+
+						`[[processes]]`+"\n"+
+						`type = "web"`+"\n"+
+						`command = "other cmd with spaces"`+"\n",
+					// default is false and therefore doesn't appear
+					filepath.Join(tmpDir, "launch.toml"),
+				)
+
+				metadata := launch.Metadata{}
+
+				h.AssertNil(t, launch.DecodeLaunchMetadataTOML(path, apiVersion, &metadata))
+				h.AssertEq(t, metadata.Processes[0].Command[0], "some-cmd")
+				h.AssertEq(t, metadata.Processes[1].Command[0], "other cmd with spaces")
+			})
+		})
+	})
+}

--- a/launch/decode_test.go
+++ b/launch/decode_test.go
@@ -33,7 +33,7 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 			tmpDir, err = ioutil.TempDir("", "test-decode-metadata-toml")
 			h.AssertNil(t, err)
 
-			apiVersion = api.MustParse("0.11")
+			apiVersion = api.MustParse("0.10")
 		})
 
 		it.After(func() {

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -56,7 +56,7 @@ func DecodeLaunchMetadataTOML(path string, platformAPI *api.Version, launchmd *M
 
 func DecodeProcesses(processes []Process, platformAPI *api.Version, md toml.MetaData) error {
 	// decode the process.commands, which will differ based on platform API
-	commandsAreStrings := platformAPI.LessThan("0.10")
+	commandsAreStrings := platformAPI.LessThan("0.11")
 
 	// processes are defined differently depending on API version
 	// and will be decoded into different values

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -47,25 +47,33 @@ func DecodeLaunchMetadataTOML(path string, platformAPI *api.Version, launchmd *M
 		return err
 	}
 
+	if err = DecodeProcesses(launchmd.Processes, platformAPI, md); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DecodeProcesses(processes []Process, platformAPI *api.Version, md toml.MetaData) error {
 	// decode the process.commands, which will differ based on platform API
-	commandsAreStrings := true
+	commandsAreStrings := platformAPI.LessThan("0.11")
 
 	// processes are defined differently depending on API version
 	// and will be decoded into different values
-	for i, process := range launchmd.Processes {
+	for i, process := range processes {
 		if commandsAreStrings {
 			var commandString string
-			if err = md.PrimitiveDecode(process.RawCommandValue, &commandString); err != nil {
+			if err := md.PrimitiveDecode(process.RawCommandValue, &commandString); err != nil {
 				return err
 			}
 
-			launchmd.Processes[i].Command = []string{commandString}
+			processes[i].Command = []string{commandString}
 		} else {
 			var command []string
-			if err = md.PrimitiveDecode(process.RawCommandValue, &command); err != nil {
+			if err := md.PrimitiveDecode(process.RawCommandValue, &command); err != nil {
 				return err
 			}
-			launchmd.Processes[i].Command = command
+			processes[i].Command = command
 		}
 	}
 

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -72,6 +72,8 @@ func DecodeLaunchMetadataTOML(path string, platformAPI *api.Version, launchmd *M
 	return nil
 }
 
+// Matches is used by goMock to compare two Metadata objects in tests
+// when matching expected calls to methods containing Metadata objects
 func (m Metadata) Matches(x interface{}) bool {
 	metadatax, ok := x.(Metadata)
 	if !ok {

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -56,7 +56,7 @@ func DecodeLaunchMetadataTOML(path string, platformAPI *api.Version, launchmd *M
 
 func DecodeProcesses(processes []Process, platformAPI *api.Version, md toml.MetaData) error {
 	// decode the process.commands, which will differ based on platform API
-	commandsAreStrings := platformAPI.LessThan("0.11")
+	commandsAreStrings := platformAPI.LessThan("0.10")
 
 	// processes are defined differently depending on API version
 	// and will be decoded into different values

--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -80,7 +80,7 @@ func (l *Launcher) launchDirect(proc Process) error {
 	if err := l.Setenv("PATH", l.Env.Get("PATH")); err != nil {
 		return errors.Wrap(err, "set path")
 	}
-	binary, err := exec.LookPath(proc.Command)
+	binary, err := exec.LookPath(proc.Command[0])
 	if err != nil {
 		return errors.Wrap(err, "path lookup")
 	}
@@ -88,7 +88,7 @@ func (l *Launcher) launchDirect(proc Process) error {
 		return errors.Wrap(err, "change directory")
 	}
 	if err := l.Exec(binary,
-		append([]string{proc.Command}, proc.Args...),
+		append(proc.Command, proc.Args...),
 		l.Env.List(),
 	); err != nil {
 		return errors.Wrap(err, "direct exec")

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -116,7 +116,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			process = launch.Process{
-				Command: "command",
+				Command: []string{"command"},
 				Args:    []string{"arg1", "arg2"},
 			}
 		})
@@ -129,9 +129,9 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 				// set command to something on the real path so exec.LookPath succeeds
 				if runtime.GOOS == "windows" {
-					process.Command = "notepad"
+					process.Command = []string{"notepad"}
 				} else {
-					process.Command = "sh"
+					process.Command = []string{"sh"}
 				}
 
 				mockEnv.EXPECT().Get("PATH").Return("some-path").AnyTimes()

--- a/launch/process.go
+++ b/launch/process.go
@@ -70,10 +70,10 @@ func (l *Launcher) userProvidedProcess(cmd []string) (Process, error) {
 		return Process{}, errors.New("when there is no default process a command is required")
 	}
 	if len(cmd) > 1 && cmd[0] == "--" {
-		return Process{Command: cmd[1], Args: cmd[2:], Direct: true}, nil
+		return Process{Command: []string{cmd[1]}, Args: cmd[2:], Direct: true}, nil
 	}
 
-	return Process{Command: cmd[0], Args: cmd[1:]}, nil
+	return Process{Command: []string{cmd[0]}, Args: cmd[1:]}, nil
 }
 
 func getProcessWorkingDirectory(process Process, appDir string) string {

--- a/launch/process_test.go
+++ b/launch/process_test.go
@@ -3,6 +3,8 @@ package launch_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
@@ -15,6 +17,10 @@ func TestProcess(t *testing.T) {
 	spec.Run(t, "Process", testProcess, spec.Report(report.Terminal{}))
 }
 
+var processCmpOpts = []cmp.Option{
+	cmpopts.IgnoreFields(launch.Process{}, "RawCommandValue"),
+}
+
 func testProcess(t *testing.T, when spec.G, it spec.S) {
 	var (
 		launcher *launch.Launcher
@@ -23,13 +29,13 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 		launcher = &launch.Launcher{Processes: []launch.Process{
 			{
 				Type:        "some-type",
-				Command:     "some-command",
+				Command:     []string{"some-command"},
 				Args:        []string{"some-arg1", "some-arg2"},
 				BuildpackID: "some-buildpack",
 			},
 			{
 				Type:        "other-type",
-				Command:     "other-command",
+				Command:     []string{"other-command"},
 				Args:        []string{"other-arg1", "other-arg2"},
 				BuildpackID: "some-buildpack",
 			},
@@ -49,10 +55,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: "user-command",
+								Command: []string{"user-command"},
 								Args:    []string{"user-arg1", "user-arg2"},
 								Direct:  true,
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -61,9 +67,9 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: "user-command",
+								Command: []string{"user-command"},
 								Args:    []string{"user-arg1", "user-arg2"},
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -85,10 +91,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 						h.AssertNil(t, err)
 						h.AssertEq(t, proc, launch.Process{
 							Type:        "some-type",
-							Command:     "some-command",
+							Command:     []string{"some-command"},
 							Args:        []string{"some-arg1", "some-arg2", "user-arg1", "user-arg1"},
 							BuildpackID: "some-buildpack",
-						})
+						}, processCmpOpts...)
 					})
 				})
 
@@ -125,10 +131,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "other-type",
-								Command:     "other-command",
+								Command:     []string{"other-command"},
 								Args:        []string{"other-arg1", "other-arg2"},
 								BuildpackID: "some-buildpack",
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -137,10 +143,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: "user-command",
+								Command: []string{"user-command"},
 								Args:    []string{"user-arg1", "user-arg2"},
 								Direct:  true,
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -149,9 +155,9 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: "user-command",
+								Command: []string{"user-command"},
 								Args:    []string{"user-arg1", "user-arg2"},
-							})
+							}, processCmpOpts...)
 						})
 					})
 				})
@@ -167,10 +173,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "some-type",
-								Command:     "some-command",
+								Command:     []string{"some-command"},
 								Args:        []string{"some-arg1", "some-arg2"},
 								BuildpackID: "some-buildpack",
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -180,10 +186,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "other-type",
-								Command:     "other-command",
+								Command:     []string{"other-command"},
 								Args:        []string{"other-arg1", "other-arg2"},
 								BuildpackID: "some-buildpack",
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -192,10 +198,10 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: "user-command",
+								Command: []string{"user-command"},
 								Args:    []string{"user-arg1", "user-arg2"},
 								Direct:  true,
-							})
+							}, processCmpOpts...)
 						})
 					})
 
@@ -204,9 +210,9 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: "user-command",
+								Command: []string{"user-command"},
 								Args:    []string{"user-arg1", "user-arg2"},
-							})
+							}, processCmpOpts...)
 						})
 					})
 				})

--- a/launch/process_test.go
+++ b/launch/process_test.go
@@ -17,6 +17,7 @@ func TestProcess(t *testing.T) {
 	spec.Run(t, "Process", testProcess, spec.Report(report.Terminal{}))
 }
 
+// RawCommandValue should be ignored because it is a toml.Primitive that has not been exported.
 var processCmpOpts = []cmp.Option{
 	cmpopts.IgnoreFields(launch.Process{}, "RawCommandValue"),
 }

--- a/launch/shell.go
+++ b/launch/shell.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -34,10 +35,14 @@ func (l *Launcher) launchWithShell(self string, proc Process) error {
 	if err != nil {
 		return err
 	}
+	command := ""
+	if len(proc.Command) > 0 {
+		command = strings.Join(proc.Command, " ")
+	}
 	return l.Shell.Launch(ShellProcess{
 		Script:           script,
 		Caller:           self,
-		Command:          proc.Command,
+		Command:          command, // TODO: support multiple commands
 		Args:             proc.Args,
 		Profiles:         profs,
 		Env:              l.Env.List(),

--- a/platform/files.go
+++ b/platform/files.go
@@ -94,26 +94,8 @@ func DecodeBuildMetadataTOML(path string, platformAPI *api.Version, buildmd *Bui
 		return err
 	}
 
-	// decode the process.commands, which will differ based on platform API
-	commandsAreStrings := true
-
-	// processes are defined differently depending on API version
-	// and will be decoded into different values
-	for i, process := range buildmd.Processes {
-		if commandsAreStrings {
-			var commandString string
-			if err = md.PrimitiveDecode(process.RawCommandValue, &commandString); err != nil {
-				return err
-			}
-
-			buildmd.Processes[i].Command = []string{commandString}
-		} else {
-			var command []string
-			if err = md.PrimitiveDecode(process.RawCommandValue, &command); err != nil {
-				return err
-			}
-			buildmd.Processes[i].Command = command
-		}
+	if err = launch.DecodeProcesses(buildmd.Processes, platformAPI, md); err != nil {
+		return err
 	}
 
 	buildmd.PlatformAPI = platformAPI

--- a/platform/files.go
+++ b/platform/files.go
@@ -5,6 +5,7 @@ package platform
 import (
 	"encoding/json"
 
+	"github.com/BurntSushi/toml"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 
@@ -85,17 +86,88 @@ type BuildMetadata struct {
 	PlatformAPI                 *api.Version             `toml:"-" json:"-"`
 }
 
+// DecodeBuildMetadataTOML reads a metadata.toml file
+func DecodeBuildMetadataTOML(path string, platformAPI *api.Version, buildmd *BuildMetadata) error {
+	// decode the common bits
+	md, err := toml.DecodeFile(path, &buildmd)
+	if err != nil {
+		return err
+	}
+
+	// decode the process.commands, which will differ based on platform API
+	commandsAreStrings := true
+
+	// processes are defined differently depending on API version
+	// and will be decoded into different values
+	for i, process := range buildmd.Processes {
+		if commandsAreStrings {
+			var commandString string
+			if err = md.PrimitiveDecode(process.RawCommandValue, &commandString); err != nil {
+				return err
+			}
+
+			buildmd.Processes[i].Command = []string{commandString}
+		} else {
+			var command []string
+			if err = md.PrimitiveDecode(process.RawCommandValue, &command); err != nil {
+				return err
+			}
+			buildmd.Processes[i].Command = command
+		}
+	}
+
+	buildmd.PlatformAPI = platformAPI
+
+	return nil
+}
+
 func (md *BuildMetadata) MarshalJSON() ([]byte, error) {
+	type BuildMetadataProcessSerializer struct {
+		Type             string   `toml:"type" json:"type"`
+		Command          string   `toml:"command" json:"command"`
+		Args             []string `toml:"args" json:"args"`
+		Direct           bool     `toml:"direct" json:"direct"`
+		Default          bool     `toml:"default,omitempty" json:"default,omitempty"`
+		BuildpackID      string   `toml:"buildpack-id" json:"buildpackID"`
+		WorkingDirectory string   `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+	}
+	var processes []BuildMetadataProcessSerializer
+
+	if md.Processes != nil {
+		processes = []BuildMetadataProcessSerializer{}
+
+		for _, process := range md.Processes {
+			processes = append(processes, BuildMetadataProcessSerializer{
+				Type:             process.Type,
+				Command:          process.Command[0],
+				Args:             append(process.Command[1:], process.Args[0:]...),
+				Direct:           process.Direct,
+				Default:          process.Default,
+				BuildpackID:      process.BuildpackID,
+				WorkingDirectory: process.WorkingDirectory,
+			})
+		}
+	}
+
 	if md.PlatformAPI == nil || md.PlatformAPI.LessThan("0.9") {
-		return json.Marshal(*md)
+		type BuildMetadataSerializer BuildMetadata // prevent infinite recursion when serializing
+		return json.Marshal(&struct {
+			*BuildMetadataSerializer
+			Processes []BuildMetadataProcessSerializer `toml:"processes" json:"processes"`
+		}{
+			BuildMetadataSerializer: (*BuildMetadataSerializer)(md),
+			Processes:               processes,
+		})
 	}
 	type BuildMetadataSerializer BuildMetadata // prevent infinite recursion when serializing
 	return json.Marshal(&struct {
 		*BuildMetadataSerializer
-		BOM []buildpack.BOMEntry `json:"bom,omitempty"`
+		Processes []BuildMetadataProcessSerializer `toml:"processes" json:"processes"`
+		BOM       []buildpack.BOMEntry             `json:"bom,omitempty"`
 	}{
 		BuildMetadataSerializer: (*BuildMetadataSerializer)(md),
 		BOM:                     []buildpack.BOMEntry{},
+		Processes:               processes,
 	})
 }
 

--- a/platform/files.go
+++ b/platform/files.go
@@ -94,7 +94,7 @@ func DecodeBuildMetadataTOML(path string, platformAPI *api.Version, buildmd *Bui
 		return err
 	}
 
-	if err = launch.DecodeProcesses(buildmd.Processes, platformAPI, md); err != nil {
+	if err = launch.DecodeProcesses(buildmd.Processes, md); err != nil {
 		return err
 	}
 

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -55,9 +55,9 @@ func AssertSameInstance(t *testing.T, actual, expected interface{}) {
 }
 
 // Assert deep equality (and provide useful difference as a test failure)
-func AssertEq(t *testing.T, actual, expected interface{}) {
+func AssertEq(t *testing.T, actual, expected interface{}, opts ...cmp.Option) {
 	t.Helper()
-	if diff := cmp.Diff(actual, expected); diff != "" {
+	if diff := cmp.Diff(actual, expected, opts...); diff != "" {
 		t.Fatal(diff)
 	}
 }


### PR DESCRIPTION
This is a first step to implementing #322. This PR is updating our internal structs to allow for a slice of commands while keeping the external API and behavior the same. A future PR will implement handling multiple commands depending on the API version and changing the behavior of the launcher and metadat file output changes.

Signed-off-by: Jesse Brown <jabrown85@gmail.com>