### PR TITLE
Fix pack acceptance with 0.28.0-rc1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,11 @@ jobs:
     needs: build-and-publish
     runs-on: windows-2019
     steps:
+      - name: Set git to use LF and symlinks
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global core.symlinks true
       - uses: actions/checkout@v2
         with:
           repository: 'buildpacks/pack'


### PR DESCRIPTION
We need to configure git to use line feeds on Windows, otherwise
  the test fixtures and hence the layer diff IDs will be different from the test expectations.

Signed-off-by: Natalie Arellano <narellano@vmware.com>