### PR TITLE
Fix special character escaping when marshaling launch process

### DIFF
--- a/launch/launch.go
+++ b/launch/launch.go
@@ -73,13 +73,17 @@ func (c RawCommand) MarshalTOML() ([]byte, error) {
 			if i != 0 {
 				buffer.WriteString(", ")
 			}
-			buffer.WriteString(fmt.Sprintf("%q", entry))
+			escaped, err := json.Marshal(entry) // properly escape special characters in single string
+			if err != nil {
+				return nil, err
+			}
+			buffer.WriteString(string(escaped))
 		}
 		buffer.WriteString("]")
 		return []byte(buffer.String()), nil
 	}
 
-	return []byte(fmt.Sprintf("\"%s\"", c.Entries[0])), nil
+	return json.Marshal(c.Entries[0]) // properly escape special characters in single string
 }
 
 func (c RawCommand) MarshalJSON() ([]byte, error) {

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -91,7 +91,7 @@ func (c RawCommand) MarshalJSON() ([]byte, error) {
 		return json.Marshal(c.Entries)
 	}
 
-	return []byte(fmt.Sprintf("\"%s\"", c.Entries[0])), nil
+	return json.Marshal(c.Entries[0])
 }
 
 // UnmarshalTOML implements toml.Unmarshaler and is needed because we read metadata.toml

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -276,7 +276,7 @@ buildpack-id = "some-buildpack-id"
 			})
 		})
 
