### PR TITLE
Remove <image> as an argument to the extender

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -986,14 +986,15 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 }
 
 func assertAnalyzedMetadata(t *testing.T, path string) *platform.AnalyzedMetadata {
-	contents, _ := ioutil.ReadFile(path)
+	contents, err := ioutil.ReadFile(path)
+	h.AssertNil(t, err)
 	h.AssertEq(t, len(contents) > 0, true)
 
-	var analyzedMd platform.AnalyzedMetadata
-	_, err := toml.Decode(string(contents), &analyzedMd)
+	var analyzedMD platform.AnalyzedMetadata
+	_, err = toml.Decode(string(contents), &analyzedMD)
 	h.AssertNil(t, err)
 
-	return &analyzedMd
+	return &analyzedMD
 }
 
 func assertLogsAndRestoresAppMetadata(t *testing.T, dir, output string) {

--- a/acceptance/builder_test.go
+++ b/acceptance/builder_test.go
@@ -457,9 +457,9 @@ func getBuilderMetadata(t *testing.T, path string) *platform.BuildMetadata {
 	contents, _ := ioutil.ReadFile(path)
 	h.AssertEq(t, len(contents) > 0, true)
 
-	var analyzedMd platform.BuildMetadata
-	_, err := toml.Decode(string(contents), &analyzedMd)
+	var buildMD platform.BuildMetadata
+	_, err := toml.Decode(string(contents), &buildMD)
 	h.AssertNil(t, err)
 
-	return &analyzedMd
+	return &buildMD
 }

--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -290,7 +290,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"-order=/custom/order.toml")
 				output, err := command.CombinedOutput()
 				h.AssertNotNil(t, err)
-				expected := "failed to initialize detector: reading order: reading buildpack order file: open /custom/order.toml: no such file or directory"
+				expected := "failed to initialize detector: reading order: failed to read order file: open /custom/order.toml: no such file or directory"
 				h.AssertStringContains(t, string(output), expected)
 			})
 		})

--- a/acceptance/extender_test.go
+++ b/acceptance/extender_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/auth"
+	"github.com/buildpacks/lifecycle/internal/encoding"
 	"github.com/buildpacks/lifecycle/internal/selective"
