### PR TITLE
Add GitHub Actions workflow to update go when a new version is available

### DIFF
--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -15,6 +15,8 @@ jobs:
             - uses: actions/checkout@v3
             - name: Read go versions
               id: read-go
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                 #!/usr/bin/env bash
 
@@ -33,6 +35,8 @@ jobs:
                 echo "::set-output name=latest-release-version::${LATEST_RELEASE_VERSION}"
             - name: Create issue if needed
               if: ${{ steps.read-go.outputs.latest-go-version != steps.read-go.outputs.latest-release-go-version }}
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                 #!/usr/bin/env bash
 

--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -68,6 +68,40 @@ jobs:
             echo $search_output
           fi
       - name: Scan latest release image
+        id: scan-image
         uses: anchore/scan-action@v3
         with:
           image: buildpacksio/lifecycle:${{ steps.read-go.outputs.latest-release-version }}
+      - name: Create issue if needed
+        if: failure() && steps.scan-image.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            #!/usr/bin/env bash
+
+            set -euo pipefail
+
+            title="CVE(s) found"
+            label=cve
+
+            # Create label to use for exact search
+            gh label create "$label" || true
+
+            search_output=$(gh issue list --search "$title" --label "$label")
+
+            GITHUB_WORKFLOW_URL=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+            body="Latest lifecycle release v${{ steps.read-go.outputs.latest-release-version }} triggered CVE(s) from Grype. For further details, see: $GITHUB_WORKFLOW_URL"
+
+            if [ -z "${search_output// }" ]
+            then
+              echo "No issues matched search; creating new issue..."
+              gh issue create \
+              --label "type/bug" \
+              --label "status/triage" \
+              --label "$label" \
+              --title "$title" \
+              --body "$body"
+            else
+              echo "Found matching issues:"
+              echo $search_output
+            fi

--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -1,55 +1,73 @@
 name: Check latest lifecycle release
 "on":
-    schedule:
-        - cron: 0 2 * * 1,4
-    workflow_dispatch: {}
+  schedule:
+    - cron: 0 2 * * 1,4
+  workflow_dispatch: { }
 jobs:
-    update:
-        name: Check go version
-        runs-on:
-            - ubuntu-latest
-        steps:
-            - uses: actions/setup-go@v3
-              with:
-                go-version: "1.18"
-            - uses: actions/checkout@v3
-            - name: Read go versions
-              id: read-go
-              env:
-                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                #!/usr/bin/env bash
-
-                set -euo pipefail
-
-                LATEST_GO_VERSION=$(go version | cut -d ' ' -f 3)
-
-                LATEST_RELEASE_VERSION=$(gh release list -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2)
-
-                wget https://github.com/buildpacks/lifecycle/releases/download/$LATEST_RELEASE_VERSION/lifecycle-$LATEST_RELEASE_VERSION+linux.x86-64.tgz -O lifecycle.tgz
-                tar xzf lifecycle.tgz
-                LATEST_RELEASE_GO_VERSION=$(go version ./lifecycle/lifecycle | cut -d ' ' -f 2)
-
-                echo "::set-output name=latest-go-version::${LATEST_GO_VERSION}"
-                echo "::set-output name=latest-release-go-version::${LATEST_RELEASE_GO_VERSION}"
-
-                LATEST_RELEASE_VERSION=$(echo $LATEST_RELEASE_VERSION | cut -d \v -f 2)
-                echo "::set-output name=latest-release-version::${LATEST_RELEASE_VERSION}"
-            - name: Create issue if needed
-              if: ${{ steps.read-go.outputs.latest-go-version != steps.read-go.outputs.latest-release-go-version }}
-              env:
-                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                #!/usr/bin/env bash
-
-                set -euo pipefail
-
-                gh issue create \
-                  --label "type/bug" \
-                  --label "status/triage" \
-                  --body "Latest lifecycle release is built with Go version ${{ steps.read-go.outputs.latest-release-go-version }}; newer version ${{ steps.read-go.outputs.latest-go-version }} is available." \
-                  --title "Upgrade lifecycle to latest version of Go 1.18.x"
-            - name: Scan latest release image
-              uses: anchore/scan-action@v3
-              with:
-                image: buildpacksio/lifecycle:${{ steps.read-go.outputs.latest-release-version }}
+  update:
+    name: Check go version
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
+      - uses: actions/checkout@v3
+      - name: Read go versions
+        id: read-go
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #!/usr/bin/env bash
+          
+          set -euo pipefail
+          
+          LATEST_GO_VERSION=$(go version | cut -d ' ' -f 3)
+          
+          LATEST_RELEASE_VERSION=$(gh release list -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2)
+          
+          wget https://github.com/buildpacks/lifecycle/releases/download/$LATEST_RELEASE_VERSION/lifecycle-$LATEST_RELEASE_VERSION+linux.x86-64.tgz -O lifecycle.tgz
+          tar xzf lifecycle.tgz
+          LATEST_RELEASE_GO_VERSION=$(go version ./lifecycle/lifecycle | cut -d ' ' -f 2)
+          
+          echo "::set-output name=latest-go-version::${LATEST_GO_VERSION}"
+          echo "::set-output name=latest-release-go-version::${LATEST_RELEASE_GO_VERSION}"
+          
+          LATEST_RELEASE_VERSION=$(echo $LATEST_RELEASE_VERSION | cut -d \v -f 2)
+          echo "::set-output name=latest-release-version::${LATEST_RELEASE_VERSION}"
+      - name: Create issue if needed
+        if: ${{ steps.read-go.outputs.latest-go-version != steps.read-go.outputs.latest-release-go-version }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          #!/usr/bin/env bash
+          
+          set -euo pipefail
+          
+          title="Upgrade lifecycle to ${{ steps.read-go.outputs.latest-go-version }}"
+          label=${{ steps.read-go.outputs.latest-go-version }}
+          
+          # Create label to use for exact search
+          gh label create "$label" || true
+          
+          search_output=$(gh issue list --search "$title" --label "$label")
+          
+          body="Latest lifecycle release v${{ steps.read-go.outputs.latest-release-version }} is built with Go version ${{ steps.read-go.outputs.latest-release-go-version }}; newer version ${{ steps.read-go.outputs.latest-go-version }} is available."
+          
+          if [ -z "${search_output// }" ]
+          then
+            echo "No issues matched search; creating new issue..."
+            gh issue create \
+              --label "type/bug" \
+              --label "status/triage" \
+              --label "$label" \
+              --title "$title" \
+              --body "$body"
+          else
+            echo "Found matching issues:"
+            echo $search_output
+          fi
+      - name: Scan latest release image
+        uses: anchore/scan-action@v3
+        with:
+          image: buildpacksio/lifecycle:${{ steps.read-go.outputs.latest-release-version }}

--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -32,6 +32,8 @@ jobs:
 
                 echo "::set-output name=latest-go-version::${LATEST_GO_VERSION}"
                 echo "::set-output name=latest-release-go-version::${LATEST_RELEASE_GO_VERSION}"
+
+                LATEST_RELEASE_VERSION=$(echo $LATEST_RELEASE_VERSION | cut -d \v -f 2)
                 echo "::set-output name=latest-release-version::${LATEST_RELEASE_VERSION}"
             - name: Create issue if needed
               if: ${{ steps.read-go.outputs.latest-go-version != steps.read-go.outputs.latest-release-go-version }}

--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -1,0 +1,49 @@
+name: Check latest lifecycle release
+"on":
+    schedule:
+        - cron: 0 2 * * 1,4
+    workflow_dispatch: {}
+jobs:
+    update:
+        name: Check go version
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/setup-go@v3
+              with:
+                go-version: "1.18"
+            - uses: actions/checkout@v3
+            - name: Read go versions
+              id: read-go
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                LATEST_GO_VERSION=$(go version | cut -d ' ' -f 3)
+
+                LATEST_RELEASE_VERSION=$(gh release list -L 1 | cut -d $'\t' -f 1 | cut -d ' ' -f 2)
+
+                wget https://github.com/buildpacks/lifecycle/releases/download/$LATEST_RELEASE_VERSION/lifecycle-$LATEST_RELEASE_VERSION+linux.x86-64.tgz -O lifecycle.tgz
+                tar xzf lifecycle.tgz
+                LATEST_RELEASE_GO_VERSION=$(go version ./lifecycle/lifecycle | cut -d ' ' -f 2)
+
+                echo "::set-output name=latest-go-version::${LATEST_GO_VERSION}"
+                echo "::set-output name=latest-release-go-version::${LATEST_RELEASE_GO_VERSION}"
+                echo "::set-output name=latest-release-version::${LATEST_RELEASE_VERSION}"
+            - name: Create issue if needed
+              if: ${{ steps.read-go.outputs.latest-go-version != steps.read-go.outputs.latest-release-go-version }}
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                gh issue create \
+                  --label "type/bug" \
+                  --label "status/triage" \
+                  --body "Latest lifecycle release is built with Go version ${{ steps.read-go.outputs.latest-release-go-version }}; newer version ${{ steps.read-go.outputs.latest-go-version }} is available." \
+                  --title "Upgrade lifecycle to latest version of Go 1.18.x"
+            - name: Scan latest release image
+              uses: anchore/scan-action@v3
+              with:
+                image: buildpacksio/lifecycle:${{ steps.read-go.outputs.latest-release-version }}


### PR DESCRIPTION
Together with release/0.14.2, resolves https://github.com/buildpacks/lifecycle/issues/905.

Lifted from https://github.com/buildpacks/libcnb/blob/main/.github/workflows/pb-update-go.yml.