### PR TITLE
Fix regression in metadata.toml rendering

### DIFF
--- a/acceptance/builder_test.go
+++ b/acceptance/builder_test.go
@@ -135,14 +135,77 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 			h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
 			h.AssertStringContains(t, md.Buildpacks[0].Version, "0.0.1")
-			h.AssertEq(t, 1, len(md.Processes))
-			h.AssertEq(t, "hello", md.Processes[0].Type)
-			h.AssertEq(t, "echo world", md.Processes[0].Command[0])
-			h.AssertEq(t, 1, len(md.Processes[0].Args))
-			h.AssertEq(t, "arg1", md.Processes[0].Args[0])
-			h.AssertEq(t, false, md.Processes[0].Direct)
-			h.AssertEq(t, "", md.Processes[0].WorkingDirectory)
-			h.AssertEq(t, false, md.Processes[0].Default)
+			h.AssertEq(t, len(md.Processes), 1)
+			h.AssertEq(t, md.Processes[0].Type, "hello")
+			h.AssertEq(t, len(md.Processes[0].Command.Entries), 1)
+			h.AssertEq(t, md.Processes[0].Command.Entries[0], "echo world")
+			h.AssertEq(t, len(md.Processes[0].Args), 1)
+			h.AssertEq(t, md.Processes[0].Args[0], "arg1")
+			h.AssertEq(t, md.Processes[0].Direct, false)
+			h.AssertEq(t, md.Processes[0].WorkingDirectory, "")
+			h.AssertEq(t, md.Processes[0].Default, false)
+		})
+	})
+
+	when("writing metadata.toml", func() {
+		it("writes and reads successfully", func() {
+			h.DockerRunAndCopy(t,
+				containerName,
+				copyDir,
+				ctrPath("/layers"),
+				builderImage,
+				h.WithFlags(
+					"--env", "CNB_PLATFORM_API="+latestPlatformAPI,
+					"--env", "CNB_GROUP_PATH=/cnb/group_tomls/always_detect_group.toml",
+					"--env", "CNB_PLAN_PATH=/cnb/plan_tomls/always_detect_plan.toml",
+				),
+			)
+			// check builder metadata.toml for success test
+			md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+
+			h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
+			h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
+			h.AssertStringContains(t, md.Buildpacks[0].Version, "0.0.1")
+			h.AssertEq(t, len(md.Processes), 1)
+			h.AssertEq(t, md.Processes[0].Type, "hello")
+			h.AssertEq(t, len(md.Processes[0].Command.Entries), 1)
+			h.AssertEq(t, md.Processes[0].Command.Entries[0], "echo world")
+			h.AssertEq(t, len(md.Processes[0].Args), 1)
+			h.AssertEq(t, md.Processes[0].Args[0], "arg1")
+			h.AssertEq(t, md.Processes[0].Direct, false)
+			h.AssertEq(t, md.Processes[0].WorkingDirectory, "")
+			h.AssertEq(t, md.Processes[0].Default, false)
+		})
+
+		when("the platform < 0.10", func() {
+			it("writes and reads successfully", func() {
+				h.DockerRunAndCopy(t,
+					containerName,
+					copyDir,
+					ctrPath("/layers"),
+					builderImage,
+					h.WithFlags(
+						"--env", "CNB_PLATFORM_API=0.9",
+						"--env", "CNB_GROUP_PATH=/cnb/group_tomls/always_detect_group.toml",
+						"--env", "CNB_PLAN_PATH=/cnb/plan_tomls/always_detect_plan.toml",
+					),
+				)
+				// check builder metadata.toml for success test
+				md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+
+				h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
+				h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
+				h.AssertStringContains(t, md.Buildpacks[0].Version, "0.0.1")
+				h.AssertEq(t, len(md.Processes), 1)
+				h.AssertEq(t, md.Processes[0].Type, "hello")
+				h.AssertEq(t, len(md.Processes[0].Command.Entries), 1)
+				h.AssertEq(t, md.Processes[0].Command.Entries[0], "echo world")
+				h.AssertEq(t, len(md.Processes[0].Args), 1)
+				h.AssertEq(t, md.Processes[0].Args[0], "arg1")
+				h.AssertEq(t, md.Processes[0].Direct, false)
+				h.AssertEq(t, md.Processes[0].WorkingDirectory, "")
+				h.AssertEq(t, md.Processes[0].Default, false)
+			})
 		})
 	})
 

--- a/acceptance/builder_test.go
+++ b/acceptance/builder_test.go
@@ -130,20 +130,11 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				),
 			)
 			// check builder metadata.toml for success test
-			md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+			_, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
 
 			h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 			h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
 			h.AssertStringContains(t, md.Buildpacks[0].Version, "0.0.1")
-			h.AssertEq(t, len(md.Processes), 1)
-			h.AssertEq(t, md.Processes[0].Type, "hello")
-			h.AssertEq(t, len(md.Processes[0].Command.Entries), 1)
-			h.AssertEq(t, md.Processes[0].Command.Entries[0], "echo world")
-			h.AssertEq(t, len(md.Processes[0].Args), 1)
-			h.AssertEq(t, md.Processes[0].Args[0], "arg1")
-			h.AssertEq(t, md.Processes[0].Direct, false)
-			h.AssertEq(t, md.Processes[0].WorkingDirectory, "")
-			h.AssertEq(t, md.Processes[0].Default, false)
 		})
 	})
 
