### PR TITLE
allow passing previous image in rebase cmd

### DIFF
--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -102,7 +102,7 @@ func (r *rebaseCmd) Exec() error {
 		Logger:      cmd.DefaultLogger,
 		PlatformAPI: r.PlatformAPI,
 	}
-	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.AdditionalTags, r.OutputImageRef)
+	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.OutputImageRef, r.AdditionalTags)
 	if err != nil {
 		return cmd.FailErrCode(err, r.CodeFor(platform.RebaseError), "rebase")
 	}

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -102,7 +102,7 @@ func (r *rebaseCmd) Exec() error {
 		Logger:      cmd.DefaultLogger,
 		PlatformAPI: r.PlatformAPI,
 	}
-	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.AdditionalTags)
+	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.AdditionalTags, r.OutputImageRef)
 	if err != nil {
 		return cmd.FailErrCode(err, r.CodeFor(platform.RebaseError), "rebase")
 	}
@@ -129,7 +129,7 @@ func (r *rebaseCmd) setAppImage() error {
 
 	if r.UseDaemon {
 		r.appImage, err = local.NewImage(
-			r.OutputImageRef,
+			targetImageRef,
 			r.docker,
 			local.FromBaseImage(targetImageRef),
 		)
@@ -140,7 +140,7 @@ func (r *rebaseCmd) setAppImage() error {
 			return err
 		}
 		r.appImage, err = remote.NewImage(
-			r.OutputImageRef,
+			targetImageRef,
 			keychain,
 			remote.FromBaseImage(targetImageRef),
 		)

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -40,6 +40,10 @@ func (r *rebaseCmd) DefineFlags() {
 	cli.FlagPreviousImage(&r.PreviousImageRef)
 
 	cli.DeprecatedFlagRunImage(&r.DeprecatedRunImageRef)
+
+	if r.PlatformAPI.AtLeast("0.11") {
+		cli.FlagPreviousImage(&r.PreviousImageRef)
+	}
 }
 
 // Args validates arguments and flags, and fills in default values.

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -37,8 +37,6 @@ func (r *rebaseCmd) DefineFlags() {
 	cli.FlagRunImage(&r.RunImageRef)
 	cli.FlagUID(&r.UID)
 	cli.FlagUseDaemon(&r.UseDaemon)
-	cli.FlagPreviousImage(&r.PreviousImageRef)
-
 	cli.DeprecatedFlagRunImage(&r.DeprecatedRunImageRef)
 
 	if r.PlatformAPI.AtLeast("0.11") {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/buildpacks/lifecycle
 
+replace github.com/buildpacks/imgutil => github.com/joeybrown-sf/imgutil v0.0.0-20230109163644-1c47df232fe2
+
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/GoogleContainerTools/kaniko v1.9.2-0.20220928141902-4d077e2a4084

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,11 @@
 module github.com/buildpacks/lifecycle
 
-replace github.com/buildpacks/imgutil => github.com/joeybrown-sf/imgutil v0.0.0-20230109163644-1c47df232fe2
-
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/GoogleContainerTools/kaniko v1.9.2-0.20220928141902-4d077e2a4084
 	github.com/apex/log v1.9.0
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20221206183240-3b42f427f89a
-	github.com/buildpacks/imgutil v0.0.0-20221128174954-533a87656dc4
+	github.com/buildpacks/imgutil v0.0.0-20230109221445-3a4729624abe
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20221129204813-6a4d6ed5d396
 	github.com/containerd/containerd v1.6.13
 	github.com/docker/docker v20.10.21+incompatible

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/buildpacks/imgutil v0.0.0-20230109221445-3a4729624abe h1:/6zdvfeEvaf1mOrw6LaaUE+wG0PvAKOZOaB3z1DzioA=
+github.com/buildpacks/imgutil v0.0.0-20230109221445-3a4729624abe/go.mod h1:7XJyKf8MwQfHcsjjA9et24BWN3gE1FztxnN8de54mL0=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
@@ -787,8 +789,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
-github.com/joeybrown-sf/imgutil v0.0.0-20230109163644-1c47df232fe2 h1:H/jUMPAaH/LIikH6fPeLXT5coXU29lznERaTyOR3mmE=
-github.com/joeybrown-sf/imgutil v0.0.0-20230109163644-1c47df232fe2/go.mod h1:7XJyKf8MwQfHcsjjA9et24BWN3gE1FztxnN8de54mL0=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,6 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildpacks/imgutil v0.0.0-20221128174954-533a87656dc4 h1:JrC06zJNkuOGrNVh7u8RXjfSNO8810blRjLeBplMQZA=
-github.com/buildpacks/imgutil v0.0.0-20221128174954-533a87656dc4/go.mod h1:7XJyKf8MwQfHcsjjA9et24BWN3gE1FztxnN8de54mL0=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
@@ -789,6 +787,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
+github.com/joeybrown-sf/imgutil v0.0.0-20230109163644-1c47df232fe2 h1:H/jUMPAaH/LIikH6fPeLXT5coXU29lznERaTyOR3mmE=
+github.com/joeybrown-sf/imgutil v0.0.0-20230109163644-1c47df232fe2/go.mod h1:7XJyKf8MwQfHcsjjA9et24BWN3gE1FztxnN8de54mL0=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=

--- a/rebaser.go
+++ b/rebaser.go
@@ -25,7 +25,7 @@ type RebaseReport struct {
 	Image platform.ImageReport `toml:"image"`
 }
 
-func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, additionalNames []string) (RebaseReport, error) {
+func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, additionalNames []string, outputImageRef string) (RebaseReport, error) {
 	var origMetadata platform.LayersMetadataCompat
 	if err := image.DecodeLabel(appImage, platform.LayerMetadataLabel, &origMetadata); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "get image metadata")
@@ -86,6 +86,7 @@ func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, add
 		return RebaseReport{}, errors.Wrap(err, "set stack labels")
 	}
 
+	appImage.Rename(outputImageRef)
 	report := RebaseReport{}
 	report.Image, err = saveImage(appImage, additionalNames, r.Logger)
 	if err != nil {

--- a/rebaser.go
+++ b/rebaser.go
@@ -25,13 +25,13 @@ type RebaseReport struct {
 	Image platform.ImageReport `toml:"image"`
 }
 
-func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, additionalNames []string, outputImageRef string) (RebaseReport, error) {
+func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image, outputImageRef string, additionalNames []string) (RebaseReport, error) {
 	var origMetadata platform.LayersMetadataCompat
-	if err := image.DecodeLabel(appImage, platform.LayerMetadataLabel, &origMetadata); err != nil {
+	if err := image.DecodeLabel(workingImage, platform.LayerMetadataLabel, &origMetadata); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "get image metadata")
 	}
 
-	appStackID, err := appImage.Label(platform.StackIDLabel)
+	appStackID, err := workingImage.Label(platform.StackIDLabel)
 	if err != nil {
 		return RebaseReport{}, errors.Wrap(err, "get app image stack")
 	}
@@ -53,11 +53,11 @@ func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, add
 		return RebaseReport{}, fmt.Errorf("incompatible stack: '%s' is not compatible with '%s'", newBaseStackID, appStackID)
 	}
 
-	if err := validateMixins(appImage, newBaseImage); err != nil {
+	if err := validateMixins(workingImage, newBaseImage); err != nil {
 		return RebaseReport{}, err
 	}
 
-	if err := appImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage); err != nil {
+	if err := workingImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "rebase app image")
 	}
 
