### PR TITLE
Fix creator restore bug

### DIFF
--- a/acceptance/testdata/creator/container/cnb/buildpacks/samples_hello-world/0.0.1/bin/build
+++ b/acceptance/testdata/creator/container/cnb/buildpacks/samples_hello-world/0.0.1/bin/build
@@ -90,3 +90,9 @@ if test -f ${layers_dir}/build.sbom.cdx.json; then
   exit 1
 fi
 echo -n "{\"key\": \"some-bom-content\"}" > ${layers_dir}/build.sbom.cdx.json
+
+# store.toml
+if test -f ${layers_dir}/store.toml; then
+  echo "${layers_dir}/store.toml restored with content: $(cat ${layers_dir}/store.toml)"
+fi
+printf "[metadata]\n\"some-key\" = \"some-value\"" > ${layers_dir}/store.toml

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -271,7 +271,7 @@ func (c *createCmd) Exec() error {
 		}
 	}
 
-	if !c.skipRestore {
+	if !c.skipRestore || c.platform.API().AtLeast("0.10") {
 		cmd.DefaultLogger.Phase("RESTORING")
 		err := restoreArgs{
 			keychain:   c.keychain,

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -205,6 +205,7 @@ func (r restoreArgs) restore(layerMetadata platform.LayersMetadata, group buildp
 		SBOMRestorer: layer.NewSBOMRestorer(layer.SBOMRestorerOpts{
 			LayersDir: r.layersDir,
 			Logger:    cmd.DefaultLogger,
+			Nop:       r.skipLayers,
 		}, r.platform.API()),
 	}
 

--- a/internal/selective/write_test.go
+++ b/internal/selective/write_test.go
@@ -35,11 +35,12 @@ func testSelective(t *testing.T, when spec.G, it spec.S) {
 			var opts []remote.Option
 			fileNotFoundMsg = "no such file or directory"
 			if runtime.GOOS == "windows" {
-				testImageName = "mcr.microsoft.com/windows/nanoserver:1809"
+				testImageName = "mcr.microsoft.com/windows/nanoserver@sha256:8bd4389d56e69bebf6e4666251fba42f7cce3d5b768d28816884fb4370155fee" // mcr.microsoft.com/windows/nanoserver:1809
+
 				windowsPlatform := v1.Platform{
 					Architecture: "amd64",
 					OS:           "windows",
-					OSVersion:    "10.0.17763.3406",
+					OSVersion:    "10.0.17763.3532",
 				}
 				opts = append(opts, remote.WithPlatform(windowsPlatform))
 				fileNotFoundMsg = "The system cannot find the file specified"

--- a/testhelpers/docker.go
+++ b/testhelpers/docker.go
@@ -40,7 +40,7 @@ func DockerBuild(t *testing.T, name, context string, ops ...DockerCmdOp) {
 
 func DockerImageRemove(t *testing.T, name string) {
 	t.Helper()
-	Run(t, exec.Command("docker", "rmi", name)) // #nosec G204
+	Run(t, exec.Command("docker", "rmi", name, "--force")) // #nosec G204
 }
 
 func DockerRun(t *testing.T, image string, ops ...DockerCmdOp) string {


### PR DESCRIPTION
When platform API is at least 0.10, run the restore phase always but pass
-skip-restore as skip layers to skip layer metadata and SBOM restoration
    
This ensures:
- In the 5 phase invocation, the restorer can always run (for extension purposes)
- The 5 phase invocation will match the creator invocation