### PR TITLE
Add launcher SBOM input

### DIFF
--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -15,12 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/buildpacks/imgutil"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/sclevine/spec"
 	"github.com/sclevine/spec/report"
-
-	"github.com/buildpacks/imgutil"
-
-	"github.com/google/go-containerregistry/pkg/authn"
 
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/cache"

--- a/buildpack/bomfile.go
+++ b/buildpack/bomfile.go
@@ -23,6 +23,10 @@ const (
 	MediaTypeSPDX        = "application/spdx+json"
 	MediaTypeSyft        = "application/vnd.syft+json"
 	mediaTypeUnsupported = "unsupported"
+
+	ExtensionCycloneDX = "sbom.cdx.json"
+	ExtensionSPDX      = "sbom.spdx.json"
+	ExtensionSyft      = "sbom.syft.json"
 )
 
 type LayerType int
@@ -43,11 +47,11 @@ type BOMFile struct {
 func (b *BOMFile) Name() (string, error) {
 	switch b.mediaType() {
 	case MediaTypeCycloneDX:
-		return "sbom.cdx.json", nil
+		return ExtensionCycloneDX, nil
 	case MediaTypeSPDX:
-		return "sbom.spdx.json", nil
+		return ExtensionSPDX, nil
 	case MediaTypeSyft:
-		return "sbom.syft.json", nil
+		return ExtensionSyft, nil
 	default:
 		return "", errors.Errorf("unsupported SBOM format: '%s'", b.Path)
 	}
@@ -57,11 +61,11 @@ func (b *BOMFile) mediaType() string {
 	name := filepath.Base(b.Path)
 
 	switch {
-	case strings.HasSuffix(name, ".sbom.cdx.json"):
+	case strings.HasSuffix(name, "."+ExtensionCycloneDX):
 		return MediaTypeCycloneDX
-	case strings.HasSuffix(name, ".sbom.spdx.json"):
+	case strings.HasSuffix(name, "."+ExtensionSPDX):
 		return MediaTypeSPDX
-	case strings.HasSuffix(name, ".sbom.syft.json"):
+	case strings.HasSuffix(name, "."+ExtensionSyft):
 		return MediaTypeSyft
 	default:
 		return mediaTypeUnsupported

--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -65,6 +65,10 @@ func FlagLauncherPath(launcherPath *string) {
 	flagSet.StringVar(launcherPath, "launcher", *launcherPath, "path to launcher binary")
 }
 
+func FlagLauncherSBOMDir(launcherSBOMDir *string) {
+	flagSet.StringVar(launcherSBOMDir, "launcher-sbom", *launcherSBOMDir, "path to launcher SBOM directory")
+}
+
 func FlagLayersDir(layersDir *string) {
 	flagSet.StringVar(layersDir, "layers", *layersDir, "path to layers directory")
 }

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -27,6 +27,9 @@ type createCmd struct {
 
 // DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (c *createCmd) DefineFlags() {
+	if c.PlatformAPI.AtLeast("0.11") {
+		cli.FlagLauncherSBOMDir(&c.LauncherSBOMDir)
+	}
 	cli.FlagAppDir(&c.AppDir)
 	cli.FlagBuildpacksDir(&c.BuildpacksDir)
 	cli.FlagCacheDir(&c.CacheDir)

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -41,6 +41,9 @@ type exportData struct {
 
 // DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (e *exportCmd) DefineFlags() {
+	if e.PlatformAPI.AtLeast("0.11") {
+		cli.FlagLauncherSBOMDir(&e.LauncherSBOMDir)
+	}
 	cli.FlagAnalyzedPath(&e.AnalyzedPath)
 	cli.FlagAppDir(&e.AppDir)
 	cli.FlagCacheDir(&e.CacheDir)
@@ -178,7 +181,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore lifecycle.Cache, an
 		AdditionalNames:    e.AdditionalTags,
 		AppDir:             e.AppDir,
 		DefaultProcessType: e.DefaultProcessType,
-		LauncherConfig:     launcherConfig(e.LauncherPath),
+		LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
 		LayersDir:          e.LayersDir,
 		OrigMetadata:       analyzedMD.Metadata,
 		Project:            projectMD,
@@ -274,9 +277,10 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD platform.AnalyzedMetadata) (im
 	return appImage, runImageID.String(), nil
 }
 
-func launcherConfig(launcherPath string) lifecycle.LauncherConfig {
+func launcherConfig(launcherPath, launcherSBOMDir string) lifecycle.LauncherConfig {
 	return lifecycle.LauncherConfig{
-		Path: launcherPath,
+		Path:    launcherPath,
+		SBOMDir: launcherSBOMDir,
 		Metadata: platform.LauncherMetadata{
 			Version: cmd.Version,
 			Source: platform.SourceMetadata{

--- a/exporter.go
+++ b/exporter.go
@@ -8,15 +8,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/buildpacks/lifecycle/internal/fsutil"
-	paths "github.com/buildpacks/lifecycle/internal/path"
-
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/imgutil"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/buildpack"
+	"github.com/buildpacks/lifecycle/internal/fsutil"
 	"github.com/buildpacks/lifecycle/launch"
 	"github.com/buildpacks/lifecycle/layers"
 	"github.com/buildpacks/lifecycle/log"
@@ -51,6 +49,7 @@ type LayerFactory interface {
 
 type LauncherConfig struct {
 	Path     string
+	SBOMDir  string
 	Metadata platform.LauncherMetadata
 }
 
@@ -71,9 +70,8 @@ func (e *Exporter) Export(opts ExportOptions) (platform.ExportReport, error) {
 	var err error
 
 	if e.PlatformAPI.AtLeast("0.11") {
-		err := copySboms(opts.LayersDir, e)
-		if err != nil {
-			return platform.ExportReport{}, errors.Wrapf(err, "failed to copy lifecycle/launch sboms")
+		if err = e.copyBuildpacksioSBOMs(opts); err != nil {
+			return platform.ExportReport{}, errors.Wrapf(err, "failed to copy buildpacksio SBOMs")
 		}
 	}
 
@@ -167,59 +165,51 @@ func (e *Exporter) Export(opts ExportOptions) (platform.ExportReport, error) {
 	return report, nil
 }
 
-func copySboms(layerDir string, e *Exporter) error {
-	targetBuildDir := filepath.Join(layerDir, "sbom", "build", "buildpacksio_lifecycle")
-	targetLaunchDir := filepath.Join(layerDir, "sbom", "launch", "buildpacksio_lifecycle")
-
-	if err := os.MkdirAll(targetBuildDir, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "fail to create directory %v", targetBuildDir)
-	}
-
-	if err := os.MkdirAll(targetLaunchDir, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "fail to create directory %v", targetLaunchDir)
-	}
-
-	extensions := e.SBOMExtensions()
-	components := e.SBOMComponents()
-
-	var targetDir string
-	for _, component := range components {
-		if component == "lifecycle" {
-			targetDir = targetBuildDir
-		} else if component == "launcher" {
-			targetDir = targetLaunchDir
-		}
-		for _, extension := range extensions {
-			sbomFilename := component + extension
-
-			srcSbomAbsPath := filepath.Join(paths.DefaultLifecycleDir, sbomFilename)
-
-			_, err := os.Stat(srcSbomAbsPath)
-			if !errors.Is(err, os.ErrNotExist) {
-				destSbomFilename := strings.Replace(sbomFilename, component+".", "", 1)
-				destSbomAbsPath := filepath.Join(targetDir, destSbomFilename)
-
-				err := fsutil.Copy(srcSbomAbsPath, destSbomAbsPath)
-
-				if err != nil {
-					return errors.Wrapf(err, "Fail to copy "+sbomFilename)
-				}
-
-				e.Logger.Infof("Copying " + component + " SBOM (" + destSbomFilename + ")")
-			} else {
-				e.Logger.Warn(sbomFilename + " is missing")
-			}
-		}
-	}
-	return nil
-}
-
-func (e *Exporter) SBOMExtensions() []string {
+func SBOMExtensions() []string {
 	return []string{".sbom.cdx.json", ".sbom.spdx.json", ".sbom.syft.json"}
 }
 
-func (e *Exporter) SBOMComponents() []string {
-	return []string{"lifecycle", "launcher"}
+func (e *Exporter) copyBuildpacksioSBOMs(opts ExportOptions) error {
+	targetBuildDir := filepath.Join(opts.LayersDir, "sbom", "build", launch.EscapeID("buildpacksio/lifecycle"))
+	if err := e.copyDefaultSBOMsForComponent("lifecycle", targetBuildDir); err != nil {
+		return err
+	}
+
+	targetLaunchDir := filepath.Join(opts.LayersDir, "sbom", "launch", launch.EscapeID("buildpacksio/lifecycle"))
+	switch {
+	case opts.LauncherConfig.SBOMDir == "" ||
+		opts.LauncherConfig.SBOMDir == platform.DefaultBuildpacksioSBOMDir:
+		return e.copyDefaultSBOMsForComponent("launcher", targetLaunchDir)
+	default:
+		// if provided a custom launcher SBOM directory, just copy everything in the directory
+		return fsutil.Copy(opts.LauncherConfig.SBOMDir, targetLaunchDir)
+	}
+}
+
+func (e *Exporter) copyDefaultSBOMsForComponent(component, dstDir string) error {
+	for _, extension := range SBOMExtensions() {
+		srcFilename := component + extension
+		srcPath := filepath.Join(platform.DefaultBuildpacksioSBOMDir, srcFilename)
+		if _, err := os.Stat(srcPath); err != nil {
+			if os.IsNotExist(err) {
+				e.Logger.Warnf("Did not find SBOM %s for %s", srcFilename, component)
+				continue
+			} else {
+				return err
+			}
+		}
+		// create target directory if not exists
+		if err := os.MkdirAll(dstDir, os.ModePerm); err != nil {
+			return err
+		}
+		dstFilename := strings.Replace(srcFilename, component+".", "", 1)
+		dstPath := filepath.Join(dstDir, dstFilename)
+		e.Logger.Debugf("Copying SBOM %s for %s", srcFilename, component)
+		if err := fsutil.Copy(srcPath, dstPath); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (e *Exporter) addBuildpackLayers(opts ExportOptions, meta *platform.LayersMetadata) error {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1076,20 +1076,6 @@ version = "4.5.6"
 				h.AssertNil(t, err)
 				h.AssertContains(t, fakeAppImage.SavedNames(), append(opts.AdditionalNames, fakeAppImage.Name())...)
 			})
-
-			it("should display that the SBOM is missing", func() {
-				exporter.PlatformAPI = api.MustParse("0.11")
-				_, err := exporter.Export(opts)
-				h.AssertNil(t, err)
-
-				extensions := lifecycle.SBOMExtensions()
-
-				for _, component := range []string{"lifecycle", "launcher"} {
-					for _, extension := range extensions {
-						assertLogEntry(t, logHandler, fmt.Sprintf("Did not find SBOM %s for %s", component+extension, component))
-					}
-				}
-			})
 		})
 
 		when("default process", func() {
@@ -1489,6 +1475,44 @@ version = "4.5.6"
 					err,
 					"layer 'buildpack.id:cache-layer-no-contents' is cache=true but has no contents",
 				)
+			})
+		})
+
+		when("buildpacksio SBOM", func() {
+			it.Before(func() {
+				exporter.PlatformAPI = api.MustParse("0.11")
+			})
+
+			when("missing from default directory", func() {
+				it.Before(func() {
+					h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "empty-metadata", "layers"), opts.LayersDir) // don't care
+				})
+
+				it("should display that the SBOM is missing", func() {
+					_, err := exporter.Export(opts)
+					h.AssertNil(t, err)
+
+					extensions := lifecycle.SBOMExtensions()
+					for _, component := range []string{"lifecycle", "launcher"} {
+						for _, extension := range extensions {
+							assertLogEntry(t, logHandler, fmt.Sprintf("Did not find SBOM %s.%s", component, extension))
+						}
+					}
+				})
+			})
+
+			when("custom launcher SBOM is provided", func() {
+				it.Before(func() {
+					h.RecursiveCopy(t, filepath.Join("testdata", "exporter", "launcher-sbom", "layers"), opts.LayersDir)
+					opts.LauncherConfig.SBOMDir = filepath.Join(opts.LayersDir, "some-launcher-sbom-dir")
+				})
+
+				it("copies everything in the launcher SBOM directory", func() {
+					_, err := exporter.Export(opts)
+					h.AssertNil(t, err)
+
+					h.AssertPathExists(t, filepath.Join(opts.LayersDir, "sbom", "launch", "buildpacksio_lifecycle", "launcher", "some-sbom-file"))
+				})
 			})
 		})
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/buildpacks/lifecycle"
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/buildpack"
+	"github.com/buildpacks/lifecycle/internal/path"
 	"github.com/buildpacks/lifecycle/launch"
 	"github.com/buildpacks/lifecycle/layers"
 	"github.com/buildpacks/lifecycle/platform"
@@ -1081,12 +1082,11 @@ version = "4.5.6"
 				_, err := exporter.Export(opts)
 				h.AssertNil(t, err)
 
-				extensions := exporter.SBOMExtensions()
-				components := exporter.SBOMComponents()
+				extensions := lifecycle.SBOMExtensions()
 
-				for _, component := range components {
+				for _, component := range []string{"lifecycle", "launcher"} {
 					for _, extension := range extensions {
-						assertLogEntry(t, logHandler, component+extension+" is missing")
+						assertLogEntry(t, logHandler, fmt.Sprintf("Did not find SBOM %s for %s", component+extension, component))
 					}
 				}
 			})
@@ -1104,7 +1104,7 @@ version = "4.5.6"
 						_, err := exporter.Export(opts)
 						h.AssertNil(t, err)
 
-						assertHasEntrypoint(t, fakeAppImage, filepath.Join(rootDir, "cnb", "process", "some-process-type"+execExt))
+						assertHasEntrypoint(t, fakeAppImage, filepath.Join(path.RootDir, "cnb", "process", "some-process-type"+path.ExecExt))
 					})
 
 					it("doesn't set CNB_PROCESS_TYPE", func() {
@@ -1139,7 +1139,7 @@ version = "4.5.6"
 						_, err := exporter.Export(opts)
 						h.AssertNil(t, err)
 						assertLogEntry(t, logHandler, "no default process type")
-						assertHasEntrypoint(t, fakeAppImage, filepath.Join(rootDir, "cnb", "lifecycle", "launcher"+execExt))
+						assertHasEntrypoint(t, fakeAppImage, filepath.Join(path.RootDir, "cnb", "lifecycle", "launcher"+path.ExecExt))
 					})
 				})
 
@@ -1167,7 +1167,7 @@ version = "4.5.6"
 					it("sets the ENTRYPOINT to this process type", func() {
 						_, err := exporter.Export(opts)
 						h.AssertNil(t, err)
-						assertHasEntrypoint(t, fakeAppImage, filepath.Join(rootDir, "cnb", "process", "some-process-type"+execExt))
+						assertHasEntrypoint(t, fakeAppImage, filepath.Join(path.RootDir, "cnb", "process", "some-process-type"+path.ExecExt))
 					})
 
 					it("doesn't set CNB_PROCESS_TYPE", func() {
@@ -1196,7 +1196,7 @@ version = "4.5.6"
 						_, err := exporter.Export(opts)
 						h.AssertNil(t, err)
 						assertLogEntry(t, logHandler, "default process type 'some-non-existing-process-type' not present in list [some-process-type]")
-						assertHasEntrypoint(t, fakeAppImage, filepath.Join(rootDir, "cnb", "lifecycle", "launcher"+execExt))
+						assertHasEntrypoint(t, fakeAppImage, filepath.Join(path.RootDir, "cnb", "lifecycle", "launcher"+path.ExecExt))
 					})
 				})
 