@@ -77,18 +77,17 @@ func (r *Rebaser) Rebase(appImage imgutil.Image, newBaseImage imgutil.Image, add
 		return RebaseReport{}, errors.Wrap(err, "marshall metadata")
 	}
 
-	if err := appImage.SetLabel(platform.LayerMetadataLabel, string(data)); err != nil {
+	if err := workingImage.SetLabel(platform.LayerMetadataLabel, string(data)); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "set app image metadata label")
 	}
 
 	hasPrefix := func(l string) bool { return strings.HasPrefix(l, "io.buildpacks.stack.") }
-	if err := image.SyncLabels(newBaseImage, appImage, hasPrefix); err != nil {
+	if err := image.SyncLabels(newBaseImage, workingImage, hasPrefix); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "set stack labels")
 	}
-
-	appImage.Rename(outputImageRef)
 	report := RebaseReport{}
-	report.Image, err = saveImage(appImage, additionalNames, r.Logger)
+	workingImage.Rename("") // unset name
+	report.Image, err = saveImageAs(workingImage, outputImageRef, additionalNames, r.Logger)
 	if err != nil {
 		return RebaseReport{}, err
 	}

--- a/rebaser.go
+++ b/rebaser.go
@@ -86,7 +86,6 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 		return RebaseReport{}, errors.Wrap(err, "set stack labels")
 	}
 	report := RebaseReport{}
