### PR TITLE
fixes from testing.

### DIFF
--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -167,6 +167,8 @@ func readStack(stackPath string) (platform.StackMetadata, error) {
 		if os.IsNotExist(err) {
 			cmd.DefaultLogger.Infof("no stack metadata found at path '%s'\n", stackPath)
 		} else {
+			cmd.DefaultLogger.Debugf("Stack metadata found at path '%s'\n", stackPath)
+			cmd.DefaultLogger.Debugf("Stack selected runImage '%s' mirrors '%s'\n", stackMD.RunImage.Image, stackMD.RunImage.Mirrors)
 			return platform.StackMetadata{}, err
 		}
 	}
@@ -239,6 +241,7 @@ func (e *exportCmd) populateRunImageRefIfNeeded() error {
 			return errors.New("run image not found in analyzed metadata")
 		}
 		e.runImageRef = e.analyzedMD.RunImage.Reference
+		cmd.DefaultLogger.Debugf("Using runImage from analyzed metadata '%s'\n", e.runImageRef)
 	} else if e.runImageRef == "" {
 		var err error
 		e.runImageRef, err = e.stackMD.BestRunImageMirror(e.targetRegistry)


### PR DESCRIPTION
Fixes for..
- detecting build.Dockerfiles (generate.go readOutputFilesExt) {missing logic to look for build.Dockerfileand add to br.Dockerfiles with appropriate DockerfileKind}
- detecting run.Dockerfiles during scanning for updated runImage (generator.go checkNewRunImage) {missing use of launch.Escape for extID}
- filtering the buildplan based on capabilities extensions provides (generator.go now returns filteredBuildPlan as part of GenerateResult, and detector.go uses that plan when supplied to update plan.toml as part of Exec)