@@ -1204,7 +1204,7 @@ version = "4.5.6"
 					it("sets the ENTRYPOINT to the only process", func() {
 						_, err := exporter.Export(opts)
 						h.AssertNil(t, err)
-						assertHasEntrypoint(t, fakeAppImage, filepath.Join(rootDir, "cnb", "process", "some-process-type"+execExt))
+						assertHasEntrypoint(t, fakeAppImage, filepath.Join(path.RootDir, "cnb", "process", "some-process-type"+path.ExecExt))
 					})
 				})
 			})

--- a/internal/path/defaults.go
+++ b/internal/path/defaults.go
@@ -1,9 +1,0 @@
-package paths
-
-import (
-	"path/filepath"
-)
-
-var (
-	DefaultLifecycleDir = filepath.Join(rootDir, "cnb", "lifecycle")
-)

--- a/internal/path/defaults_unix.go
+++ b/internal/path/defaults_unix.go
@@ -1,8 +1,9 @@
 //go:build linux || darwin
 // +build linux darwin
 
-package paths
+package path
 
 const (
-	rootDir = "/"
+	ExecExt = ``
+	RootDir = `/`
 )

--- a/internal/path/defaults_windows.go
+++ b/internal/path/defaults_windows.go
@@ -1,5 +1,6 @@
-package paths
+package path
 
 const (
-	rootDir = `c:\`
+	ExecExt = `.exe`
+	RootDir = `c:\`
 )

--- a/lifecycle_unix_test.go
+++ b/lifecycle_unix_test.go
@@ -1,9 +1,0 @@
-//go:build linux || darwin
-// +build linux darwin
-
-package lifecycle_test
-
-const (
-	rootDir = "/"
-	execExt = ""
-)

--- a/lifecycle_windows_test.go
+++ b/lifecycle_windows_test.go
@@ -1,6 +1,0 @@
-package lifecycle_test
-
-const (
-	rootDir = `c:\`
-	execExt = ".exe"
-)

--- a/platform/create_inputs.go
+++ b/platform/create_inputs.go
@@ -14,8 +14,10 @@ import (
 func DefaultCreateInputs(platformAPI *api.Version) LifecycleInputs {
 	var inputs LifecycleInputs
 	switch {
-	case platformAPI.AtLeast("0.6"):
+	case platformAPI.AtLeast("0.11"):
 		inputs = defaultCreateInputs()
+	case platformAPI.AtLeast("0.6"):
+		inputs = defaultCreateInputs06To010()
 	case platformAPI.AtLeast("0.5"):
 		inputs = defaultCreateInputs05()
 	default:
@@ -26,6 +28,12 @@ func DefaultCreateInputs(platformAPI *api.Version) LifecycleInputs {
 }
 
 func defaultCreateInputs() LifecycleInputs {
+	ci := defaultCreateInputs06To010()
+	ci.LauncherSBOMDir = DefaultBuildpacksioSBOMDir
+	return ci
+}
+
+func defaultCreateInputs06To010() LifecycleInputs {
 	ci := defaultCreateInputs05()
 	ci.OrderPath = envOrDefault(EnvOrderPath, placeholderOrderPath)
 	return ci

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -3,6 +3,8 @@ package platform
 import (
 	"path/filepath"
 	"time"
+
+	"github.com/buildpacks/lifecycle/internal/path"
 )
 
 // # Platform Inputs to the Lifecycle and their Default Values
@@ -79,14 +81,14 @@ const (
 )
 
 var (
-	DefaultBuildpacksDir = filepath.Join(rootDir, "cnb", "buildpacks")
-	DefaultExtensionsDir = filepath.Join(rootDir, "cnb", "extensions")
+	DefaultBuildpacksDir = filepath.Join(path.RootDir, "cnb", "buildpacks")
+	DefaultExtensionsDir = filepath.Join(path.RootDir, "cnb", "extensions")
 
 	// DefaultOrderPath is the default order path.
-	DefaultOrderPath = filepath.Join(rootDir, "cnb", "order.toml")
+	DefaultOrderPath = filepath.Join(path.RootDir, "cnb", "order.toml")
 
 	// DefaultStackPath is the default stack path.
-	DefaultStackPath = filepath.Join(rootDir, "cnb", "stack.toml")
+	DefaultStackPath = filepath.Join(path.RootDir, "cnb", "stack.toml")
 )
 
 // ## Provided at Build Time
@@ -101,9 +103,9 @@ const (
 
 // The following are the default locations of input directories if not specified.
 var (
-	DefaultAppDir      = filepath.Join(rootDir, "workspace")
-	DefaultLayersDir   = filepath.Join(rootDir, "layers")
-	DefaultPlatformDir = filepath.Join(rootDir, "platform")
+	DefaultAppDir      = filepath.Join(path.RootDir, "workspace")
+	DefaultLayersDir   = filepath.Join(path.RootDir, "layers")
+	DefaultPlatformDir = filepath.Join(path.RootDir, "platform")
 )
 
 // The following instruct the lifecycle where to write files and data during the build.
@@ -190,6 +192,9 @@ const (
 	DefaultProjectMetadataFile = "project-metadata.toml"
 )
 
-// DefaultLauncherPath is the default location of the launcher executable during the build.
-// The launcher is exported in the output application image and is used to start application processes at runtime.
-var DefaultLauncherPath = filepath.Join(rootDir, "cnb", "lifecycle", "launcher"+execExt)
+var (
+	// DefaultLauncherPath is the default location of the launcher executable during the build.
+	// The launcher is exported in the output application image and is used to start application processes at runtime.
+	DefaultLauncherPath        = filepath.Join(path.RootDir, "cnb", "lifecycle", "launcher"+path.ExecExt)
+	DefaultBuildpacksioSBOMDir = filepath.Join(path.RootDir, "cnb", "lifecycle")
+)

--- a/platform/defaults_unix.go
+++ b/platform/defaults_unix.go
@@ -1,9 +1,0 @@
-//go:build linux || darwin
-// +build linux darwin
-
-package platform
-
-const (
-	execExt = ""
-	rootDir = "/"
-)

--- a/platform/defaults_windows.go
+++ b/platform/defaults_windows.go
@@ -1,6 +1,0 @@
-package platform
-
-const (
-	execExt = ".exe"
-	rootDir = `c:\`
-)

--- a/platform/export_inputs.go
+++ b/platform/export_inputs.go
@@ -14,8 +14,10 @@ import (
 func DefaultExportInputs(platformAPI *api.Version) LifecycleInputs {
 	var inputs LifecycleInputs
 	switch {
-	case platformAPI.AtLeast("0.7"):
+	case platformAPI.AtLeast("0.11"):
 		inputs = defaultExportInputs()
+	case platformAPI.AtLeast("0.7"):
+		inputs = defaultExportInputs07To010()
 	case platformAPI.AtLeast("0.5"):
 		inputs = defaultExportInputs05To06()
 	default:
@@ -26,6 +28,12 @@ func DefaultExportInputs(platformAPI *api.Version) LifecycleInputs {
 }
 
 func defaultExportInputs() LifecycleInputs {
+	ei := defaultExportInputs07To010()
+	ei.LauncherSBOMDir = DefaultBuildpacksioSBOMDir
+	return ei
+}
+
+func defaultExportInputs07To010() LifecycleInputs {
 	ei := defaultExportInputs05To06()
 	ei.RunImageRef = "" // removed
 	return ei

--- a/platform/launch/defaults.go
+++ b/platform/launch/defaults.go
@@ -1,6 +1,10 @@
 package launch
 
-import "path/filepath"
+import (
+	"path/filepath"
+
+	"github.com/buildpacks/lifecycle/internal/path"
+)
 
 const (
 	EnvAppDir      = "CNB_APP_DIR"
@@ -12,10 +16,10 @@ const (
 	DefaultPlatformAPI = "0.3"
 	DefaultProcessType = "web"
 
-	DefaultExecExt = execExt
+	DefaultExecExt = path.ExecExt
 )
 
 var (
-	DefaultAppDir    = filepath.Join(rootDir, "workspace")
-	DefaultLayersDir = filepath.Join(rootDir, "layers")
+	DefaultAppDir    = filepath.Join(path.RootDir, "workspace")
+	DefaultLayersDir = filepath.Join(path.RootDir, "layers")
 )

--- a/platform/launch/defaults_unix.go
+++ b/platform/launch/defaults_unix.go
@@ -1,9 +1,0 @@
-//go:build linux || darwin
-// +build linux darwin
-
-package launch
-
-const (
-	execExt = ""
-	rootDir = "/"
-)

--- a/platform/launch/defaults_windows.go
+++ b/platform/launch/defaults_windows.go
@@ -1,6 +1,0 @@
-package launch
-
-const (
-	execExt = ".exe"
-	rootDir = `c:\`
-)

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -33,6 +33,7 @@ type LifecycleInputs struct {
 	KanikoDir             string
 	LaunchCacheDir        string
 	LauncherPath          string
+	LauncherSBOMDir       string
 	LayersDir             string
 	LogLevel              string
 	OrderPath             string

--- a/tools/packager/main.go
+++ b/tools/packager/main.go
@@ -16,10 +16,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	bp "github.com/buildpacks/lifecycle/buildpack"
-
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/archive"
+	bp "github.com/buildpacks/lifecycle/buildpack"
 )
 
 var (


### PR DESCRIPTION
As a follow on to https://github.com/buildpacks/lifecycle/pull/944, this PR introduces a `-launcher-sbom` flag to the exporter & creator so that users who supply their own launcher can supply an SBOM for that launcher.

Related spec PR: https://github.com/buildpacks/spec/pull/332/files?diff=split&w=1