@@ -161,8 +152,10 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				),
 			)
 			// check builder metadata.toml for success test
-			md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+			contents, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
 
+			// prevent regression of inline table serialization
+			h.AssertStringDoesNotContain(t, contents, "processes =")
 			h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 			h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
 			h.AssertStringContains(t, md.Buildpacks[0].Version, "0.0.1")
@@ -191,8 +184,10 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					),
 				)
 				// check builder metadata.toml for success test
-				md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+				contents, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
 
+				// prevent regression of inline table serialization
+				h.AssertStringDoesNotContain(t, contents, "processes =")
 				h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 				h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
 				h.AssertStringContains(t, md.Buildpacks[0].Version, "0.0.1")
@@ -223,7 +218,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 				),
 			)
 			// check builder metadata.toml for success test
-			md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+			_, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
 
 			h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 			h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
@@ -269,7 +264,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 						),
 					)
 					// check builder metadata.toml for success test
-					md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+					_, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
 					h.AssertEq(t, len(md.Processes), 0)
 				})
 			})
@@ -345,7 +340,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 						),
 					)
 					// check builder metadata.toml for success test
-					md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
+					_, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers", "config", "metadata.toml"))
 
 					h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 					h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world")
@@ -388,7 +383,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 						"--env", "CNB_PLAN_PATH=/cnb/plan_tomls/always_detect_plan_buildpack_2.toml",
 					),
 				)
-				md := getBuilderMetadata(t, filepath.Join(copyDir, "layers/different_layer_dir_from_env/config/metadata.toml"))
+				_, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers/different_layer_dir_from_env/config/metadata.toml"))
 
 				h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 				h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world_2")
@@ -410,7 +405,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 						"--env", "CNB_GROUP_PATH=/cnb/group_tomls/always_detect_group_buildpack2.toml",
 					),
 				)
-				md := getBuilderMetadata(t, filepath.Join(copyDir, "layers/different_layer_dir_from_env/config/metadata.toml"))
+				_, md := getBuilderMetadata(t, filepath.Join(copyDir, "layers/different_layer_dir_from_env/config/metadata.toml"))
 
 				h.AssertStringContains(t, md.Buildpacks[0].API, "0.2")
 				h.AssertStringContains(t, md.Buildpacks[0].ID, "hello_world_2")
@@ -514,7 +509,7 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 	})
 }
 
