### PR TITLE
ci(lint): address most staticcheck alarms

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -2,7 +2,6 @@ package acceptance
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +27,7 @@ var (
 
 func TestVersion(t *testing.T) {
 	var err error
-	buildDir, err = ioutil.TempDir("", "lifecycle-acceptance")
+	buildDir, err = os.MkdirTemp("", "lifecycle-acceptance")
 	h.AssertNil(t, err)
 	defer func() {
 		h.AssertNil(t, os.RemoveAll(buildDir))

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -2,7 +2,6 @@ package acceptance
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -61,7 +60,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 		it.Before(func() {
 			containerName = "test-container-" + h.RandString(10)
 			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+			copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 			h.AssertNil(t, err)
 		})
 
@@ -986,7 +985,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 }
 
 func assertAnalyzedMetadata(t *testing.T, path string) *platform.AnalyzedMetadata {
-	contents, _ := ioutil.ReadFile(path)
+	contents, _ := os.ReadFile(path)
 	h.AssertEq(t, len(contents) > 0, true)
 
 	var analyzedMd platform.AnalyzedMetadata

--- a/acceptance/builder_test.go
+++ b/acceptance/builder_test.go
@@ -3,7 +3,6 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -66,7 +65,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		containerName = "test-container-" + h.RandString(10)
 		var err error
-		copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+		copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 		h.AssertNil(t, err)
 	})
 
@@ -454,7 +453,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 
 func getBuilderMetadata(t *testing.T, path string) *platform.BuildMetadata {
 	t.Helper()
-	contents, _ := ioutil.ReadFile(path)
+	contents, _ := os.ReadFile(path)
 	h.AssertEq(t, len(contents) > 0, true)
 
 	var analyzedMd platform.BuildMetadata

--- a/acceptance/creator_test.go
+++ b/acceptance/creator_test.go
@@ -4,7 +4,6 @@
 package acceptance
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -165,7 +164,7 @@ func testCreatorFunc(platformAPI string) func(t *testing.T, when spec.G, it spec
 				}
 				// create temp dirs
 				for _, dirPtr := range []*string{&dirCache, &dirLaunchCache, &dirBuild1, &dirRun1, &dirBuild2, &dirRun2} {
-					dir, err := ioutil.TempDir("", "creator-acceptance")
+					dir, err := os.MkdirTemp("", "creator-acceptance")
 					h.AssertNil(t, err)
 					h.AssertNil(t, os.Chmod(dir, 0777)) // Override umask
 

--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -5,7 +5,6 @@ package acceptance
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -129,7 +128,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			containerName = "test-container-" + h.RandString(10)
 			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+			copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 			h.AssertNil(t, err)
 		})
 
@@ -180,7 +179,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			containerName = "test-container-" + h.RandString(10)
 			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+			copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 			h.AssertNil(t, err)
 		})
 
@@ -219,7 +218,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 
 			// check plan.toml - should be empty since we're using always_detect_order.toml so there is no "actual plan"
 			tempPlanToml := filepath.Join(copyDir, "layers", "custom_plan.toml")
-			planContents, err := ioutil.ReadFile(tempPlanToml)
+			planContents, err := os.ReadFile(tempPlanToml)
 			h.AssertNil(t, err)
 			h.AssertEq(t, len(planContents) == 0, true)
 
@@ -238,7 +237,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			containerName = "test-container-" + h.RandString(10)
 			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+			copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 			h.AssertNil(t, err)
 
 			simpleOrderTOML := filepath.Join("testdata", "detector", "container", "cnb", "orders", "simple_order.toml")
