### PR TITLE
Use json to marshal command entry for older platform

### DIFF
--- a/launch/launch.go
+++ b/launch/launch.go
@@ -91,7 +91,7 @@ func (c RawCommand) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.Entries)
 	}
 
-	return []byte(fmt.Sprintf("\"%s\"", c.Entries[0])), nil
+	return json.Marshal(c.Entries[0])
 }
 
 // UnmarshalTOML implements toml.Unmarshaler and is needed because we read metadata.toml


### PR DESCRIPTION
This should fix the Windows tests (pack acceptance)