-func getBuilderMetadata(t *testing.T, path string) *platform.BuildMetadata {
+func getBuilderMetadata(t *testing.T, path string) (string, *platform.BuildMetadata) {
 	t.Helper()
 	contents, _ := os.ReadFile(path)
 	h.AssertEq(t, len(contents) > 0, true)
@@ -523,5 +518,5 @@ func getBuilderMetadata(t *testing.T, path string) *platform.BuildMetadata {
 	_, err := toml.Decode(string(contents), &buildMD)
 	h.AssertNil(t, err)
 
-	return &buildMD
+	return string(contents), &buildMD
 }

--- a/buildpack/files.go
+++ b/buildpack/files.go
@@ -85,7 +85,7 @@ func (p *ProcessEntry) ToLaunchProcess(bpID string) launch.Process {
 
 	return launch.Process{
 		Type:             p.Type,
-		Command:          p.Command,
+		Command:          launch.NewRawCommand(p.Command),
 		Args:             p.Args,
 		Direct:           direct, // launch.Process requires a value
 		Default:          p.Default,

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -109,8 +109,9 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 			ProcessTypesLayer(launch.Metadata{
 				Processes: []launch.Process{
 					{
-						Type:        "some-process-type",
-						Command:     []string{"/some/command"},
+						Type: "some-process-type",
+						Command: launch.NewRawCommand([]string{"/some/command"}).
+							WithPlatformAPI(platformAPI),
 						Args:        []string{"some", "command", "args"},
 						Direct:      true,
 						BuildpackID: "buildpack.id",
@@ -1134,8 +1135,9 @@ version = "4.5.6"
 							ProcessTypesLayer(launch.Metadata{
 								Processes: []launch.Process{
 									{
-										Type:        "some-process-type",
-										Command:     []string{"/some/command"},
+										Type: "some-process-type",
+										Command: launch.NewRawCommand([]string{"/some/command"}).
+											WithPlatformAPI(api.Platform.Latest()),
 										Args:        []string{"some", "command", "args"},
 										Direct:      true,
 										BuildpackID: "buildpack.id",

--- a/launch/decode_test.go
+++ b/launch/decode_test.go
@@ -54,11 +54,11 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 
 			_, err := toml.DecodeFile(path, &metadata)
 			h.AssertNil(t, err)
-			h.AssertEq(t, metadata.Processes[0].Command[0], "some-cmd")
-			h.AssertEq(t, metadata.Processes[0].Command[1], "more")
+			h.AssertEq(t, metadata.Processes[0].Command.Entries[0], "some-cmd")
+			h.AssertEq(t, metadata.Processes[0].Command.Entries[1], "more")
 
-			h.AssertEq(t, metadata.Processes[1].Command[0], "other cmd with spaces")
-			h.AssertEq(t, metadata.Processes[1].Command[1], "other more")
+			h.AssertEq(t, metadata.Processes[1].Command.Entries[0], "other cmd with spaces")
+			h.AssertEq(t, metadata.Processes[1].Command.Entries[1], "other more")
 		})
 
 		when("string commands", func() {
@@ -80,8 +80,8 @@ func testDecodeMetataTOML(t *testing.T, when spec.G, it spec.S) {
 
 				_, err := toml.DecodeFile(path, &metadata)
 				h.AssertNil(t, err)
-				h.AssertEq(t, metadata.Processes[0].Command[0], "some-cmd")
-				h.AssertEq(t, metadata.Processes[1].Command[0], "other cmd with spaces")
+				h.AssertEq(t, metadata.Processes[0].Command.Entries[0], "some-cmd")
+				h.AssertEq(t, metadata.Processes[1].Command.Entries[0], "other cmd with spaces")
 			})
 		})
 	})

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -7,112 +7,93 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pkg/errors"
 
 	"github.com/buildpacks/lifecycle/api"
-	"github.com/buildpacks/lifecycle/internal/encoding"
 )
 
-// Process represents a process to launch at runtime.
-// NOTE: This struct MUST be kept in sync with `processSerializer` and `processSerializerPlatformLessThan010`.
-type Process struct {
-	Type             string         `toml:"type" json:"type"`
-	Command          []string       `toml:"-" json:"-"` // ignored
-	RawCommandValue  toml.Primitive `toml:"command" json:"command"`
-	Args             []string       `toml:"args" json:"args"`
-	Direct           bool           `toml:"direct" json:"direct"`
-	Default          bool           `toml:"default,omitempty" json:"default,omitempty"`
-	BuildpackID      string         `toml:"buildpack-id" json:"buildpackID"`
-	WorkingDirectory string         `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
-	PlatformAPI      *api.Version   `toml:"-" json:"-"`
+type RawCommand struct {
+	Entries     []string
+	PlatformAPI *api.Version
 }
 
-// processSerializer is used to encode a process to toml.
-// NOTE: This struct MUST be kept in sync with `Process` and `processSerializerPlatformLessThan010`.
-type processSerializer struct {
-	Type             string   `toml:"type" json:"type"`
-	Command          []string `toml:"command" json:"command"` // command is array
-	Args             []string `toml:"args" json:"args"`
-	Direct           bool     `toml:"direct" json:"direct"`
-	Default          bool     `toml:"default,omitempty" json:"default,omitempty"`
-	BuildpackID      string   `toml:"buildpack-id" json:"buildpackID"`
-	WorkingDirectory string   `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+func NewRawCommand(entries []string) RawCommand {
+	return RawCommand{Entries: entries}
 }
 
-// processSerializerPlatformLessThan010 is used to encode a process to toml for older platform APIs.
-// NOTE: This struct MUST be kept in sync with `Process` and `processSerializer`.
-type processSerializerPlatformLessThan010 struct {
-	Type             string   `toml:"type" json:"type"`
-	Command          string   `toml:"command" json:"command"` // command is string
-	Args             []string `toml:"args" json:"args"`
-	Direct           bool     `toml:"direct" json:"direct"`
-	Default          bool     `toml:"default,omitempty" json:"default,omitempty"`
-	BuildpackID      string   `toml:"buildpack-id" json:"buildpackID"`
-	WorkingDirectory string   `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+func (c RawCommand) WithPlatformAPI(api *api.Version) RawCommand {
+	c.PlatformAPI = api
+	return c
 }
 
-// MarshalText implements the toml TextMarshaler interface to allow us more control when writing a Process to a toml file.
-func (p Process) MarshalText() ([]byte, error) {
-	if p.PlatformAPI.AtLeast("0.10") {
-		return encoding.MarshalTOML(p.toProcessSerializer())
+func (c RawCommand) MarshalTOML() ([]byte, error) {
+	if c.PlatformAPI == nil {
+		return nil, fmt.Errorf("missing PlatformAPI while encoding RawCommand")
 	}
-	return encoding.MarshalTOML(p.toProcessSerializerPlatformLessThan010())
-}
 
-// MarhsalJSON implements the json Marshaler interface to allow us more control when writing a Process to a json file.
-func (p Process) MarshalJSON() ([]byte, error) {
-	if p.PlatformAPI.AtLeast("0.10") {
-		return json.Marshal(p.toProcessSerializer())
+	if c.PlatformAPI.AtLeast("0.10") {
+		buffer := &strings.Builder{}
+		// turn array into toml array
+		buffer.WriteString("[")
+		for i, entry := range c.Entries {
+			if i != 0 {
+				buffer.WriteString(", ")
+			}
+			buffer.WriteString(fmt.Sprintf("%q", entry))
+		}
+		buffer.WriteString("]")
+		return []byte(buffer.String()), nil
 	}
-	return json.Marshal(p.toProcessSerializerPlatformLessThan010())
+
+	return []byte(fmt.Sprintf("\"%s\"", c.Entries[0])), nil
 }
 
-// UnmarshalTOML implements the toml Unmarshaler interface to allow us more control when reading a Process from toml.
-func (p *Process) UnmarshalTOML(data interface{}) error {
-	var tomlString string
+func (c RawCommand) MarshalJSON() ([]byte, error) {
+	if c.PlatformAPI == nil {
+		return nil, fmt.Errorf("missing PlatformAPI while encoding RawCommand")
+	}
+
+	if c.PlatformAPI.AtLeast("0.10") {
+		return json.Marshal(c.Entries)
+	}
+
+	return []byte(fmt.Sprintf("\"%s\"", c.Entries[0])), nil
+}
+
+// UnmarshalTOML implements toml.Unmarshaler and is needed because we read metadata.toml
+// this method will attempt to parse the command in either string or array format
+func (c *RawCommand) UnmarshalTOML(data interface{}) error {
+	var values []string
+	// the raw value is either "the-command" or ["the-command", "arg1", "arg2"]
+	// the latter is exposed as []interface{} by toml library and needs conversion
 	switch v := data.(type) {
 	case string:
-		tomlString = v
-	case map[string]interface{}:
-		// when unmarshaling as part of a parent struct, the process is a map[string]interface{}
-		// turn back into a string
-		bytes, _ := encoding.MarshalTOML(v)
-		tomlString = string(bytes)
-	default:
-		return errors.New("could not cast data to string")
-	}
-
-	// This is the same as launch.Process and exists to allow us to toml.Decode inside of UnmarshalTOML
-	type pProcess Process
-
-	// unmarshal the common bits
-	newProcess := pProcess{}
-	md, err := toml.Decode(tomlString, &newProcess)
-	if err != nil {
-		return err
-	}
-
-	// handle the process.command, which will differ based on APIs
-	var commandWasString bool
-	var commandString string
-	if err := md.PrimitiveDecode(newProcess.RawCommandValue, &commandString); err == nil {
-		commandWasString = true
-		newProcess.Command = []string{commandString}
-	}
-
-	if !commandWasString {
-		var command []string
-		if err := md.PrimitiveDecode(newProcess.RawCommandValue, &command); err != nil {
-			return err
+		values = []string{v}
+	case []interface{}:
+		s := make([]string, len(v))
+		for i, v := range v {
+			s[i] = fmt.Sprint(v)
 		}
-		newProcess.Command = command
+		values = s
+	default:
+		return fmt.Errorf("unknown command toml type %T", data)
 	}
 
-	*p = Process(newProcess)
+	*c = NewRawCommand(values)
 	return nil
+}
+
+// Process represents a process to launch at runtime.
+type Process struct {
+	Type             string       `toml:"type" json:"type"`
+	Command          RawCommand   `toml:"command" json:"command"`
+	Args             []string     `toml:"args" json:"args"`
+	Direct           bool         `toml:"direct" json:"direct"`
+	Default          bool         `toml:"default,omitempty" json:"default,omitempty"`
+	BuildpackID      string       `toml:"buildpack-id" json:"buildpackID"`
+	WorkingDirectory string       `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+	PlatformAPI      *api.Version `toml:"-" json:"-"`
 }
 
 func (p Process) NoDefault() Process {
@@ -121,32 +102,19 @@ func (p Process) NoDefault() Process {
 }
 
 func (p Process) WithPlatformAPI(platformAPI *api.Version) Process {
+	// set on the process itself
 	p.PlatformAPI = platformAPI
+	// set on the command as well, this is needed when we serialize the command
+	p.Command.PlatformAPI = platformAPI
+
+	// for platform versions < 0.10
+	// we only support a single command
+	// push any extra entries into the args so they aren't lost
+	if p.PlatformAPI.LessThan("0.10") {
+		p.Args = append(p.Command.Entries[1:], p.Args[0:]...)
+		p.Command.Entries = []string{p.Command.Entries[0]}
+	}
 	return p
-}
-
-func (p Process) toProcessSerializer() processSerializer {
-	return processSerializer{
-		Type:             p.Type,
-		Command:          p.Command,
-		Args:             p.Args,
-		Direct:           p.Direct,
-		Default:          p.Default,
-		BuildpackID:      p.BuildpackID,
-		WorkingDirectory: p.WorkingDirectory,
-	}
-}
-
-func (p Process) toProcessSerializerPlatformLessThan010() processSerializerPlatformLessThan010 {
-	return processSerializerPlatformLessThan010{
-		Type:             p.Type,
-		Command:          p.Command[0],
-		Args:             append(p.Command[1:], p.Args[0:]...),
-		Direct:           p.Direct,
-		Default:          p.Default,
-		BuildpackID:      p.BuildpackID,
-		WorkingDirectory: p.WorkingDirectory,
-	}
 }
 
 // ProcessPath returns the absolute path to the symlink for a given process type
@@ -172,9 +140,12 @@ func (m Metadata) Matches(x interface{}) bool {
 		return false
 	}
 
-	// we need to ignore the RawCommandValue field because it is a toml.Primitive and is not part of our equality
+	// we need to ignore the PlatformAPI field because it isn't always set where these are used
+	// and trying to compare it will cause a panic
 	for i, p := range m.Processes {
-		if s := cmp.Diff(metadatax.Processes[i], p, cmpopts.IgnoreFields(Process{}, "RawCommandValue")); s != "" {
+		if s := cmp.Diff(metadatax.Processes[i], p,
+			cmpopts.IgnoreFields(Process{}, "PlatformAPI"),
+			cmpopts.IgnoreFields(RawCommand{}, "PlatformAPI")); s != "" {
 			return false
 		}
 	}

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -1,13 +1,17 @@
 package launch_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/internal/encoding"
 	"github.com/buildpacks/lifecycle/launch"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
@@ -18,11 +22,12 @@ func TestLaunch(t *testing.T) {
 
 func testLaunch(t *testing.T, when spec.G, it spec.S) {
 	when("Process", func() {
-		when("MarshalText", func() {
+		when("MarhsalTOML", func() {
 			it("command is array", func() {
 				process := launch.Process{
-					Type:             "some-type",
-					Command:          []string{"some-command", "some-command-arg1"},
+					Type: "some-type",
+					Command: launch.NewRawCommand([]string{"some-command", "some-command-arg1"}).
+						WithPlatformAPI(api.Platform.Latest()),
 					Args:             []string{"some-arg1"},
 					Direct:           true,
 					Default:          true,
@@ -31,7 +36,7 @@ func testLaunch(t *testing.T, when spec.G, it spec.S) {
 					PlatformAPI:      api.Platform.Latest(),
 				}
 
-				bytes, err := process.MarshalText()
+				bytes, err := encoding.MarshalTOML(process)
 				h.AssertNil(t, err)
 				expected := `type = "some-type"
 command = ["some-command", "some-command-arg1"]
@@ -48,16 +53,15 @@ working-dir = "some-working-directory"
 				it("command is string", func() {
 					process := launch.Process{
 						Type:             "some-type",
-						Command:          []string{"some-command", "some-arg1"},
+						Command:          launch.NewRawCommand([]string{"some-command", "some-arg1"}),
 						Args:             []string{"some-arg2"},
 						Direct:           true,
 						Default:          true,
 						BuildpackID:      "some-buildpack-id",
 						WorkingDirectory: "some-working-directory",
-						PlatformAPI:      api.MustParse("0.9"),
-					}
+					}.WithPlatformAPI(api.MustParse("0.9"))
 
-					bytes, err := process.MarshalText()
+					bytes, err := encoding.MarshalTOML(process)
 					h.AssertNil(t, err)
 					expected := `type = "some-type"
 command = "some-command"
@@ -67,6 +71,7 @@ default = true
 buildpack-id = "some-buildpack-id"
 working-dir = "some-working-directory"
 `
+					fmt.Println("RENDERED: " + string(bytes))
 					h.AssertEq(t, string(bytes), expected)
 				})
 			})
@@ -75,8 +80,9 @@ working-dir = "some-working-directory"
 		when("MarshalJSON", func() {
 			it("command is array", func() {
 				process := launch.Process{
-					Type:             "some-type",
-					Command:          []string{"some-command", "some-command-arg1"},
+					Type: "some-type",
+					Command: launch.NewRawCommand([]string{"some-command", "some-command-arg1"}).
+						WithPlatformAPI(api.Platform.Latest()),
 					Args:             []string{"some-arg1"},
 					Direct:           true,
 					Default:          true,
@@ -85,7 +91,7 @@ working-dir = "some-working-directory"
 					PlatformAPI:      api.Platform.Latest(),
 				}
 
-				bytes, err := process.MarshalJSON()
+				bytes, err := json.Marshal(process)
 				h.AssertNil(t, err)
 				expected := `{"type":"some-type","command":["some-command","some-command-arg1"],"args":["some-arg1"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
 				h.AssertEq(t, string(bytes), expected)
@@ -95,16 +101,15 @@ working-dir = "some-working-directory"
 				it("command is string", func() {
 					process := launch.Process{
 						Type:             "some-type",
-						Command:          []string{"some-command", "some-arg1"},
+						Command:          launch.NewRawCommand([]string{"some-command", "some-arg1"}),
 						Args:             []string{"some-arg2"},
 						Direct:           true,
 						Default:          true,
 						BuildpackID:      "some-buildpack-id",
 						WorkingDirectory: "some-working-directory",
-						PlatformAPI:      api.MustParse("0.9"),
-					}
+					}.WithPlatformAPI(api.MustParse("0.9"))
 
-					bytes, err := process.MarshalJSON()
+					bytes, err := json.Marshal(process)
 					h.AssertNil(t, err)
 					expected := `{"type":"some-type","command":"some-command","args":["some-arg1","some-arg2"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
 					h.AssertEq(t, string(bytes), expected)
@@ -124,11 +129,13 @@ buildpack-id = "some-buildpack-id"
 working-dir = "some-working-directory"
 `
 					process := launch.Process{}
-					h.AssertNil(t, process.UnmarshalTOML(data))
+					_, err := toml.Decode(data, &process)
+					h.AssertNil(t, err)
 					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
 						{
-							Type:             "some-type",
-							Command:          []string{"some-command"},
+							Type: "some-type",
+							Command: launch.NewRawCommand([]string{"some-command"}).
+								WithPlatformAPI(api.Platform.Latest()),
 							Args:             []string{"some-arg"},
 							Direct:           true,
 							Default:          true,
@@ -152,11 +159,13 @@ buildpack-id = "some-buildpack-id"
 working-dir = "some-working-directory"
 `
 					process := launch.Process{}
-					h.AssertNil(t, process.UnmarshalTOML(data))
+					_, err := toml.Decode(data, &process)
+					h.AssertNil(t, err)
 					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
 						{
-							Type:             "some-type",
-							Command:          []string{"some-command", "some-command-arg"},
+							Type: "some-type",
+							Command: launch.NewRawCommand([]string{"some-command", "some-command-arg"}).
+								WithPlatformAPI(api.Platform.Latest()),
 							Args:             []string{"some-arg"},
 							Direct:           true,
 							Default:          true,

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -2,7 +2,6 @@ package launch_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -22,7 +21,7 @@ func TestLaunch(t *testing.T) {
 
 func testLaunch(t *testing.T, when spec.G, it spec.S) {
 	when("Process", func() {
-		when("MarhsalTOML", func() {
+		when("MarshalTOML", func() {
 			it("command is array", func() {
 				process := launch.Process{
 					Type: "some-type",
@@ -71,7 +70,6 @@ default = true
 buildpack-id = "some-buildpack-id"
 working-dir = "some-working-directory"
 `
-					fmt.Println("RENDERED: " + string(bytes))
 					h.AssertEq(t, string(bytes), expected)
 				})
 			})

--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -79,7 +79,7 @@ func (l *Launcher) launchDirect(proc Process) error {
 	if err := l.Setenv("PATH", l.Env.Get("PATH")); err != nil {
 		return errors.Wrap(err, "set path")
 	}
-	binary, err := exec.LookPath(proc.Command[0])
+	binary, err := exec.LookPath(proc.Command.Entries[0])
 	if err != nil {
 		return errors.Wrap(err, "path lookup")
 	}
@@ -87,7 +87,7 @@ func (l *Launcher) launchDirect(proc Process) error {
 		return errors.Wrap(err, "change directory")
 	}
 	if err := l.Exec(binary,
-		append(proc.Command, proc.Args...),
+		append(proc.Command.Entries, proc.Args...),
 		l.Env.List(),
 	); err != nil {
 		return errors.Wrap(err, "direct exec")

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -115,7 +115,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			process = launch.Process{
-				Command: []string{"command"},
+				Command: launch.NewRawCommand([]string{"command"}),
 				Args:    []string{"arg1", "arg2"},
 			}
 		})
@@ -128,9 +128,9 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 				// set command to something on the real path so exec.LookPath succeeds
 				if runtime.GOOS == "windows" {
-					process.Command = []string{"notepad"}
+					process.Command = launch.NewRawCommand([]string{"notepad"})
 				} else {
-					process.Command = []string{"sh"}
+					process.Command = launch.NewRawCommand([]string{"sh"})
 				}
 
 				mockEnv.EXPECT().Get("PATH").Return("some-path").AnyTimes()

--- a/launch/process.go
+++ b/launch/process.go
@@ -49,10 +49,10 @@ func (l *Launcher) handleUserArgsPlatformLessThan010(process Process, userArgs [
 
 func (l *Launcher) handleUserArgs(process Process, userArgs []string) (Process, error) {
 	switch {
-	case len(process.Command) > 1: // definitely newer buildpack
+	case len(process.Command.Entries) > 1: // definitely newer buildpack
 		overridableArgs := process.Args
-		process.Args = process.Command[1:]             // set always-provided args
-		process.Command = []string{process.Command[0]} // when exec'ing the process we always expect Command to have just one entry
+		process.Args = process.Command.Entries[1:]                     // set always-provided args
+		process.Command.Entries = []string{process.Command.Entries[0]} // when exec'ing the process we always expect Command to have just one entry
 		if len(userArgs) > 0 {
 			process.Args = append(process.Args, userArgs...)
 		} else {
@@ -118,10 +118,10 @@ func (l *Launcher) userProvidedProcess(cmd []string) (Process, error) {
 		return Process{}, errors.New("when there is no default process a command is required")
 	}
 	if len(cmd) > 1 && cmd[0] == "--" {
-		return Process{Command: []string{cmd[1]}, Args: cmd[2:], Direct: true}, nil
+		return Process{Command: RawCommand{Entries: []string{cmd[1]}}, Args: cmd[2:], Direct: true}, nil
 	}
 
-	return Process{Command: []string{cmd[0]}, Args: cmd[1:]}, nil
+	return Process{Command: RawCommand{Entries: []string{cmd[0]}}, Args: cmd[1:]}, nil
 }
 
 func getProcessWorkingDirectory(process Process, appDir string) string {

--- a/launch/process_test.go
+++ b/launch/process_test.go
@@ -19,7 +19,8 @@ func TestProcess(t *testing.T) {
 
 // RawCommandValue should be ignored because it is a toml.Primitive that has not been exported.
 var processCmpOpts = []cmp.Option{
-	cmpopts.IgnoreFields(launch.Process{}, "RawCommandValue", "PlatformAPI"),
+	cmpopts.IgnoreFields(launch.Process{}, "PlatformAPI"),
+	cmpopts.IgnoreFields(launch.RawCommand{}, "PlatformAPI"),
 }
 
 func testProcess(t *testing.T, when spec.G, it spec.S) {
@@ -35,25 +36,25 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 			Processes: []launch.Process{
 				{
 					Type:        "some-type",
-					Command:     []string{"some-command"},
+					Command:     launch.NewRawCommand([]string{"some-command"}),
 					Args:        []string{"some-arg1", "some-arg2"},
 					BuildpackID: "some-buildpack",
 				},
 				{
 					Type:        "other-type",
-					Command:     []string{"other-command"},
+					Command:     launch.NewRawCommand([]string{"other-command"}),
 					Args:        []string{"other-arg1", "other-arg2"},
 					BuildpackID: "some-buildpack",
 				},
 				{
 					Type:        "type-with-always-and-overridable-args",
-					Command:     []string{"some-command", "always-arg"},
+					Command:     launch.NewRawCommand([]string{"some-command", "always-arg"}),
 					Args:        []string{"overridable-arg"},
 					BuildpackID: "some-newer-buildpack",
 				},
 				{
 					Type:        "type-with-overridable-arg",
-					Command:     []string{"some-command"},
+					Command:     launch.NewRawCommand([]string{"some-command"}),
 					Args:        []string{"overridable-arg"},
 					BuildpackID: "some-newer-buildpack",
 				},
@@ -70,7 +71,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 						proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 						h.AssertNil(t, err)
 						h.AssertEq(t, proc, launch.Process{
-							Command: []string{"user-command"},
+							Command: launch.NewRawCommand([]string{"user-command"}),
 							Args:    []string{"user-arg1", "user-arg2"},
 							Direct:  true,
 						}, processCmpOpts...)
@@ -82,7 +83,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 						proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 						h.AssertNil(t, err)
 						h.AssertEq(t, proc, launch.Process{
-							Command: []string{"user-command"},
+							Command: launch.NewRawCommand([]string{"user-command"}),
 							Args:    []string{"user-arg1", "user-arg2"},
 						}, processCmpOpts...)
 					})
@@ -107,7 +108,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 						h.AssertNil(t, err)
 						h.AssertEq(t, proc, launch.Process{
 							Type:        "type-with-always-and-overridable-args",
-							Command:     []string{"some-command"},
+							Command:     launch.NewRawCommand([]string{"some-command"}),
 							Args:        []string{"always-arg", "user-arg1", "user-arg2"},
 							BuildpackID: "some-newer-buildpack",
 						}, processCmpOpts...)
@@ -119,7 +120,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "type-with-always-and-overridable-args",
-								Command:     []string{"some-command"},
+								Command:     launch.NewRawCommand([]string{"some-command"}),
 								Args:        []string{"always-arg", "overridable-arg"},
 								BuildpackID: "some-newer-buildpack",
 							}, processCmpOpts...)
@@ -138,7 +139,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "type-with-overridable-arg",
-								Command:     []string{"some-command"},
+								Command:     launch.NewRawCommand([]string{"some-command"}),
 								Args:        []string{"user-arg1", "user-arg1"},
 								BuildpackID: "some-newer-buildpack",
 							}, processCmpOpts...)
@@ -150,7 +151,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 								h.AssertNil(t, err)
 								h.AssertEq(t, proc, launch.Process{
 									Type:        "type-with-overridable-arg",
-									Command:     []string{"some-command"},
+									Command:     launch.NewRawCommand([]string{"some-command"}),
 									Args:        []string{"overridable-arg"},
 									BuildpackID: "some-newer-buildpack",
 								}, processCmpOpts...)
@@ -168,7 +169,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "some-type",
-								Command:     []string{"some-command"},
+								Command:     launch.NewRawCommand([]string{"some-command"}),
 								Args:        []string{"some-arg1", "some-arg2", "user-arg1", "user-arg1"},
 								BuildpackID: "some-buildpack",
 							}, processCmpOpts...)
@@ -201,7 +202,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: []string{"user-command"},
+								Command: launch.NewRawCommand([]string{"user-command"}),
 								Args:    []string{"user-arg1", "user-arg2"},
 								Direct:  true,
 							}, processCmpOpts...)
@@ -213,7 +214,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: []string{"user-command"},
+								Command: launch.NewRawCommand([]string{"user-command"}),
 								Args:    []string{"user-arg1", "user-arg2"},
 							}, processCmpOpts...)
 						})
@@ -237,7 +238,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 						h.AssertNil(t, err)
 						h.AssertEq(t, proc, launch.Process{
 							Type:        "type-with-overridable-arg",
-							Command:     []string{"some-command"},
+							Command:     launch.NewRawCommand([]string{"some-command"}),
 							Args:        []string{"overridable-arg", "user-arg1", "user-arg1"},
 							BuildpackID: "some-newer-buildpack",
 						}, processCmpOpts...)
@@ -249,7 +250,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "type-with-overridable-arg",
-								Command:     []string{"some-command"},
+								Command:     launch.NewRawCommand([]string{"some-command"}),
 								Args:        []string{"overridable-arg"},
 								BuildpackID: "some-newer-buildpack",
 							}, processCmpOpts...)
@@ -290,7 +291,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "other-type",
-								Command:     []string{"other-command"},
+								Command:     launch.NewRawCommand([]string{"other-command"}),
 								Args:        []string{"other-arg1", "other-arg2"},
 								BuildpackID: "some-buildpack",
 							}, processCmpOpts...)
@@ -302,7 +303,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: []string{"user-command"},
+								Command: launch.NewRawCommand([]string{"user-command"}),
 								Args:    []string{"user-arg1", "user-arg2"},
 								Direct:  true,
 							}, processCmpOpts...)
@@ -314,7 +315,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: []string{"user-command"},
+								Command: launch.NewRawCommand([]string{"user-command"}),
 								Args:    []string{"user-arg1", "user-arg2"},
 							}, processCmpOpts...)
 						})
@@ -332,7 +333,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "some-type",
-								Command:     []string{"some-command"},
+								Command:     launch.NewRawCommand([]string{"some-command"}),
 								Args:        []string{"some-arg1", "some-arg2"},
 								BuildpackID: "some-buildpack",
 							}, processCmpOpts...)
@@ -345,7 +346,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
 								Type:        "other-type",
-								Command:     []string{"other-command"},
+								Command:     launch.NewRawCommand([]string{"other-command"}),
 								Args:        []string{"other-arg1", "other-arg2"},
 								BuildpackID: "some-buildpack",
 							}, processCmpOpts...)