+	"github.com/buildpacks/lifecycle/platform"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -65,7 +67,7 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 		})
 
 		when("kaniko case", func() {
-			var kanikoDir, buildImageDigest string
+			var kanikoDir, analyzedPath string
 
 			it.Before(func() {
 				var err error
@@ -76,7 +78,9 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				h.Run(t, exec.Command("docker", "tag", extendImage, extendTest.RegRepoName(extendImage)))
 				h.AssertNil(t, h.PushImage(h.DockerCli(t), extendTest.RegRepoName(extendImage), extendTest.targetRegistry.registry.EncodedLabeledAuth()))
 
-				// warm kaniko cache - this mimics what the analyzer or restorer would have done
+				// mimic what the restorer would have done in the previous phase:
+
+				// warm kaniko cache
 				os.Setenv("DOCKER_CONFIG", extendTest.targetRegistry.dockerConfigDir)
 				ref, auth, err := auth.ReferenceForRepoName(authn.DefaultKeychain, extendTest.RegRepoName(extendImage))
 				h.AssertNil(t, err)
@@ -84,12 +88,17 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				h.AssertNil(t, err)
 				buildImageHash, err := remoteImage.Digest()
 				h.AssertNil(t, err)
-				buildImageDigest = buildImageHash.String()
+				buildImageDigest := buildImageHash.String()
 				baseCacheDir := filepath.Join(kanikoDir, "cache", "base")
 				h.AssertNil(t, os.MkdirAll(baseCacheDir, 0755))
 				layoutPath, err := selective.Write(filepath.Join(baseCacheDir, buildImageDigest), empty.Index)
 				h.AssertNil(t, err)
 				h.AssertNil(t, layoutPath.AppendImage(remoteImage))
+
+				// write build image reference in analyzed.toml
+				analyzedMD := platform.AnalyzedMetadata{BuildImage: &platform.ImageIdentifier{Reference: fmt.Sprintf("%s@%s", extendTest.RegRepoName(extendImage), buildImageDigest)}}
+				analyzedPath = h.TempFile(t, "", "analyzed.toml")
+				h.AssertNil(t, encoding.WriteTOML(analyzedPath, analyzedMD))
 			})
 
 			it.After(func() {
@@ -100,20 +109,23 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				it("succeeds", func() {
 					extendArgs := []string{
 						ctrPath(extenderPath),
+						"-analyzed", "/layers/analyzed.toml",
 						"-generated", "/layers/generated",
 						"-log-level", "debug",
 						"-gid", "1000",
 						"-uid", "1234",
-						"oci:/kaniko/cache/base/" + buildImageDigest,
+					}
+
+					extendFlags := []string{
+						"--env", "CNB_PLATFORM_API=" + platformAPI,
+						"--volume", fmt.Sprintf("%s:/layers/analyzed.toml", analyzedPath),
+						"--volume", fmt.Sprintf("%s:/kaniko", kanikoDir),
 					}
 
 					t.Log("first build extends the build image by running Dockerfile commands")
 					firstOutput := h.DockerRunWithCombinedOutput(t,
 						extendImage,
-						h.WithFlags(
-							"--env", "CNB_PLATFORM_API="+platformAPI,
-							"--volume", fmt.Sprintf("%s:/kaniko", kanikoDir),
-						),
+						h.WithFlags(extendFlags...),
 						h.WithArgs(extendArgs...),
 					)
 					h.AssertStringDoesNotContain(t, firstOutput, "Did not find cache key, pulling remote image...")
@@ -130,10 +142,7 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					t.Log("second build extends the build image by pulling from the cache directory")
 					secondOutput := h.DockerRunWithCombinedOutput(t,
 						extendImage,
-						h.WithFlags(
-							"--env", "CNB_PLATFORM_API="+platformAPI,
-							"--volume", fmt.Sprintf("%s:/kaniko", kanikoDir),
-						),
+						h.WithFlags(extendFlags...),
 						h.WithArgs(extendArgs...),
 					)
 					h.AssertStringDoesNotContain(t, secondOutput, "Did not find cache key, pulling remote image...")

--- a/acceptance/extender_test.go
+++ b/acceptance/extender_test.go
@@ -129,6 +129,7 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 						h.WithArgs(extendArgs...),
 					)
 					h.AssertStringDoesNotContain(t, firstOutput, "Did not find cache key, pulling remote image...")
+					h.AssertStringDoesNotContain(t, firstOutput, "Error while retrieving image from cache: oci")
 					h.AssertStringContains(t, firstOutput, "ca-certificates")
 					h.AssertStringContains(t, firstOutput, "Hello Extensions buildpack\ncurl") // output by buildpack, shows that curl was installed on the build image
 					t.Log("sets environment variables from the extended build image in the build context")
@@ -146,7 +147,8 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 						h.WithArgs(extendArgs...),
 					)
 					h.AssertStringDoesNotContain(t, secondOutput, "Did not find cache key, pulling remote image...")
-					h.AssertStringDoesNotContain(t, secondOutput, "ca-certificates")
+					h.AssertStringDoesNotContain(t, secondOutput, "Error while retrieving image from cache: oci")
+					h.AssertStringDoesNotContain(t, secondOutput, "ca-certificates")            // shows that cache layer was used
 					h.AssertStringContains(t, secondOutput, "Hello Extensions buildpack\ncurl") // output by buildpack, shows that curl is still installed in the unpacked cached layer
 				})
 			})

--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
+	"github.com/buildpacks/lifecycle"
 	"github.com/buildpacks/lifecycle/api"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
@@ -194,7 +195,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				h.DockerRunAndCopy(t,
 					containerName,
 					copyDir,
-					"/kaniko",
+					"/",
 					restoreImage,
 					h.WithFlags(
 						"--env", "CNB_PLATFORM_API="+platformAPI,
@@ -203,6 +204,10 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					),
 					h.WithArgs("-build-image", restoreRegFixtures.SomeCacheImage), // some-cache-image simulates a builder image in a registry
 				)
+				t.Log("records builder image digest in analyzed.toml")
+				analyzedMD, err := lifecycle.Config.ReadAnalyzed(filepath.Join(copyDir, "layers", "analyzed.toml"))
+				h.AssertNil(t, err)
+				h.AssertStringContains(t, analyzedMD.BuildImage.Reference, restoreRegFixtures.SomeCacheImage+"@sha256:")
 				t.Log("writes builder manifest and config to the kaniko cache")
 				fis, err := os.ReadDir(filepath.Join(copyDir, "kaniko", "cache", "base"))
 				h.AssertNil(t, err)