@@ -322,7 +321,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 		it.Before(func() {
 			containerName = "test-container-" + h.RandString(10)
 			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+			copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 			h.AssertNil(t, err)
 			orderPath, err = filepath.Abs(filepath.Join("testdata", "detector", "container", "cnb", "orders", "order_with_ext.toml"))
 			h.AssertNil(t, err)
@@ -381,7 +380,7 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			t.Log("copies the generated dockerfiles to the output directory")
 			dockerfilePath := filepath.Join(copyDir, "layers", "generated", "run", "simple_extension", "Dockerfile")
 			h.AssertPathExists(t, dockerfilePath)
-			contents, err := ioutil.ReadFile(dockerfilePath)
+			contents, err := os.ReadFile(dockerfilePath)
 			h.AssertEq(t, string(contents), "FROM some-run-image-from-extension\n")
 			t.Log("records the new run image in analyzed.toml")
 			foundAnalyzedTOML := filepath.Join(copyDir, "layers", "analyzed.toml")

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -6,8 +6,8 @@ package acceptance
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -294,9 +294,9 @@ func updateAnalyzedTOMLFixturesWithRegRepoName(t *testing.T, phaseTest *PhaseTes
 }
 
 func calculateEmptyLayerSha(t *testing.T) string {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	h.AssertNil(t, err)
 	testLayerEmptyPath := filepath.Join(tmpDir, "empty.tar")
-	h.AssertNil(t, ioutil.WriteFile(testLayerEmptyPath, []byte{}, 0600))
+	h.AssertNil(t, os.WriteFile(testLayerEmptyPath, []byte{}, 0600))
 	return "sha256:" + h.ComputeSHA256ForFile(t, testLayerEmptyPath)
 }

--- a/acceptance/extender_test.go
+++ b/acceptance/extender_test.go
@@ -69,7 +69,7 @@ func testExtenderFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 
 			it.Before(func() {
 				var err error
-				kanikoDir, err = ioutil.TempDir("", "lifecycle-acceptance")
+				kanikoDir, err = os.MkdirTemp("", "lifecycle-acceptance")
 				h.AssertNil(t, err)
 
 				// push "builder" image to test registry

--- a/acceptance/phase_test.go
+++ b/acceptance/phase_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -188,10 +188,10 @@ func (d *targetDaemon) removeFixtures(t *testing.T) {
 func (r *targetRegistry) start(t *testing.T) {
 	var err error
 
-	r.dockerConfigDir, err = ioutil.TempDir("", "test.docker.config.dir")
+	r.dockerConfigDir, err = os.MkdirTemp("", "test.docker.config.dir")
 	h.AssertNil(t, err)
 
-	sharedRegHandler := registry.New(registry.Logger(log.New(ioutil.Discard, "", log.Lshortfile)))
+	sharedRegHandler := registry.New(registry.Logger(log.New(io.Discard, "", log.Lshortfile)))
 	r.registry = ih.NewDockerRegistry(
 		ih.WithAuth(r.dockerConfigDir),
 		ih.WithSharedHandler(sharedRegHandler),
@@ -345,7 +345,7 @@ func cleanupDaemonFixtures(t *testing.T, fixtures interface{}) {
 }
 
 func minifyMetadata(t *testing.T, path string, metadataStruct interface{}) string {
-	metadata, err := ioutil.ReadFile(path)
+	metadata, err := os.ReadFile(path)
 	h.AssertNil(t, err)
 
 	// Unmarshal and marshal to strip unnecessary whitespace

--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -4,7 +4,6 @@
 package acceptance
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -59,7 +58,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 		it.Before(func() {
 			containerName = "test-container-" + h.RandString(10)
 			var err error
-			copyDir, err = ioutil.TempDir("", "test-docker-copy-")
+			copyDir, err = os.MkdirTemp("", "test-docker-copy-")
 			h.AssertNil(t, err)
 		})
 
@@ -148,7 +147,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					h.AssertPathExists(t, cachedFile)
 
 					// check restored cache file content is correct
-					contents, err := ioutil.ReadFile(cachedFile)
+					contents, err := os.ReadFile(cachedFile)
 					h.AssertNil(t, err)
 					h.AssertEq(t, string(contents), "cached-data\n")
 				})

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -3,7 +3,6 @@ package lifecycle_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,7 +56,7 @@ func testAnalyzerFactory(t *testing.T, when spec.G, it spec.S) {
 			fakeRegistryHandler = testmock.NewMockRegistryHandler(mockController)
 			logger = &log.Logger{Handler: &discard.Handler{}}
 			var err error
-			tempDir, err = ioutil.TempDir("", "")
+			tempDir, err = os.MkdirTemp("", "")
 			h.AssertNil(t, err)
 		})
 
@@ -437,13 +436,13 @@ func testAnalyzer(platformAPI string) func(t *testing.T, when spec.G, it spec.S)
 		it.Before(func() {
 			var err error
 
-			tmpDir, err = ioutil.TempDir("", "analyzer-tests")
+			tmpDir, err = os.MkdirTemp("", "analyzer-tests")
 			h.AssertNil(t, err)
 
-			layersDir, err = ioutil.TempDir("", "lifecycle-layer-dir")
+			layersDir, err = os.MkdirTemp("", "lifecycle-layer-dir")
 			h.AssertNil(t, err)
 
-			cacheDir, err = ioutil.TempDir("", "some-cache-dir")
+			cacheDir, err = os.MkdirTemp("", "some-cache-dir")
 			h.AssertNil(t, err)
 
 			testCache, err = cache.NewVolumeCache(cacheDir)

--- a/api/apis.go
+++ b/api/apis.go
@@ -37,12 +37,13 @@ func newApisMustParse(supported []string, deprecated []string) APIs {
 }
 
 // NewApis constructs an instance of APIs
-//  supported must be a superset of deprecated
-//  deprecated APIs greater than 1.0 should should not include minor versions
-//  supported APIs should always include minor versions
-//  Examples:
-//     deprecated API 1 implies all 1.x APIs are deprecated
-//     supported API 1 implies only 1.0 is supported
+//
+//	supported must be a superset of deprecated
+//	deprecated APIs greater than 1.0 should should not include minor versions
+//	supported APIs should always include minor versions
+//	Examples:
+//	   deprecated API 1 implies all 1.x APIs are deprecated
+//	   supported API 1 implies only 1.0 is supported
 func NewAPIs(supported []string, deprecated []string) (APIs, error) {
 	apis := APIs{}
 	for _, api := range supported {

--- a/api/version.go
+++ b/api/version.go
@@ -84,9 +84,10 @@ func (v *Version) Equal(o *Version) bool {
 }
 
 // Compare returns one of the following results
-//   -1 is less than *Version o
-//    0 is equal to *Version o
-//    1 is greater than *Version o
+//
+//	-1 is less than *Version o
+//	 0 is equal to *Version o
+//	 1 is greater than *Version o
 func (v *Version) Compare(o *Version) int {
 	if v.Major != o.Major {
 		if v.Major < o.Major {

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -28,7 +27,7 @@ func testWrite(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "archive-write-test")
+		tmpDir, err = os.MkdirTemp("", "archive-write-test")
 		h.AssertNil(t, err)
 	})
 

--- a/archive/extract_test.go
+++ b/archive/extract_test.go
@@ -2,7 +2,6 @@ package archive_test
 
 import (
 	"archive/tar"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -125,7 +124,7 @@ func testExtract(t *testing.T, when spec.G, it spec.S) {
 }
 
 func newFakeTarReader(t *testing.T) (*archive.NormalizingTarReader, string) {
-	tmpDir, err := ioutil.TempDir("", "archive-extract-test")
+	tmpDir, err := os.MkdirTemp("", "archive-extract-test")
 	h.AssertNil(t, err)
 	ftr := &fakeTarReader{}
 	tr := archive.NewNormalizingTarReader(ftr)

--- a/archive/reader.go
+++ b/archive/reader.go
@@ -36,7 +36,8 @@ func (tr *NormalizingTarReader) ExcludePaths(paths []string) {
 }
 
 // PrependDir will set the Name of any subsequently read *tar.Header the result of filepath.Join of dir and the
-//  original Name
+//
+//	original Name
 func (tr *NormalizingTarReader) PrependDir(dir string) {
 	tr.headerOpts = append(tr.headerOpts, func(hdr *tar.Header) *tar.Header {
 		// Suppress gosec check for zip slip vulnerability, as we set dir in our code.
@@ -53,7 +54,9 @@ func NewNormalizingTarReader(tr TarReader) *NormalizingTarReader {
 
 // Next calls Next on the wrapped TarReader and applies modifications before returning the *tar.Header
 // If the wrapped TarReader returns a *tar.Header matching an excluded path Next will proceed to the next entry,
-//  returning the first non-excluded entry
+//
+//	returning the first non-excluded entry
+//
 // Modification options will be apply in the order the options were invoked.
 // Standard modifications (path separators normalization) are applied last.
 func (tr *NormalizingTarReader) Next() (*tar.Header, error) {

--- a/archive/tar_windows.go
+++ b/archive/tar_windows.go
@@ -24,7 +24,8 @@ func setUmask(newMask int) (oldMask int) {
 
 // createSymlink uses the file attributes in the PAX records to decide whether to make a directory or file type symlink.
 // We must use the syscall because we often create symlinks when the target does not exist and os.Symlink uses the mode
-//   of the target to create the appropriate type of symlink on windows https://github.com/golang/go/issues/39183
+//
+//	of the target to create the appropriate type of symlink on windows https://github.com/golang/go/issues/39183
 func createSymlink(hdr *tar.Header) error {
 	var flags uint32 = symbolicLinkFlagAllowUnprivilegedCreate
 	if attrStr, ok := hdr.PAXRecords[hdrFileAttributes]; ok {

--- a/archive/tar_windows_test.go
+++ b/archive/tar_windows_test.go
@@ -2,7 +2,6 @@ package archive_test
 
 import (
 	"archive/tar"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ func testTarWindows(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "archive-extract-test")
+		tmpDir, err = os.MkdirTemp("", "archive-extract-test")
 		h.AssertNil(t, err)
 		ftr = &fakeTarReader{}
 		tr = archive.NewNormalizingTarReader(ftr)

--- a/auth/keychain.go
+++ b/auth/keychain.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 
@@ -18,7 +18,7 @@ import (
 const EnvRegistryAuth = "CNB_REGISTRY_AUTH"
 
 var (
-	amazonKeychain = authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(ioutil.Discard)))
+	amazonKeychain = authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard)))
 	azureKeychain  = authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper())
 )
 

--- a/auth/keychain.go
+++ b/auth/keychain.go
@@ -153,11 +153,13 @@ func (k *ResolvedKeychain) Resolve(resource authn.Resource) (authn.Authenticator
 // Complementary to `BuildEnvVar`.
 //
 // Example Input:
-// 	{"gcr.io": "Bearer asdf=", "docker.io": "Basic qwerty="}
+//
+//	{"gcr.io": "Bearer asdf=", "docker.io": "Basic qwerty="}
 //
 // Example Output:
-//  gcr.io -> Bearer asdf=
-//  docker.io -> Basic qwerty=
+//
+//	gcr.io -> Bearer asdf=
+//	docker.io -> Basic qwerty=
 func ReadEnvVar(envVar string) (map[string]string, error) {
 	authMap := map[string]string{}
 

--- a/builder.go
+++ b/builder.go
@@ -181,19 +181,21 @@ func (b *Builder) getCommonInputs() (buildpack.BuildInputs, error) {
 // Before:
 // /layers
 // └── buildpack.id
-//     ├── A
-//     │   └── ...
-//     ├── A.sbom.cdx.json
-//     └── launch.sbom.cdx.json
+//
+//	├── A
+//	│   └── ...
+//	├── A.sbom.cdx.json
+//	└── launch.sbom.cdx.json
 //
 // After:
 // /layers
 // └── sbom
-//     └── launch
-//         └── buildpack.id
-//             ├── A
-//             │   └── sbom.cdx.json
-//             └── sbom.cdx.json
+//
+//	└── launch
+//	    └── buildpack.id
+//	        ├── A
+//	        │   └── sbom.cdx.json
+//	        └── sbom.cdx.json
 func (b *Builder) copySBOMFiles(layersDir string, bomFiles []buildpack.BOMFile) error {
 	var (
 		buildSBOMDir  = filepath.Join(layersDir, "sbom", "build")

--- a/builder_test.go
+++ b/builder_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,7 +59,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 		executor = testmock.NewMockBuildExecutor(mockCtrl)
 
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle")
+		tmpDir, err = os.MkdirTemp("", "lifecycle")
 		h.AssertNil(t, err)
 		layersDir = filepath.Join(tmpDir, "launch")
 		appDir = filepath.Join(layersDir, "app")
@@ -373,7 +372,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 
 					t.Log("saves the aggregated legacy launch bom to <layers>/sbom/launch/sbom.legacy.json")
 					var foundLaunch []buildpack.BOMEntry
-					launchContents, err := ioutil.ReadFile(filepath.Join(builder.LayersDir, "sbom", "launch", "sbom.legacy.json"))
+					launchContents, err := os.ReadFile(filepath.Join(builder.LayersDir, "sbom", "launch", "sbom.legacy.json"))
 					h.AssertNil(t, err)
 					h.AssertNil(t, json.Unmarshal(launchContents, &foundLaunch))
 					expectedLaunch := []buildpack.BOMEntry{
@@ -398,7 +397,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 
 					t.Log("saves the aggregated legacy build bom to <layers>/sbom/build/sbom.legacy.json")
 					var foundBuild []buildpack.BOMEntry
-					buildContents, err := ioutil.ReadFile(filepath.Join(builder.LayersDir, "sbom", "build", "sbom.legacy.json"))
+					buildContents, err := os.ReadFile(filepath.Join(builder.LayersDir, "sbom", "build", "sbom.legacy.json"))
 					h.AssertNil(t, err)
 					h.AssertNil(t, json.Unmarshal(buildContents, &foundBuild))
 					expectedBuild := []buildpack.BOMEntry{

--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -72,7 +72,7 @@ func (e *DefaultBuildExecutor) Build(d BpDescriptor, inputs BuildInputs, logger 
 	}
 
 	logger.Debug("Creating plan directory")
-	planDir, err := ioutil.TempDir("", launch.EscapeID(d.Buildpack.ID)+"-")
+	planDir, err := os.MkdirTemp("", launch.EscapeID(d.Buildpack.ID)+"-")
 	if err != nil {
 		return BuildOutputs{}, err
 	}

--- a/buildpack/build_test.go
+++ b/buildpack/build_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,7 +82,7 @@ func testBuild(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		// setup dirs
-		tmpDir, err = ioutil.TempDir("", "lifecycle")
+		tmpDir, err = os.MkdirTemp("", "lifecycle")
 		h.AssertNil(t, err)
 		layersDir = filepath.Join(tmpDir, "launch")
 		appDir = filepath.Join(layersDir, "app")

--- a/buildpack/detect.go
+++ b/buildpack/detect.go
@@ -3,7 +3,6 @@ package buildpack
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -158,12 +157,12 @@ func processPlatformPaths(inputs DetectInputs) (string, string, error) {
 }
 
 func processBuildpackPaths() (string, string, error) {
-	planDir, err := ioutil.TempDir("", "plan.")
+	planDir, err := os.MkdirTemp("", "plan.")
 	if err != nil {
 		return "", "", err
 	}
 	planPath := filepath.Join(planDir, "plan.toml")
-	if err = ioutil.WriteFile(planPath, nil, 0600); err != nil {
+	if err = os.WriteFile(planPath, nil, 0600); err != nil {
 		return "", "", err
 	}
 	return planDir, planPath, nil

--- a/buildpack/detect_test.go
+++ b/buildpack/detect_test.go
@@ -2,7 +2,6 @@ package buildpack_test
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -49,7 +48,7 @@ func testDetect(t *testing.T, when spec.G, it spec.S) {
 
 		// setup dirs
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle")
+		tmpDir, err = os.MkdirTemp("", "lifecycle")
 		if err != nil {
 			t.Fatalf("Error: %s\n", err)
 		}

--- a/buildpack/dockerfile.go
+++ b/buildpack/dockerfile.go
@@ -3,6 +3,7 @@ package buildpack
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"

--- a/buildpack/dockerfile.go
+++ b/buildpack/dockerfile.go
@@ -3,7 +3,6 @@ package buildpack
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
@@ -41,7 +40,7 @@ type ExtendArg struct {
 func parseDockerfile(dockerfile string) ([]instructions.Stage, []instructions.ArgCommand, error) {
 	var err error
 	var d []uint8
-	d, err = ioutil.ReadFile(dockerfile)
+	d, err = os.ReadFile(dockerfile)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildpack/dockerfile_test.go
+++ b/buildpack/dockerfile_test.go
@@ -2,7 +2,6 @@ package buildpack_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ func testDockerfile(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "")
+		tmpDir, err = os.MkdirTemp("", "")
 		h.AssertNil(t, err)
 
 		logHandler = memory.New()
@@ -84,7 +83,7 @@ RUN echo "this statement is never cached"
 					for i, content := range dockerfileContents {
 						dockerfileName := fmt.Sprintf("Dockerfile%d", i)
 						dockerfilePath := filepath.Join(tmpDir, dockerfileName)
-						h.AssertNil(t, ioutil.WriteFile(dockerfilePath, []byte(content), 0600))
+						h.AssertNil(t, os.WriteFile(dockerfilePath, []byte(content), 0600))
 						err := buildpack.VerifyBuildDockerfile(dockerfilePath, logger)
 						if err != nil {
 							t.Fatalf("Error verifying Dockerfile %d: %s", i, err)
@@ -140,7 +139,7 @@ FROM ${base_image}
 					}
 					for i, tc := range testCases {
 						dockerfilePath := filepath.Join(tmpDir, fmt.Sprintf("Dockerfile%d", i))
-						h.AssertNil(t, ioutil.WriteFile(dockerfilePath, []byte(tc.dockerfileContent), 0600))
+						h.AssertNil(t, os.WriteFile(dockerfilePath, []byte(tc.dockerfileContent), 0600))
 						logHandler = memory.New()
 						logger = &log.Logger{Handler: logHandler}
 						err := buildpack.VerifyBuildDockerfile(dockerfilePath, logger)
@@ -183,7 +182,7 @@ COPY --from=0 /some-source.txt ./some-dest.txt
 					}
 					for i, tc := range testCases {
 						dockerfilePath := filepath.Join(tmpDir, fmt.Sprintf("Dockerfile%d", i))
-						h.AssertNil(t, ioutil.WriteFile(dockerfilePath, []byte(tc.dockerfileContent), 0600))
+						h.AssertNil(t, os.WriteFile(dockerfilePath, []byte(tc.dockerfileContent), 0600))
 						err := buildpack.VerifyBuildDockerfile(dockerfilePath, logger)
 						h.AssertError(t, err, tc.expectedError)
 					}
@@ -200,7 +199,7 @@ COPY --from=0 /some-source.txt ./some-dest.txt
 					for i, content := range dockerfileContents {
 						dockerfileName := fmt.Sprintf("Dockerfile%d", i)
 						dockerfilePath := filepath.Join(tmpDir, dockerfileName)
-						h.AssertNil(t, ioutil.WriteFile(dockerfilePath, []byte(content), 0600))
+						h.AssertNil(t, os.WriteFile(dockerfilePath, []byte(content), 0600))
 						err := buildpack.VerifyRunDockerfile(dockerfilePath)
 						if err != nil {
 							t.Fatalf("Error verifying Dockerfile %d: %s", i, err)
@@ -238,7 +237,7 @@ RUN echo "hello" > /world.txt
 					}
 					for i, tc := range testCases {
 						dockerfilePath := filepath.Join(tmpDir, fmt.Sprintf("Dockerfile%d", i))
-						h.AssertNil(t, ioutil.WriteFile(dockerfilePath, []byte(tc.dockerfileContent), 0600))
+						h.AssertNil(t, os.WriteFile(dockerfilePath, []byte(tc.dockerfileContent), 0600))
 						err := buildpack.VerifyRunDockerfile(dockerfilePath)
 						h.AssertError(t, err, tc.expectedError)
 					}

--- a/buildpack/generate.go
+++ b/buildpack/generate.go
@@ -2,7 +2,6 @@ package buildpack
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -41,7 +40,7 @@ type DefaultGenerateExecutor struct{}
 
 func (e *DefaultGenerateExecutor) Generate(d ExtDescriptor, inputs GenerateInputs, logger log.Logger) (GenerateOutputs, error) {
 	logger.Debug("Creating plan directory")
-	planDir, err := ioutil.TempDir("", launch.EscapeID(d.Extension.ID)+"-")
+	planDir, err := os.MkdirTemp("", launch.EscapeID(d.Extension.ID)+"-")
 	if err != nil {
 		return GenerateOutputs{}, err
 	}

--- a/buildpack/generate_test.go
+++ b/buildpack/generate_test.go
@@ -3,7 +3,6 @@ package buildpack_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -73,7 +72,7 @@ func testGenerate(t *testing.T, when spec.G, it spec.S) {
 		}
 
 		// setup dirs
-		tmpDir, err = ioutil.TempDir("", "lifecycle")
+		tmpDir, err = os.MkdirTemp("", "lifecycle")
 		h.AssertNil(t, err)
 		outputDir = filepath.Join(tmpDir, "launch")
 		appDir = filepath.Join(outputDir, "app")

--- a/buildpack/layers.go
+++ b/buildpack/layers.go
@@ -161,7 +161,7 @@ func (l *Layer) Read() (LayerMetadata, error) {
 		}
 	}
 	var sha string
-	shaBytes, err := ioutil.ReadFile(l.Path() + ".sha")
+	shaBytes, err := os.ReadFile(l.Path() + ".sha")
 	if err != nil && !os.IsNotExist(err) { // if the sha file doesn't exist, an empty sha will be returned
 		return LayerMetadata{}, err
 	}
@@ -193,7 +193,7 @@ func (l *Layer) WriteMetadata(metadata LayerMetadataFile) error {
 }
 
 func (l *Layer) WriteSha(sha string) error {
-	if err := ioutil.WriteFile(l.path+".sha", []byte(sha), 0666); err != nil {
+	if err := os.WriteFile(l.path+".sha", []byte(sha), 0666); err != nil {
 		return err
 	} // #nosec G306
 	return nil

--- a/cache/caching_image_test.go
+++ b/cache/caching_image_test.go
@@ -2,7 +2,6 @@ package cache_test
 
 import (
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -39,7 +38,7 @@ func testCachingImage(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 		fakeImage = fakes.NewImage("some-image", "", nil)
-		tmpDir, err = ioutil.TempDir("", "")
+		tmpDir, err = os.MkdirTemp("", "")
 		h.AssertNil(t, err)
 		volumeCache, err = cache.NewVolumeCache(tmpDir)
 		h.AssertNil(t, err)
@@ -142,7 +141,7 @@ func testCachingImage(t *testing.T, when spec.G, it spec.S) {
 				rc, err := subject.GetLayer(layerSHA)
 				h.AssertNil(t, err)
 				defer rc.Close()
-				contents, err := ioutil.ReadAll(rc)
+				contents, err := io.ReadAll(rc)
 				h.AssertNil(t, err)
 				h.AssertEq(t, contents, layerData)
 			})
@@ -159,7 +158,7 @@ func testCachingImage(t *testing.T, when spec.G, it spec.S) {
 				rc, err := subject.GetLayer(layerSHA)
 				h.AssertNil(t, err)
 				defer rc.Close()
-				contents, err := ioutil.ReadAll(rc)
+				contents, err := io.ReadAll(rc)
 				h.AssertNil(t, err)
 				h.AssertEq(t, contents, layerData)
 			})

--- a/cache/image_cache_test.go
+++ b/cache/image_cache_test.go
@@ -2,7 +2,7 @@ package cache_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -38,7 +38,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		tmpDir, err = ioutil.TempDir("", "")
+		tmpDir, err = os.MkdirTemp("", "")
 		h.AssertNil(t, err)
 
 		fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOriginalImage"})
@@ -47,7 +47,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 		subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
 
 		testLayerTarPath = filepath.Join(tmpDir, "some-layer.tar")
-		h.AssertNil(t, ioutil.WriteFile(testLayerTarPath, []byte("dummy data"), 0600))
+		h.AssertNil(t, os.WriteFile(testLayerTarPath, []byte("dummy data"), 0600))
 		testLayerSHA = "sha256:" + h.ComputeSHA256ForFile(t, testLayerTarPath)
 	})
 
@@ -129,7 +129,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 				defer rc.Close()
 
-				bytes, err := ioutil.ReadAll(rc)
+				bytes, err := io.ReadAll(rc)
 				h.AssertNil(t, err)
 				h.AssertEq(t, string(bytes), "dummy data")
 			})
@@ -208,7 +208,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					defer rc.Close()
 
-					bytes, err := ioutil.ReadAll(rc)
+					bytes, err := io.ReadAll(rc)
 					h.AssertNil(t, err)
 					h.AssertEq(t, string(bytes), "dummy data")
 				})
@@ -250,7 +250,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					defer rc.Close()
 
-					bytes, err := ioutil.ReadAll(rc)
+					bytes, err := io.ReadAll(rc)
 					h.AssertNil(t, err)
 					h.AssertEq(t, string(bytes), "dummy data")
 				})
@@ -273,7 +273,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, err)
 					defer rc.Close()
 
-					bytes, err := ioutil.ReadAll(rc)
+					bytes, err := io.ReadAll(rc)
 					h.AssertNil(t, err)
 					h.AssertEq(t, string(bytes), "dummy data")
 				})

--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -30,7 +30,7 @@ func Run(c Command, asSubcommand bool) {
 		noColor      bool
 	)
 
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	FlagVersion(&printVersion)
 	FlagLogLevel(&logLevel)
 	FlagNoColor(&noColor)

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -266,7 +265,7 @@ func (e *exportCmd) validateRunImageInput() error {
 }
 
 func (ea exportArgs) export(group buildpack.Group, cacheStore lifecycle.Cache, analyzedMD platform.AnalyzedMetadata) error {
-	artifactsDir, err := ioutil.TempDir("", "lifecycle.exporter.layer")
+	artifactsDir, err := os.MkdirTemp("", "lifecycle.exporter.layer")
 	if err != nil {
 		return cmd.FailErr(err, "create temp directory")
 	}

--- a/env/env.go
+++ b/env/env.go
@@ -146,7 +146,7 @@ func suffix(s string, suffix ...byte) string {
 }
 
 func delim(dir, name string, def ...byte) []byte {
-	value, err := ioutil.ReadFile(filepath.Join(dir, name+".delim"))
+	value, err := os.ReadFile(filepath.Join(dir, name+".delim"))
 	if err != nil {
 		return def
 	}
@@ -173,7 +173,7 @@ func eachEnvFile(dir string, fn func(k, v string) error) error {
 				continue
 			}
 		}
-		value, err := ioutil.ReadFile(filepath.Join(dir, f.Name()))
+		value, err := os.ReadFile(filepath.Join(dir, f.Name()))
 		if err != nil {
 			return err
 		}

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -2,7 +2,6 @@ package env_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,7 +28,7 @@ func testEnv(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle")
+		tmpDir, err = os.MkdirTemp("", "lifecycle")
 		if err != nil {
 			t.Fatalf("Error: %s\n", err)
 		}
@@ -299,7 +298,7 @@ func mkdir(t *testing.T, dirs ...string) {
 func mkfile(t *testing.T, data string, paths ...string) {
 	t.Helper()
 	for _, p := range paths {
-		if err := ioutil.WriteFile(p, []byte(data), 0600); err != nil {
+		if err := os.WriteFile(p, []byte(data), 0600); err != nil {
 			t.Fatalf("Error: %s\n", err)
 		}
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -3,7 +3,7 @@ package lifecycle_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -57,7 +57,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 		layerFactory = testmock.NewMockLayerFactory(mockCtrl)
 
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle.exporter.layer")
+		tmpDir, err = os.MkdirTemp("", "lifecycle.exporter.layer")
 		h.AssertNil(t, err)
 
 		launcherPath, err := filepath.Abs(filepath.Join("testdata", "exporter", "launcher"))
@@ -78,7 +78,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 
 		opts.LayersDir = filepath.Join(tmpDir, "layers")
 		h.AssertNil(t, os.Mkdir(opts.LayersDir, 0777))
-		h.AssertNil(t, ioutil.WriteFile(filepath.Join(tmpDir, "launcher"), []byte("some-launcher"), 0600))
+		h.AssertNil(t, os.WriteFile(filepath.Join(tmpDir, "launcher"), []byte("some-launcher"), 0600))
 		opts.AppDir = filepath.Join(tmpDir, "app")
 
 		fakeAppImage = fakes.NewImage(
@@ -464,7 +464,7 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 
 					when("metadata.toml is missing bom and has empty process list", func() {
 						it.Before(func() {
-							err := ioutil.WriteFile(filepath.Join(opts.LayersDir, "config", "metadata.toml"), []byte(`
+							err := os.WriteFile(filepath.Join(opts.LayersDir, "config", "metadata.toml"), []byte(`
 processes = []
 
 [[buildpacks]]
@@ -992,7 +992,7 @@ version = "4.5.6"
 			when("there are store.toml files", func() {
 				it.Before(func() {
 					path := filepath.Join(opts.LayersDir, "buildpack.id", "store.toml")
-					h.AssertNil(t, ioutil.WriteFile(path, []byte("[metadata]\n  key = \"val\""), 0600))
+					h.AssertNil(t, os.WriteFile(path, []byte("[metadata]\n  key = \"val\""), 0600))
 				})
 
 				it("saves store metadata", func() {
@@ -1548,7 +1548,7 @@ func assertHasLayer(t *testing.T, fakeAppImage *fakes.Image, id string) {
 	rc, err := fakeAppImage.GetLayer(testLayerDigest(id))
 	h.AssertNil(t, err)
 	defer rc.Close()
-	contents, err := ioutil.ReadAll(rc)
+	contents, err := io.ReadAll(rc)
 	h.AssertNil(t, err)
 	h.AssertEq(t, string(contents), testLayerContents(id))
 }

--- a/extender_test.go
+++ b/extender_test.go
@@ -1,7 +1,6 @@
 package lifecycle_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -111,7 +110,7 @@ func testExtender(t *testing.T, when spec.G, it spec.S) {
 		mockCtrl = gomock.NewController(t)
 
 		var err error
-		generatedDir, err = ioutil.TempDir("", "lifecycle")
+		generatedDir, err = os.MkdirTemp("", "lifecycle")
 		h.AssertNil(t, err)
 
 		providedExtensions := []buildpack.GroupElement{

--- a/generator.go
+++ b/generator.go
@@ -3,7 +3,6 @@ package lifecycle
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -87,7 +86,7 @@ type GenerateResult struct {
 
 func (g *Generator) Generate() (GenerateResult, error) {
 	inputs := g.getCommonInputs()
-	extensionOutputParentDir, err := ioutil.TempDir("", "cnb-extensions-generated.")
+	extensionOutputParentDir, err := os.MkdirTemp("", "cnb-extensions-generated.")
 	if err != nil {
 		return GenerateResult{}, err
 	}

--- a/generator_test.go
+++ b/generator_test.go
@@ -2,7 +2,6 @@ package lifecycle_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -121,7 +120,7 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 		executor = testmock.NewMockGenerateExecutor(mockCtrl)
 
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle")
+		tmpDir, err = os.MkdirTemp("", "lifecycle")
 		h.AssertNil(t, err)
 		generatedDir = filepath.Join(tmpDir, "output")
 		appDir = filepath.Join(generatedDir, "app")

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,7 +1,6 @@
 package lifecycle_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ func testHandlers(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle.test")
+		tmpDir, err = os.MkdirTemp("", "lifecycle.test")
 		h.AssertNil(t, err)
 
 		groupTOMLContents = `

--- a/internal/encoding/utils_test.go
+++ b/internal/encoding/utils_test.go
@@ -1,7 +1,6 @@
 package encoding_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,7 +24,7 @@ func testEncoding(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "lifecycle.test")
+			tmpDir, err = os.MkdirTemp("", "lifecycle.test")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -54,7 +53,7 @@ func testEncoding(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "lifecycle.test")
+			tmpDir, err = os.MkdirTemp("", "lifecycle.test")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/fsutil/utils_test.go
+++ b/internal/fsutil/utils_test.go
@@ -1,7 +1,6 @@
 package fsutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ func testIO(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle.test")
+		tmpDir, err = os.MkdirTemp("", "lifecycle.test")
 		h.AssertNil(t, err)
 	})
 

--- a/internal/layer/metadata_restorer_test.go
+++ b/internal/layer/metadata_restorer_test.go
@@ -40,7 +40,7 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		layerDir, err = ioutil.TempDir("", "lifecycle-layer-dir")
+		layerDir, err = os.MkdirTemp("", "lifecycle-layer-dir")
 		h.AssertNil(t, err)
 		useShaFiles = true // notice - the default for platform API >= 0.7 is false (it's set to false in some of the tests)
 		logger = log.Logger{Handler: &discard.Handler{}}

--- a/internal/layer/sbom_restorer_test.go
+++ b/internal/layer/sbom_restorer_test.go
@@ -2,7 +2,6 @@ package layer_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func testSBOMRestorer(t *testing.T, when spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		layersDir, err = ioutil.TempDir("", "lifecycle.layers-dir.")
+		layersDir, err = os.MkdirTemp("", "lifecycle.layers-dir.")
 		h.AssertNil(t, err)
 
 		sbomRestorer = layer.NewSBOMRestorer(layer.SBOMRestorerOpts{
@@ -89,7 +88,7 @@ func testSBOMRestorer(t *testing.T, when spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			artifactsDir, err = ioutil.TempDir("", "lifecycle.artifacts-dir.")
+			artifactsDir, err = os.MkdirTemp("", "lifecycle.artifacts-dir.")
 			h.AssertNil(t, err)
 			h.Mkdir(t, filepath.Join(layersDir, "sbom", "launch"))
 			h.Mkfile(t, "some-bom-data", filepath.Join(layersDir, "sbom", "launch", "some-file"))
@@ -153,7 +152,7 @@ func testSBOMRestorer(t *testing.T, when spec.G, it spec.S) {
 		)
 
 		it.Before(func() {
-			artifactsDir, err = ioutil.TempDir("", "lifecycle.artifacts-dir.")
+			artifactsDir, err = os.MkdirTemp("", "lifecycle.artifacts-dir.")
 			h.AssertNil(t, err)
 			h.Mkdir(t, filepath.Join(layersDir, "sbom", "cache"))
 			h.Mkfile(t, "some-bom-data", filepath.Join(layersDir, "sbom", "cache", "some-file"))
@@ -162,7 +161,7 @@ func testSBOMRestorer(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, err)
 			layerDigest = layer.Digest
 
-			cacheDir, err = ioutil.TempDir("", "lifecycle.cache-dir.")
+			cacheDir, err = os.MkdirTemp("", "lifecycle.cache-dir.")
 			h.AssertNil(t, err)
 			testCache, err = cache.NewVolumeCache(cacheDir)
 			h.AssertNil(t, err)

--- a/internal/selective/write.go
+++ b/internal/selective/write.go
@@ -2,7 +2,7 @@ package selective
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
@@ -59,7 +59,7 @@ func (l Path) writeImage(img v1.Image) error {
 	if err != nil {
 		return err
 	}
-	if err := l.WriteBlob(cfgName, ioutil.NopCloser(bytes.NewReader(cfgBlob))); err != nil {
+	if err := l.WriteBlob(cfgName, io.NopCloser(bytes.NewReader(cfgBlob))); err != nil {
 		return err
 	}
 
@@ -72,7 +72,7 @@ func (l Path) writeImage(img v1.Image) error {
 	if err != nil {
 		return err
 	}
-	return l.WriteBlob(d, ioutil.NopCloser(bytes.NewReader(manifest)))
+	return l.WriteBlob(d, io.NopCloser(bytes.NewReader(manifest)))
 }
 
 func Write(path string, ii v1.ImageIndex) (Path, error) {

--- a/internal/selective/write_test.go
+++ b/internal/selective/write_test.go
@@ -2,6 +2,7 @@ package selective_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -52,7 +53,7 @@ func testSelective(t *testing.T, when spec.G, it spec.S) {
 			testImage, err = remote.Image(ref, opts...)
 			h.AssertNil(t, err)
 
-			tmpDir, err = ioutil.TempDir("", "")
+			tmpDir, err = os.MkdirTemp("", "")
 			h.AssertNil(t, err)
 		})
 

--- a/launch/bash.go
+++ b/launch/bash.go
@@ -42,15 +42,16 @@ func (b *BashShell) Launch(proc ShellProcess) error {
 }
 
 // bashCommandWithTokens returns a bash script that should be executed with nTokens number of bash arguments
-//  Each argument to bash is evaluated by the shell before becoming a token in the resulting script
-//  Example:
-//    Given nTokens=2 the returned script will contain `"$(eval echo \"$0\")" "$(eval echo \"$1\")"`
-//      and should be evaluated with  `bash -c '"$(eval echo \"$0\")" "$(eval echo \"$1\")"' <command> <arg>'
-//    Token evaluation example:
-//      "$(eval echo \"$0\"`)" //  given $0='$FOO' and $FOO='arg with spaces" && quotes'
-//      -> "$(eval echo \"'$FOO'\")"
-//      -> "$(echo \"'arg with spaces" && quotes'\")"
-//      -> "arg with spaces\" && quotes" // this is an evaluated and properly quoted token
+//
+//	Each argument to bash is evaluated by the shell before becoming a token in the resulting script
+//	Example:
+//	  Given nTokens=2 the returned script will contain `"$(eval echo \"$0\")" "$(eval echo \"$1\")"`
+//	    and should be evaluated with  `bash -c '"$(eval echo \"$0\")" "$(eval echo \"$1\")"' <command> <arg>'
+//	  Token evaluation example:
+//	    "$(eval echo \"$0\"`)" //  given $0='$FOO' and $FOO='arg with spaces" && quotes'
+//	    -> "$(eval echo \"'$FOO'\")"
+//	    -> "$(echo \"'arg with spaces" && quotes'\")"
+//	    -> "arg with spaces\" && quotes" // this is an evaluated and properly quoted token
 func bashCommandWithTokens(nTokens int) string {
 	commandScript := `"$(eval echo \"$0\")"`
 	for i := 1; i < nTokens; i++ {

--- a/launch/bash_test.go
+++ b/launch/bash_test.go
@@ -2,7 +2,6 @@ package launch_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,7 +28,7 @@ func testBash(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		h.SkipIf(t, runtime.GOOS == "windows", "skip bash tests on windows")
 		var err error
-		tmpDir, err = ioutil.TempDir("", "shell-test")
+		tmpDir, err = os.MkdirTemp("", "shell-test")
 		h.AssertNil(t, err)
 		shell = &launch.BashShell{Exec: hl.SyscallExecWithStdout(t, tmpDir)}
 	})

--- a/launch/cmd_test.go
+++ b/launch/cmd_test.go
@@ -2,7 +2,6 @@ package launch_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -35,7 +34,7 @@ func testCmd(t *testing.T, when spec.G, it spec.S) {
 		defaultDir, err = os.Getwd()
 		h.AssertNil(t, err)
 		h.SkipIf(t, runtime.GOOS != "windows", "skip cmd tests on unix")
-		tmpDir, err = ioutil.TempDir("", "shell-test")
+		tmpDir, err = os.MkdirTemp("", "shell-test")
 		h.AssertNil(t, err)
 		shell = &launch.CmdShell{Exec: hl.SyscallExecWithStdout(t, tmpDir)}
 	})

--- a/launch/decode_test.go
+++ b/launch/decode_test.go
@@ -1,7 +1,6 @@
 package launch_test
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -29,7 +28,7 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			var err error
-			tmpDir, err = ioutil.TempDir("", "test-decode-metadata-toml")
+			tmpDir, err = os.MkdirTemp("", "test-decode-metadata-toml")
 			h.AssertNil(t, err)
 		})
 

--- a/launch/exec_d.go
+++ b/launch/exec_d.go
@@ -2,7 +2,6 @@ package launch
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -44,7 +43,7 @@ func (e *ExecDRunner) ExecD(path string, env Env) error {
 		}
 	}()
 
-	out, err := ioutil.ReadAll(pr)
+	out, err := io.ReadAll(pr)
 	if cmdErr := <-errChan; cmdErr != nil {
 		// prefer the error from the command
 		return errors.Wrapf(cmdErr, "failed to execute exec.d file at path '%s'", path)

--- a/launch/exec_d_test.go
+++ b/launch/exec_d_test.go
@@ -2,7 +2,6 @@ package launch_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -41,7 +40,7 @@ func testExecD(t *testing.T, when spec.G, it spec.S) {
 			env = testmock.NewMockEnv(mockCtrl)
 
 			var err error
-			tmpDir, err = ioutil.TempDir("", "test-execd")
+			tmpDir, err = os.MkdirTemp("", "test-execd")
 			h.AssertNil(t, err)
 			wd, err := os.Getwd()
 			h.AssertNil(t, err)

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -1,7 +1,6 @@
 package launch_test
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -65,7 +64,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		mockEnv.EXPECT().List().Return(envList).AnyTimes()
 
 		var err error
-		tmpDir, err = ioutil.TempDir("", "lifecycle.launcher.")
+		tmpDir, err = os.MkdirTemp("", "lifecycle.launcher.")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -726,7 +725,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 func mkfile(t *testing.T, data string, paths ...string) {
 	t.Helper()
 	for _, p := range paths {
-		if err := ioutil.WriteFile(p, []byte(data), 0600); err != nil {
+		if err := os.WriteFile(p, []byte(data), 0600); err != nil {
 			t.Fatalf("Error: %s\n", err)
 		}
 	}
@@ -734,7 +733,7 @@ func mkfile(t *testing.T, data string, paths ...string) {
 
 func rdfile(t *testing.T, path string) string {
 	t.Helper()
-	out, err := ioutil.ReadFile(path)
+	out, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Error: %s\n", err)
 	}

--- a/launch/process.go
+++ b/launch/process.go
@@ -9,14 +9,15 @@ import (
 )
 
 // ProcessFor creates a process from container cmd
-//   If the Platform API if 0.4 or greater and DefaultProcess is set:
-//     * The default process is returned with `cmd` appended to the process args
-//   If the Platform API is less than 0.4
-//     * If there is exactly one argument and it matches a process type, it returns that process.
-//     * If cmd is empty, it returns the default process
-//   Else
-//     * it constructs a new process from cmd
-//     * If the first element in cmd is `cmd` the process shall be direct
+//
+//	If the Platform API if 0.4 or greater and DefaultProcess is set:
+//	  * The default process is returned with `cmd` appended to the process args
+//	If the Platform API is less than 0.4
+//	  * If there is exactly one argument and it matches a process type, it returns that process.
+//	  * If cmd is empty, it returns the default process
+//	Else
+//	  * it constructs a new process from cmd
+//	  * If the first element in cmd is `cmd` the process shall be direct
 func (l *Launcher) ProcessFor(cmd []string) (Process, error) {
 	if l.PlatformAPI.LessThan("0.4") {
 		return l.processForLegacy(cmd)

--- a/layers/dir.go
+++ b/layers/dir.go
@@ -8,7 +8,8 @@ import (
 
 // DirLayer creates a layer from the given directory
 // DirLayer will set the UID and GID of entries describing dir and its children (but not its parents)
-//    to Factory.UID and Factory.GID
+//
+//	to Factory.UID and Factory.GID
 func (f *Factory) DirLayer(id string, dir string) (layer Layer, err error) {
 	dir, err = filepath.Abs(dir)
 	if err != nil {

--- a/layers/dir_test.go
+++ b/layers/dir_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ func testDirs(t *testing.T, when spec.G, it spec.S) {
 	)
 	it.Before(func() {
 		var err error
-		artifactDir, err := ioutil.TempDir("", "layers.slices.layer")
+		artifactDir, err := os.MkdirTemp("", "layers.slices.layer")
 		h.AssertNil(t, err)
 		factory = &layers.Factory{
 			ArtifactsDir: artifactDir,

--- a/layers/launcher.go
+++ b/layers/launcher.go
@@ -60,8 +60,8 @@ func (f *Factory) LauncherLayer(path string) (layer Layer, err error) {
 }
 
 // ProcessTypesLayer creates a Layer containing symlinks pointing to target where:
-//    * any parents of the symlink files will also be added to the layer
-//    * symlinks and their parent directories shall be root owned and world readable
+//   - any parents of the symlink files will also be added to the layer
+//   - symlinks and their parent directories shall be root owned and world readable
 func (f *Factory) ProcessTypesLayer(config launch.Metadata) (layer Layer, err error) {
 	hdrs := []*tar.Header{
 		rootOwnedDir(launch.CNBDir),

--- a/layers/launcher_test.go
+++ b/layers/launcher_test.go
@@ -3,7 +3,6 @@ package layers_test
 import (
 	"archive/tar"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -30,7 +29,7 @@ func testLauncherLayers(t *testing.T, when spec.G, it spec.S) {
 	)
 	it.Before(func() {
 		var err error
-		artifactDir, err := ioutil.TempDir("", "layers.slices.layer")
+		artifactDir, err := os.MkdirTemp("", "layers.slices.layer")
 		h.AssertNil(t, err)
 		factory = &layers.Factory{
 			ArtifactsDir: artifactDir,

--- a/layers/slices_test.go
+++ b/layers/slices_test.go
@@ -2,7 +2,6 @@ package layers_test
 
 import (
 	"archive/tar"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,7 +25,7 @@ func testSlices(t *testing.T, when spec.G, it spec.S) {
 	)
 	it.Before(func() {
 		var err error
-		artifactDir, err := ioutil.TempDir("", "layers.slices.layer")
+		artifactDir, err := os.MkdirTemp("", "layers.slices.layer")
 		h.AssertNil(t, err)
 		factory = &layers.Factory{
 			ArtifactsDir: artifactDir,

--- a/restorer_test.go
+++ b/restorer_test.go
@@ -3,7 +3,6 @@ package lifecycle_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,10 +55,10 @@ func testRestorer(buildpackAPI, platformAPI string) func(t *testing.T, when spec
 			it.Before(func() {
 				var err error
 
-				layersDir, err = ioutil.TempDir("", "lifecycle-layer-dir")
+				layersDir, err = os.MkdirTemp("", "lifecycle-layer-dir")
 				h.AssertNil(t, err)
 
-				cacheDir, err = ioutil.TempDir("", "")
+				cacheDir, err = os.MkdirTemp("", "")
 				h.AssertNil(t, err)
 
 				testCache, err = cache.NewVolumeCache(cacheDir)
@@ -239,7 +238,7 @@ func testRestorer(buildpackAPI, platformAPI string) func(t *testing.T, when spec
 					h.RecursiveCopy(t, filepath.Join("testdata", "restorer"), layersDir)
 					var err error
 
-					tarTempDir, err = ioutil.TempDir("", "restorer-test-temp-layer")
+					tarTempDir, err = os.MkdirTemp("", "restorer-test-temp-layer")
 					h.AssertNil(t, err)
 
 					lf := layers.Factory{
@@ -323,7 +322,7 @@ func testRestorer(buildpackAPI, platformAPI string) func(t *testing.T, when spec
 }
 `, cacheFalseLayerSHA, cacheLaunchLayerSHA, cacheOnlyLayerSHA, noGroupLayerSHA, escapedLayerSHA)
 
-					err = ioutil.WriteFile(
+					err = os.WriteFile(
 						filepath.Join(cacheDir, "committed", "io.buildpacks.lifecycle.cache.metadata"),
 						[]byte(contents),
 						0600,
@@ -648,7 +647,7 @@ func testRestorer(buildpackAPI, platformAPI string) func(t *testing.T, when spec
 				it.Before(func() {
 					h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.8"), "Platform API < 0.8 does not restore SBOM")
 
-					tmpDir, err := ioutil.TempDir("", "")
+					tmpDir, err := os.MkdirTemp("", "")
 					h.AssertNil(t, err)
 					h.Mkfile(t, "some-data", filepath.Join(tmpDir, "some.tar"))
 					h.AssertNil(t, testCache.AddLayerFile(filepath.Join(tmpDir, "some.tar"), "some-digest"))
@@ -687,12 +686,12 @@ func writeLayer(layersDir, buildpack, name, metadata, sha string) error {
 		return errors.Wrapf(err, "creating buildpack layer directory")
 	}
 	metadataPath := filepath.Join(buildpackDir, name+".toml")
-	if err := ioutil.WriteFile(metadataPath, []byte(metadata), 0600); err != nil {
+	if err := os.WriteFile(metadataPath, []byte(metadata), 0600); err != nil {
 		return errors.Wrapf(err, "writing metadata file")
 	}
 	if sha != "" { // don't write a sha file when sha is an empty string
 		shaPath := filepath.Join(buildpackDir, name+".sha")
-		if err := ioutil.WriteFile(shaPath, []byte(sha), 0600); err != nil {
+		if err := os.WriteFile(shaPath, []byte(sha), 0600); err != nil {
 			return errors.Wrapf(err, "writing sha file")
 		}
 	}
@@ -700,7 +699,7 @@ func writeLayer(layersDir, buildpack, name, metadata, sha string) error {
 }
 
 func TestWriteLayer(t *testing.T) {
-	layersDir, err := ioutil.TempDir("", "test-write-layer")
+	layersDir, err := os.MkdirTemp("", "test-write-layer")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}

--- a/testhelpers/docker.go
+++ b/testhelpers/docker.go
@@ -145,7 +145,7 @@ func SeedDockerVolume(t *testing.T, srcPath string) string {
 }
 
 func checkResponse(responseBody io.Reader) error {
-	body, err := ioutil.ReadAll(responseBody)
+	body, err := io.ReadAll(responseBody)
 	if err != nil {
 		return errors.Wrap(err, "reading body")
 	}

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -184,7 +184,7 @@ func HTTPGetE(url string) (string, error) {
 	if resp.StatusCode >= 300 {
 		return "", fmt.Errorf("HTTP Status was bad: %s => %d", url, resp.StatusCode)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -337,7 +337,7 @@ func RandomLayer(t *testing.T, tmpDir string) (path string, sha string, contents
 
 func MustReadFile(t *testing.T, path string) []byte {
 	t.Helper()
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Error reading %q: %v", path, err)
 	}
@@ -356,7 +356,7 @@ func Mkdir(t *testing.T, dirs ...string) {
 func Mkfile(t *testing.T, data string, paths ...string) {
 	t.Helper()
 	for _, p := range paths {
-		if err := ioutil.WriteFile(p, []byte(data), 0600); err != nil {
+		if err := os.WriteFile(p, []byte(data), 0600); err != nil {
 			t.Fatalf("Error: %s\n", err)
 		}
 	}
@@ -368,7 +368,7 @@ func CleanEndings(s string) string {
 
 func Rdfile(t *testing.T, path string) string {
 	t.Helper()
-	out, err := ioutil.ReadFile(path)
+	out, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("Error: %s\n", err)
 	}

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -265,7 +264,7 @@ func lifecycleLayer() (string, error) {
 	ntr := archive.NewNormalizingTarReader(tr)
 	ntr.PrependDir("/cnb/")
 
-	lf, err := ioutil.TempFile("", "lifecycle-layer")
+	lf, err := os.CreateTemp("", "lifecycle-layer")
 	if err != nil {
 		return "", errors.Errorf("Failed to create temp layer file: %s", err)
 	}
@@ -330,7 +329,7 @@ func pullImage(dockerCli dockercli.CommonAPIClient, ref string) error {
 		}
 	}
 	defer rc.Close()
-	if _, err := io.Copy(ioutil.Discard, rc); err != nil {
+	if _, err := io.Copy(io.Discard, rc); err != nil {
 		return err
 	}
 	return nil

--- a/tools/packager/main.go
+++ b/tools/packager/main.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -61,7 +60,7 @@ func doPackage() error {
 	tw.WithUID(0)
 	tw.WithGID(0)
 
-	templateContents, err := ioutil.ReadFile(descriptorPath)
+	templateContents, err := os.ReadFile(descriptorPath)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to read descriptor file %s", descriptorPath))
 	}
@@ -82,7 +81,7 @@ func doPackage() error {
 		return errors.Wrap(err, fmt.Sprintf("Failed to stat descriptor template file %s", descriptorPath))
 	}
 
-	tempDir, err := ioutil.TempDir("", "lifecycle-descriptor")
+	tempDir, err := os.MkdirTemp("", "lifecycle-descriptor")
 	if err != nil {
 		return errors.Wrap(err, "Failed to create a temp directory")
 	}
@@ -92,7 +91,7 @@ func doPackage() error {
 		return errors.Wrap(err, "Failed to create a temp file")
 	}
 
-	err = ioutil.WriteFile(tempFile.Name(), descriptorContents, descriptorTemplateInfo.Mode())
+	err = os.WriteFile(tempFile.Name(), descriptorContents, descriptorTemplateInfo.Mode())
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Failed to write descriptor contents to file %s", tempFile.Name()))
 	}


### PR DESCRIPTION
Address most `staticcheck` alarms from running linter locally:

```console
$ make lint
> Installing goimports...
go install golang.org/x/tools/cmd/goimports@v0.1.2
> Formating code...
> Installing golangci-lint...
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
> Linting code...
cmd/lifecycle/cli/command.go:4:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
launch/bash_test.go:5:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
launch/cmd_test.go:5:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
make: *** [lint] Error 1
```

There is still a lot more linting to be done, but probably safer to break down into chunks-at-a-time instead of all-at-once. The first two commits are small. The last was search/replace anywhere I found `io/ioutil` except for instances of `ioutil.ReadDir`; for this case, I'd like to suggest a small and temporary utility as described in https://pkg.go.dev/io/ioutil#ReadDir.