-	workingImage.Rename("") // unset name
 	report.Image, err = saveImageAs(workingImage, outputImageRef, additionalNames, r.Logger)
 	if err != nil {
 		return RebaseReport{}, err

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -70,25 +70,25 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 	when("#Rebase", func() {
 		when("app image and run image exist", func() {
 			it("updates the base image of the app image", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertNil(t, err)
 				h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 			})
 
 			it("saves to all names", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertNil(t, err)
 				h.AssertContains(t, fakeAppImage.SavedNames(), "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
 			})
 
 			it("adds all names to report", func() {
-				report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertNil(t, err)
 				h.AssertContains(t, report.Image.Tags, "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
 			})
 
 			it("sets the top layer in the metadata", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
 
@@ -96,7 +96,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("sets the run image reference in the metadata", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
 
@@ -108,7 +108,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					platform.LayerMetadataLabel,
 					`{"app": [{"sha": "123456"}], "buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
 				))
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
 
@@ -144,7 +144,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("syncs matching labels", func() {
-					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 					h.AssertNil(t, err)
 
 					for _, test := range tests {
@@ -170,7 +170,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("add the digest to the report", func() {
-					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, report.Image.Digest, fakeRemoteDigest)
@@ -192,7 +192,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("doesn't set the manifest size in the report.toml", func() {
-							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 							h.AssertNil(t, err)
 
 							h.AssertEq(t, report.Image.ManifestSize, int64(0))
@@ -208,7 +208,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("add the manifest size to the report", func() {
-							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 							h.AssertNil(t, err)
 
 							h.AssertEq(t, report.Image.ManifestSize, fakeRemoteManifestSize)
@@ -222,7 +222,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("doesn't set the manifest size in the report.toml", func() {
-							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 							h.AssertNil(t, err)
 
 							h.AssertEq(t, report.Image.ManifestSize, int64(0))
@@ -233,7 +233,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 
 			when("image has an ID identifier", func() {
 				it("add the imageID to the report", func() {
-					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, report.Image.ImageID, "some-image-id")
@@ -243,7 +243,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			when("validating mixins", func() {
 				when("there are no mixin labels", func() {
 					it("allows rebase", func() {
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -252,7 +252,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				when("there are invalid mixin labels", func() {
 					it("returns an error", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "thisisn'tvalid!"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertError(t, err, "get app image mixins: failed to unmarshal context of label 'io.buildpacks.stack.mixins': invalid character 'h' in literal true (expecting 'r')")
 					})
 				})
@@ -261,7 +261,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "null"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "null"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -271,7 +271,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "null"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -281,7 +281,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -291,7 +291,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\", \"mixin-3\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -301,7 +301,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -311,7 +311,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"run:mixin-1\", \"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -321,7 +321,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("does not allow rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 						h.AssertError(t, err, "missing required mixin(s): mixin-1")
 					})
 				})
@@ -333,7 +333,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertError(t, err, "incompatible stack: 'io.buildpacks.stacks.cflinuxfs3' is not compatible with 'io.buildpacks.stacks.bionic'")
 			})
 
@@ -341,7 +341,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, ""))
 
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertError(t, err, "stack not defined on new base image")
 			})
 
@@ -349,7 +349,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, ""))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
 				h.AssertError(t, err, "stack not defined on app image")
 			})
 		})

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -370,7 +370,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, outputImageRef, additionalNames)
 				h.AssertNil(t, err)
 				h.AssertContains(t, fakeAppImage.SavedNames(), append(additionalNames, outputImageRef)...)
-				h.AssertDoesNotContain(t, fakeAppImage.SavedNames(), "some-repo/previous-image")
+				h.AssertDoesNotContain(t, fakeAppImage.SavedNames(), fakePreviousImage.Name())
 			})
 		})
 	})

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -364,7 +364,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("outputImageRef is different than app image name", func() {
+		when("outputImageRef is different than workingImage name", func() {
 			it("saves using outputImageRef, not the app image name", func() {
 				outputImageRef := "fizz"
 				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, outputImageRef, additionalNames)

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -28,11 +28,12 @@ func TestRebaser(t *testing.T) {
 
 func testRebaser(t *testing.T, when spec.G, it spec.S) {
 	var (
-		rebaser          *lifecycle.Rebaser
-		fakeAppImage     *fakes.Image
-		fakeNewBaseImage *fakes.Image
-		additionalNames  []string
-		md               platform.LayersMetadataCompat
+		rebaser           *lifecycle.Rebaser
+		fakeAppImage      *fakes.Image
+		fakeNewBaseImage  *fakes.Image
+		fakePreviousImage *fakes.Image
+		additionalNames   []string
+		md                platform.LayersMetadataCompat
 	)
 
 	it.Before(func() {
@@ -54,6 +55,15 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		)
 		h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 
+		fakePreviousImage = fakes.NewImage(
+			"some-repo/previous-image",
+			"previous-layer-sha",
+			local.IDIdentifier{
+				ImageID: "previous-run-id",
+			},
+		)
+		h.AssertNil(t, fakePreviousImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
+
 		additionalNames = []string{"some-repo/app-image:foo", "some-repo/app-image:bar"}
 
 		rebaser = &lifecycle.Rebaser{
@@ -70,25 +80,25 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 	when("#Rebase", func() {
 		when("app image and run image exist", func() {
 			it("updates the base image of the app image", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 			})
 
 			it("saves to all names", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertContains(t, fakeAppImage.SavedNames(), "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
 			})
 
 			it("adds all names to report", func() {
-				report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertContains(t, report.Image.Tags, "some-repo/app-image", "some-repo/app-image:foo", "some-repo/app-image:bar")
 			})
 
 			it("sets the top layer in the metadata", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
 
@@ -96,7 +106,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("sets the run image reference in the metadata", func() {
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
 
@@ -108,7 +118,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					platform.LayerMetadataLabel,
 					`{"app": [{"sha": "123456"}], "buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
 				))
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
 
@@ -144,7 +154,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("syncs matching labels", func() {
-					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 					h.AssertNil(t, err)
 
 					for _, test := range tests {
@@ -170,7 +180,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("add the digest to the report", func() {
-					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, report.Image.Digest, fakeRemoteDigest)
@@ -192,7 +202,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("doesn't set the manifest size in the report.toml", func() {
-							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 							h.AssertNil(t, err)
 
 							h.AssertEq(t, report.Image.ManifestSize, int64(0))
@@ -208,7 +218,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("add the manifest size to the report", func() {
-							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 							h.AssertNil(t, err)
 
 							h.AssertEq(t, report.Image.ManifestSize, fakeRemoteManifestSize)
@@ -222,7 +232,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						})
 
 						it("doesn't set the manifest size in the report.toml", func() {
-							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+							report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 							h.AssertNil(t, err)
 
 							h.AssertEq(t, report.Image.ManifestSize, int64(0))
@@ -233,7 +243,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 
 			when("image has an ID identifier", func() {
 				it("add the imageID to the report", func() {
-					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+					report, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 					h.AssertNil(t, err)
 
 					h.AssertEq(t, report.Image.ImageID, "some-image-id")
@@ -243,7 +253,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			when("validating mixins", func() {
 				when("there are no mixin labels", func() {
 					it("allows rebase", func() {
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -252,7 +262,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				when("there are invalid mixin labels", func() {
 					it("returns an error", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "thisisn'tvalid!"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertError(t, err, "get app image mixins: failed to unmarshal context of label 'io.buildpacks.stack.mixins': invalid character 'h' in literal true (expecting 'r')")
 					})
 				})
@@ -261,7 +271,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "null"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "null"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -271,7 +281,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "null"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -281,7 +291,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -291,7 +301,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\", \"mixin-3\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -301,7 +311,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -311,7 +321,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("allows rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"run:mixin-1\", \"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 						h.AssertEq(t, fakeAppImage.Base(), "some-repo/new-base-image")
 					})
@@ -321,7 +331,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					it("does not allow rebase", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "[\"mixin-1\", \"run:mixin-2\"]"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.MixinsLabel, "[\"run:mixin-2\"]"))
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertError(t, err, "missing required mixin(s): mixin-1")
 					})
 				})
@@ -333,7 +343,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertError(t, err, "incompatible stack: 'io.buildpacks.stacks.cflinuxfs3' is not compatible with 'io.buildpacks.stacks.bionic'")
 			})
 
@@ -341,7 +351,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, ""))
 
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertError(t, err, "stack not defined on new base image")
 			})
 
@@ -349,7 +359,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, ""))
 				h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, fakeAppImage.Name())
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertError(t, err, "stack not defined on app image")
 			})
 		})
@@ -357,9 +367,10 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		when("outputImageRef is different than app image name", func() {
 			it("saves using outputImageRef, not the app image name", func() {
 				outputImageRef := "fizz"
-				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, outputImageRef)
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, outputImageRef, additionalNames)
 				h.AssertNil(t, err)
 				h.AssertContains(t, fakeAppImage.SavedNames(), append(additionalNames, outputImageRef)...)
+				h.AssertDoesNotContain(t, fakeAppImage.SavedNames(), "some-repo/previous-image")
 			})
 		})
 	})

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -353,5 +353,14 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertError(t, err, "stack not defined on app image")
 			})
 		})