@@ -357,7 +358,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"--", "user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: []string{"user-command"},
+								Command: launch.NewRawCommand([]string{"user-command"}),
 								Args:    []string{"user-arg1", "user-arg2"},
 								Direct:  true,
 							}, processCmpOpts...)
@@ -369,7 +370,7 @@ func testProcess(t *testing.T, when spec.G, it spec.S) {
 							proc, err := launcher.ProcessFor([]string{"user-command", "user-arg1", "user-arg2"})
 							h.AssertNil(t, err)
 							h.AssertEq(t, proc, launch.Process{
-								Command: []string{"user-command"},
+								Command: launch.NewRawCommand([]string{"user-command"}),
 								Args:    []string{"user-arg1", "user-arg2"},
 							}, processCmpOpts...)
 						})

--- a/launch/process_test.go
+++ b/launch/process_test.go
@@ -17,7 +17,7 @@ func TestProcess(t *testing.T) {
 	spec.Run(t, "Process", testProcess, spec.Report(report.Terminal{}))
 }
 
-// RawCommandValue should be ignored because it is a toml.Primitive that has not been exported.
+// PlatformAPI should be ignored because it is not always set in these tests
 var processCmpOpts = []cmp.Option{
 	cmpopts.IgnoreFields(launch.Process{}, "PlatformAPI"),
 	cmpopts.IgnoreFields(launch.RawCommand{}, "PlatformAPI"),

--- a/launch/shell.go
+++ b/launch/shell.go
@@ -36,8 +36,8 @@ func (l *Launcher) launchWithShell(self string, proc Process) error {
 		return err
 	}
 	command := ""
-	if len(proc.Command) > 0 {
-		command = strings.Join(proc.Command, " ")
+	if len(proc.Command.Entries) > 0 {
+		command = strings.Join(proc.Command.Entries, " ")
 	}
 	return l.Shell.Launch(ShellProcess{
 		Script:           script,

--- a/platform/files.go
+++ b/platform/files.go
@@ -95,9 +95,12 @@ func DecodeBuildMetadataTOML(path string, platformAPI *api.Version, buildmd *Bui
 		return err
 	}
 
+	// set the platform API on all the appropriate fields
+	// this will allow us to re-encode the metadata.toml file with
+	// the current platform API
 	buildmd.PlatformAPI = platformAPI
 	for i := range buildmd.Processes {
-		buildmd.Processes[i].PlatformAPI = platformAPI
+		buildmd.Processes[i] = buildmd.Processes[i].WithPlatformAPI(platformAPI)
 	}
 
 	return nil


### PR DESCRIPTION
Moved the dynamic process serialization to a new field type and off of process. The TOML that was previously generated was not expected and the TOML library we use doesn't seem to have a way to render the table the way we expect. Making a new type for the single field `command` allows us to render the TOML the way we want.

Fixes: buildpacks/lifecycle#945
Signed-off-by: Jesse Brown <jabrown85@gmail.com>