-		when.Pend("UnmarshalJSON", func() {
+		when("UnmarshalJSON", func() {
 			when("input command is string", func() {
 				it("populates a launch process", func() {
 					data := `{"type":"some-type","command":"some-command","args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
@@ -305,7 +305,7 @@ buildpack-id = "some-buildpack-id"
 					h.AssertNil(t, err)
 					expected := launch.Process{
 						Type:        "some-type",
-						Command:     launch.RawCommand{Entries: []string{`\\r`}}, // TODO: check
+						Command:     launch.RawCommand{Entries: []string{`\r`}},
 						Args:        []string{`\r`},
 						BuildpackID: "some-buildpack-id",
 					}
@@ -322,7 +322,7 @@ buildpack-id = "some-buildpack-id"
 					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
 						{
 							Type:             "some-type",
-							Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}), // TODO: fix
+							Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
 							Args:             []string{"some-arg"},
 							Direct:           true,
 							Default:          true,
@@ -341,7 +341,7 @@ buildpack-id = "some-buildpack-id"
 					h.AssertNil(t, err)
 					expected := launch.Process{
 						Type:        "some-type",
-						Command:     launch.RawCommand{Entries: []string{`\r`}}, // TODO: fix
+						Command:     launch.RawCommand{Entries: []string{`\r`}},
 						Args:        []string{`\r`},
 						BuildpackID: "some-buildpack-id",
 					}

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -22,24 +22,22 @@ func TestLaunch(t *testing.T) {
 func testLaunch(t *testing.T, when spec.G, it spec.S) {
 	when("Process", func() {
 		when("MarshalTOML", func() {
-			it("command is array", func() {
+			it("output command is array", func() {
 				process := launch.Process{
-					Type: "some-type",
-					Command: launch.NewRawCommand([]string{"some-command", "some-command-arg1"}).
-						WithPlatformAPI(api.Platform.Latest()),
-					Args:             []string{"some-arg1"},
+					Type:             "some-type",
+					Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
+					Args:             []string{"some-arg"},
 					Direct:           true,
 					Default:          true,
 					BuildpackID:      "some-buildpack-id",
 					WorkingDirectory: "some-working-directory",
-					PlatformAPI:      api.Platform.Latest(),
-				}
+				}.WithPlatformAPI(api.Platform.Latest())
 
 				bytes, err := encoding.MarshalTOML(process)
 				h.AssertNil(t, err)
 				expected := `type = "some-type"
-command = ["some-command", "some-command-arg1"]
-args = ["some-arg1"]
+command = ["some-command", "some-command-arg"]
+args = ["some-arg"]
 direct = true
 default = true
 buildpack-id = "some-buildpack-id"
@@ -48,12 +46,31 @@ working-dir = "some-working-directory"
 				h.AssertEq(t, string(bytes), expected)
 			})
 
+			it("handles special characters", func() {
+				process := launch.Process{
+					Type:        "some-type",
+					Command:     launch.RawCommand{Entries: []string{`\r`}},
+					Args:        []string{`\r`},
+					BuildpackID: "some-buildpack-id",
+				}.WithPlatformAPI(api.Platform.Latest())
+
+				bytes, err := encoding.MarshalTOML(process)
+				h.AssertNil(t, err)
+				expected := `type = "some-type"
+command = ["\\r"]
+args = ["\\r"]
+direct = false
+buildpack-id = "some-buildpack-id"
+`
+				h.AssertEq(t, string(bytes), expected)
+			})
+
 			when("platform API < 0.10", func() {
-				it("command is string", func() {
+				it("output command is string", func() {
 					process := launch.Process{
 						Type:             "some-type",
-						Command:          launch.NewRawCommand([]string{"some-command", "some-arg1"}),
-						Args:             []string{"some-arg2"},
+						Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
+						Args:             []string{"some-arg"},
 						Direct:           true,
 						Default:          true,
 						BuildpackID:      "some-buildpack-id",
@@ -64,7 +81,7 @@ working-dir = "some-working-directory"
 					h.AssertNil(t, err)
 					expected := `type = "some-type"
 command = "some-command"
-args = ["some-arg1", "some-arg2"]
+args = ["some-command-arg", "some-arg"]
 direct = true
 default = true
 buildpack-id = "some-buildpack-id"
@@ -72,35 +89,66 @@ working-dir = "some-working-directory"
 `
 					h.AssertEq(t, string(bytes), expected)
 				})
+
+				it("handles special characters", func() {
+					process := launch.Process{
+						Type:        "some-type",
+						Command:     launch.RawCommand{Entries: []string{`\r`}},
+						Args:        []string{`\r`},
+						BuildpackID: "some-buildpack-id",
+					}.WithPlatformAPI(api.MustParse("0.9"))
+
+					bytes, err := encoding.MarshalTOML(process)
+					h.AssertNil(t, err)
+					expected := `type = "some-type"
+command = "\\r"
+args = ["\\r"]
+direct = false
+buildpack-id = "some-buildpack-id"
+`
+					h.AssertEq(t, string(bytes), expected)
+				})
 			})
 		})
 
 		when("MarshalJSON", func() {
-			it("command is array", func() {
+			it("output command is array", func() {
 				process := launch.Process{
-					Type: "some-type",
-					Command: launch.NewRawCommand([]string{"some-command", "some-command-arg1"}).
-						WithPlatformAPI(api.Platform.Latest()),
-					Args:             []string{"some-arg1"},
+					Type:             "some-type",
+					Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
+					Args:             []string{"some-arg"},
 					Direct:           true,
 					Default:          true,
 					BuildpackID:      "some-buildpack-id",
 					WorkingDirectory: "some-working-directory",
-					PlatformAPI:      api.Platform.Latest(),
-				}
+				}.WithPlatformAPI(api.Platform.Latest())
 
 				bytes, err := json.Marshal(process)
 				h.AssertNil(t, err)
-				expected := `{"type":"some-type","command":["some-command","some-command-arg1"],"args":["some-arg1"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
+				expected := `{"type":"some-type","command":["some-command","some-command-arg"],"args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
+				h.AssertEq(t, string(bytes), expected)
+			})
+
+			it("handles special characters", func() {
+				process := launch.Process{
+					Type:        "some-type",
+					Command:     launch.RawCommand{Entries: []string{`\r`}},
+					Args:        []string{`\r`},
+					BuildpackID: "some-buildpack-id",
+				}.WithPlatformAPI(api.Platform.Latest())
+
+				bytes, err := json.Marshal(process)
+				h.AssertNil(t, err)
+				expected := `{"type":"some-type","command":["\\r"],"args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
 				h.AssertEq(t, string(bytes), expected)
 			})
 
 			when("platform API < 0.10", func() {
-				it("command is string", func() {
+				it("output command is string", func() {
 					process := launch.Process{
 						Type:             "some-type",
-						Command:          launch.NewRawCommand([]string{"some-command", "some-arg1"}),
-						Args:             []string{"some-arg2"},
+						Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
+						Args:             []string{"some-arg"},
 						Direct:           true,
 						Default:          true,
 						BuildpackID:      "some-buildpack-id",
@@ -109,14 +157,28 @@ working-dir = "some-working-directory"
 
 					bytes, err := json.Marshal(process)
 					h.AssertNil(t, err)
-					expected := `{"type":"some-type","command":"some-command","args":["some-arg1","some-arg2"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
+					expected := `{"type":"some-type","command":"some-command","args":["some-command-arg","some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
+					h.AssertEq(t, string(bytes), expected)
+				})
+
+				it("handles special characters", func() {
+					process := launch.Process{
+						Type:        "some-type",
+						Command:     launch.RawCommand{Entries: []string{`\r`}},
+						Args:        []string{`\r`},
+						BuildpackID: "some-buildpack-id",
+					}.WithPlatformAPI(api.MustParse("0.9"))
+
+					bytes, err := json.Marshal(process)
+					h.AssertNil(t, err)
+					expected := `{"type":"some-type","command":"\\r","args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
 					h.AssertEq(t, string(bytes), expected)
 				})
 			})
 		})
 
 		when("UnmarshalTOML", func() {
-			when("provided command as string", func() {
+			when("input command is string", func() {
 				it("populates a launch process", func() {
 					data := `type = "some-type"
 command = "some-command"
@@ -126,14 +188,13 @@ default = true
 buildpack-id = "some-buildpack-id"
 working-dir = "some-working-directory"
 `
-					process := launch.Process{}
+					var process launch.Process
 					_, err := toml.Decode(data, &process)
 					h.AssertNil(t, err)
 					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
 						{
-							Type: "some-type",
-							Command: launch.NewRawCommand([]string{"some-command"}).
-								WithPlatformAPI(api.Platform.Latest()),
+							Type:             "some-type",
+							Command:          launch.NewRawCommand([]string{"some-command"}),
 							Args:             []string{"some-arg"},
 							Direct:           true,
 							Default:          true,
@@ -144,9 +205,29 @@ working-dir = "some-working-directory"
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
 				})
+
+				it("handles special characters", func() {
+					data := `type = "some-type"
+command = "\\r"
+args = ["\\r"]
+direct = false
+buildpack-id = "some-buildpack-id"
+`
+					var process launch.Process
+
+					err := toml.Unmarshal([]byte(data), &process)
+					h.AssertNil(t, err)
+					expected := launch.Process{
+						Type:        "some-type",
+						Command:     launch.RawCommand{Entries: []string{`\r`}},
+						Args:        []string{`\r`},
+						BuildpackID: "some-buildpack-id",
+					}
+					h.AssertEq(t, process, expected, processCmpOpts...)
+				})
 			})
 
-			when("provided command as array", func() {
+			when("input command is array", func() {
 				it("populates a launch process", func() {
 					data := `type = "some-type"
 command = ["some-command", "some-command-arg"]
@@ -156,14 +237,13 @@ default = true
 buildpack-id = "some-buildpack-id"
 working-dir = "some-working-directory"
 `
-					process := launch.Process{}
+					var process launch.Process
 					_, err := toml.Decode(data, &process)
 					h.AssertNil(t, err)
 					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
 						{
-							Type: "some-type",
-							Command: launch.NewRawCommand([]string{"some-command", "some-command-arg"}).
-								WithPlatformAPI(api.Platform.Latest()),
+							Type:             "some-type",
+							Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
 							Args:             []string{"some-arg"},
 							Direct:           true,
 							Default:          true,
@@ -173,6 +253,99 @@ working-dir = "some-working-directory"
 					}, processCmpOpts...); s != "" {
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
+				})
+
+				it("handles special characters", func() {
+					data := `type = "some-type"
+command = ["\\r"]
+args = ["\\r"]
+direct = false
+buildpack-id = "some-buildpack-id"
+`
+					var process launch.Process
+					err := toml.Unmarshal([]byte(data), &process)
+					h.AssertNil(t, err)
+					expected := launch.Process{
+						Type:        "some-type",
+						Command:     launch.RawCommand{Entries: []string{`\r`}},
+						Args:        []string{`\r`},
+						BuildpackID: "some-buildpack-id",
+					}
+					h.AssertEq(t, process, expected, processCmpOpts...)
+				})
+			})
+		})
+
+		when.Pend("UnmarshalJSON", func() {
+			when("input command is string", func() {
+				it("populates a launch process", func() {
+					data := `{"type":"some-type","command":"some-command","args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
+					var process launch.Process
+					err := json.Unmarshal([]byte(data), &process)
+					h.AssertNil(t, err)
+					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
+						{
+							Type:             "some-type",
+							Command:          launch.NewRawCommand([]string{"some-command"}),
+							Args:             []string{"some-arg"},
+							Direct:           true,
+							Default:          true,
+							BuildpackID:      "some-buildpack-id",
+							WorkingDirectory: "some-working-directory",
+						},
+					}, processCmpOpts...); s != "" {
+						t.Fatalf("Unexpected:\n%s\n", s)
+					}
+				})
+
+				it("handles special characters", func() {
+					data := `{"type":"some-type","command":"\\r","args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
+					var process launch.Process
+					err := json.Unmarshal([]byte(data), &process)
+					h.AssertNil(t, err)
+					expected := launch.Process{
+						Type:        "some-type",
+						Command:     launch.RawCommand{Entries: []string{`\\r`}}, // TODO: check
+						Args:        []string{`\r`},
+						BuildpackID: "some-buildpack-id",
+					}
+					h.AssertEq(t, process, expected, processCmpOpts...)
+				})
+			})
+
+			when("input command is array", func() {
+				it("populates a launch process", func() {
+					data := `{"type":"some-type","command":["some-command","some-command-arg"],"args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
+					var process launch.Process
+					err := json.Unmarshal([]byte(data), &process)
+					h.AssertNil(t, err)
+					if s := cmp.Diff([]launch.Process{process}, []launch.Process{
+						{
+							Type:             "some-type",
+							Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}), // TODO: fix
+							Args:             []string{"some-arg"},
+							Direct:           true,
+							Default:          true,
+							BuildpackID:      "some-buildpack-id",
+							WorkingDirectory: "some-working-directory",
+						},
+					}, processCmpOpts...); s != "" {
+						t.Fatalf("Unexpected:\n%s\n", s)
+					}
+				})
+
+				it("handles special characters", func() {
+					data := `{"type":"some-type","command":["\\r"],"args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
+					var process launch.Process
+					err := json.Unmarshal([]byte(data), &process)
+					h.AssertNil(t, err)
+					expected := launch.Process{
+						Type:        "some-type",
+						Command:     launch.RawCommand{Entries: []string{`\r`}}, // TODO: fix
+						Args:        []string{`\r`},
+						BuildpackID: "some-buildpack-id",
+					}
+					h.AssertEq(t, process, expected, processCmpOpts...)
 				})
 			})
 		})

--- a/platform/files.go
+++ b/platform/files.go
@@ -99,8 +99,8 @@ func DecodeBuildMetadataTOML(path string, platformAPI *api.Version, buildmd *Bui
 	// this will allow us to re-encode the metadata.toml file with
 	// the current platform API
 	buildmd.PlatformAPI = platformAPI
-	for i := range buildmd.Processes {
-		buildmd.Processes[i] = buildmd.Processes[i].WithPlatformAPI(platformAPI)
+	for i, process := range buildmd.Processes {
+		buildmd.Processes[i] = process.WithPlatformAPI(platformAPI)
 	}
 
 	return nil


### PR DESCRIPTION
Following up on https://github.com/buildpacks/lifecycle/pull/946 and https://github.com/buildpacks/lifecycle/pull/947, this handles special characters and adds an `UnmarshalJSON` method to `Command` for library consumers. 