--- a/extender.go
+++ b/extender.go
@@ -83,7 +83,9 @@ func (f *ExtenderFactory) setImageRef(extender *Extender, path string) error {
 	if err != nil {
 		return err
 	}
-	extender.ImageRef = analyzedMD.BuildImage.Reference
+	if analyzedMD.BuildImage != nil {
+		extender.ImageRef = analyzedMD.BuildImage.Reference
+	}
 	return nil
 }
 

--- a/internal/extend/kaniko/dockerfile_applier.go
+++ b/internal/extend/kaniko/dockerfile_applier.go
@@ -11,11 +11,14 @@ import (
 	"github.com/buildpacks/lifecycle/log"
 )
 
-const kanikoDir = "/kaniko"
+const (
+	kanikoDir = "/kaniko"
+	ociPrefix = "oci:"
+)
 
 var (
 	kanikoCacheDir      = filepath.Join(kanikoDir, "cache", "base")
-	kanikoCacheImageRef = filepath.Join("oci:", kanikoDir, "cache", "layers", "cached")
+	kanikoCacheImageRef = filepath.Join(ociPrefix, kanikoDir, "cache", "layers", "cached")
 )
 
 type DockerfileApplier struct {

--- a/internal/extend/kaniko/dockerfile_applier_darwin.go
+++ b/internal/extend/kaniko/dockerfile_applier_darwin.go
@@ -6,6 +6,6 @@ import (
 	"github.com/buildpacks/lifecycle/internal/extend"
 )
 
-func (a *DockerfileApplier) Apply(workspace string, baseImageRef string, dockerfiles []extend.Dockerfile, options extend.Options) error {
+func (a *DockerfileApplier) Apply(workspace string, digest string, dockerfiles []extend.Dockerfile, options extend.Options) error {
 	return nil
 }

--- a/internal/extend/kaniko/dockerfile_applier_linux.go
+++ b/internal/extend/kaniko/dockerfile_applier_linux.go
@@ -18,11 +18,12 @@ import (
 	"github.com/buildpacks/lifecycle/internal/extend"
 )
 
-func (a *DockerfileApplier) Apply(workspace string, baseImageRef string, dockerfiles []extend.Dockerfile, options extend.Options) error {
+func (a *DockerfileApplier) Apply(workspace string, digest string, dockerfiles []extend.Dockerfile, options extend.Options) error {
 	// Configure kaniko
+	baseImageRef := ociPrefix + filepath.Join(kanikoCacheDir, digest)
 	baseImage, err := readOCI(baseImageRef)
 	if err != nil {
-		return fmt.Errorf("getting base image from reference '%s': %w", baseImageRef, err)
+		return fmt.Errorf("getting base image for digest '%s': %w", digest, err)
 	}
 	image.RetrieveRemoteImage = func(image string, opts config.RegistryOptions, customPlatform string) (v1.Image, error) {
 		return baseImage, nil // force kaniko to return this base image, instead of trying to pull it from a registry

--- a/internal/extend/kaniko/dockerfile_applier_linux.go
+++ b/internal/extend/kaniko/dockerfile_applier_linux.go
@@ -20,8 +20,8 @@ import (
 
 func (a *DockerfileApplier) Apply(workspace string, digest string, dockerfiles []extend.Dockerfile, options extend.Options) error {
 	// Configure kaniko
-	baseImageRef := ociPrefix + filepath.Join(kanikoCacheDir, digest)
-	baseImage, err := readOCI(baseImageRef)
+	layoutPath := ociPrefix + filepath.Join(kanikoCacheDir, digest)
+	baseImage, err := readOCI(layoutPath)
 	if err != nil {
 		return fmt.Errorf("getting base image for digest '%s': %w", digest, err)
 	}
@@ -30,6 +30,7 @@ func (a *DockerfileApplier) Apply(workspace string, digest string, dockerfiles [
 	}
 
 	// Range over Dockerfiles
+	baseImageRef := fmt.Sprintf("base@%s", digest)
 	for idx, dfile := range dockerfiles {
 		opts := createOptions(workspace, baseImageRef, dfile, options)
 

--- a/internal/extend/kaniko/dockerfile_applier_windows.go
+++ b/internal/extend/kaniko/dockerfile_applier_windows.go
@@ -6,6 +6,6 @@ import (
 	"github.com/buildpacks/lifecycle/internal/extend"
 )
 
-func (a *DockerfileApplier) Apply(workspace string, baseImageRef string, dockerfiles []extend.Dockerfile, options extend.Options) error {
+func (a *DockerfileApplier) Apply(workspace string, digest string, dockerfiles []extend.Dockerfile, options extend.Options) error {
 	return nil
 }

--- a/internal/selective/write_test.go
+++ b/internal/selective/write_test.go
@@ -35,11 +35,12 @@ func testSelective(t *testing.T, when spec.G, it spec.S) {
 			var opts []remote.Option
 			fileNotFoundMsg = "no such file or directory"
 			if runtime.GOOS == "windows" {
-				testImageName = "mcr.microsoft.com/windows/nanoserver:1809"
+				testImageName = "mcr.microsoft.com/windows/nanoserver@sha256:8bd4389d56e69bebf6e4666251fba42f7cce3d5b768d28816884fb4370155fee" // mcr.microsoft.com/windows/nanoserver:1809
+
 				windowsPlatform := v1.Platform{
 					Architecture: "amd64",
 					OS:           "windows",
-					OSVersion:    "10.0.17763.3406",
+					OSVersion:    "10.0.17763.3532",
 				}
 				opts = append(opts, remote.WithPlatform(windowsPlatform))
 				fileNotFoundMsg = "The system cannot find the file specified"

--- a/platform/extend_inputs.go
+++ b/platform/extend_inputs.go
@@ -8,6 +8,7 @@ import (
 // ExtendInputs holds the values of command-line flags and args.
 // Fields are the cumulative total of inputs across all supported platform APIs.
 type ExtendInputs struct {
+	AnalyzedPath   string
 	AppDir         string
 	BuildpacksDir  string
 	GeneratedDir   string
@@ -43,6 +44,9 @@ func (r *InputsResolver) ResolveExtend(inputs ExtendInputs) (ExtendInputs, error
 }
 
 func (r *InputsResolver) fillExtendDefaultPaths(inputs *ExtendInputs) {
+	if inputs.AnalyzedPath == PlaceholderAnalyzedPath {
+		inputs.AnalyzedPath = defaultPath(PlaceholderAnalyzedPath, inputs.LayersDir, r.platformAPI)
+	}
 	if inputs.GeneratedDir == PlaceholderGeneratedDir {
 		inputs.GeneratedDir = defaultPath(PlaceholderGeneratedDir, inputs.LayersDir, r.platformAPI)
 	}

--- a/platform/files.go
+++ b/platform/files.go
@@ -21,6 +21,7 @@ type AnalyzedMetadata struct {
 	PreviousImage *ImageIdentifier `toml:"image"`
 	Metadata      LayersMetadata   `toml:"metadata"`
 	RunImage      *ImageIdentifier `toml:"run-image,omitempty"`
+	BuildImage    *ImageIdentifier `toml:"build-image,omitempty"`
 }
 
 // FIXME: fix key names to be accurate in the daemon case

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -362,6 +362,14 @@ func Mkfile(t *testing.T, data string, paths ...string) {
 	}
 }
 
+func TempFile(t *testing.T, dir, pattern string) string {
+	t.Helper()
+	f, err := ioutil.TempFile(dir, pattern)
+	AssertNil(t, err)
+	defer f.Close()
+	return f.Name()
+}
+
 func CleanEndings(s string) string {
 	return strings.ReplaceAll(s, "\r\n", "\n")
 }

--- a/testmock/config_handler.go
+++ b/testmock/config_handler.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
+	platform "github.com/buildpacks/lifecycle/platform"
 )
 
 // MockConfigHandler is a mock of ConfigHandler interface.
@@ -33,6 +34,21 @@ func NewMockConfigHandler(ctrl *gomock.Controller) *MockConfigHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockConfigHandler) EXPECT() *MockConfigHandlerMockRecorder {
 	return m.recorder
+}
+
+// ReadAnalyzed mocks base method.
+func (m *MockConfigHandler) ReadAnalyzed(arg0 string) (platform.AnalyzedMetadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadAnalyzed", arg0)
+	ret0, _ := ret[0].(platform.AnalyzedMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadAnalyzed indicates an expected call of ReadAnalyzed.
+func (mr *MockConfigHandlerMockRecorder) ReadAnalyzed(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAnalyzed", reflect.TypeOf((*MockConfigHandler)(nil).ReadAnalyzed), arg0)
 }
 
 // ReadGroup mocks base method.


### PR DESCRIPTION
Favors passing the reference via analyzed.toml

To reflect this commit in the platform spec PR: https://github.com/buildpacks/spec/pull/320/commits/f0a3ef244ab34f467f3530117f2aec6cf18b7bf1