+
+		when("outputImageRef is different than app image name", func() {
+			it("saves using outputImageRef, not the app image name", func() {
+				outputImageRef := "fizz"
+				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, additionalNames, outputImageRef)
+				h.AssertNil(t, err)
+				h.AssertContains(t, fakeAppImage.SavedNames(), append(additionalNames, outputImageRef)...)
+			})
+		})
 	})
 }

--- a/save.go
+++ b/save.go
@@ -13,10 +13,14 @@ import (
 )
 
 func saveImage(image imgutil.Image, additionalNames []string, logger log.Logger) (platform.ImageReport, error) {
+	return saveImageAs(image, image.Name(), additionalNames, logger)
+}
+
+func saveImageAs(image imgutil.Image, name string, additionalNames []string, logger log.Logger) (platform.ImageReport, error) {
 	var saveErr error
 	imageReport := platform.ImageReport{}
-	logger.Infof("Saving %s...\n", image.Name())
-	if err := image.Save(additionalNames...); err != nil {
+	logger.Infof("Saving %s...\n", name)
+	if err := image.SaveAs(name, additionalNames...); err != nil {
 		var ok bool
 		if saveErr, ok = err.(imgutil.SaveError); !ok {
 			return platform.ImageReport{}, errors.Wrap(err, "saving image")
@@ -32,7 +36,7 @@ func saveImage(image imgutil.Image, additionalNames []string, logger log.Logger)
 	}
 
 	logger.Infof("*** Images (%s):\n", shortID(id))
-	for _, n := range append([]string{image.Name()}, additionalNames...) {
+	for _, n := range append([]string{name}, additionalNames...) {
 		if ok, message := getSaveStatus(saveErr, n); !ok {
 			logger.Infof("      %s - %s\n", n, message)
 		} else {

--- a/testhelpers/testhelpers.go
+++ b/testhelpers/testhelpers.go
@@ -76,6 +76,15 @@ outer:
 	}
 }
 
+func AssertDoesNotContain(t *testing.T, slice []string, element string) {
+	t.Helper()
+	for _, actual := range slice {
+		if diff := cmp.Diff(actual, element); diff == "" {
+			t.Fatalf("Expected %+v not to contain: %s", slice, element)
+		}
+	}
+}
+
 func AssertStringContains(t *testing.T, str string, expected string) {
 	t.Helper()
 	if !strings.Contains(str, expected) {


### PR DESCRIPTION
This allows a rebase by a image digest reference.

Resolves [#983](https://github.com/buildpacks/lifecycle/issues/983)

Here is an example command & output:
```
➜ lifecycle rebase -previous-image localhost:5003/cnb/rebase/demo@sha256:916a9e100569ee521b86d03b8499b9b93d7d256d6e838868ae720295f2ea2f76 localhost:5003/cnb/rebase/demo:v1 localhost:5003/cnb/rebase/demo:rebased
Saving localhost:5003/cnb/rebase/demo:v1...
*** Images (sha256:07c07bba660126053df38987bbb6098784b9348226ac689ded17f588c6708ed5):
      localhost:5003/cnb/rebase/demo:v1
      localhost:5003/cnb/rebase/demo:rebased
```