### PR TITLE
Fix creator acceptance test flake

### DIFF
--- a/acceptance/testdata/creator/container/cnb/buildpacks/samples_hello-world/0.0.1/bin/build
+++ b/acceptance/testdata/creator/container/cnb/buildpacks/samples_hello-world/0.0.1/bin/build
@@ -28,7 +28,15 @@ fi
 
 echo -n "{\"key\": \"some-launch-true-bom-content\"}" > ${layers_dir}/some-layer.sbom.cdx.json
 
-cat <<EOF > "$layers_dir"/some-layer.toml
+if test -f ${layers_dir}/some-layer.toml; then
+  # mimic not downloading new content
+  echo "nop"
+else
+  # mimic downloading new content
+  sleep 1
+fi
+
+cat <<EOF > ${layers_dir}/some-layer.toml
 [types]
   launch = true
 EOF
@@ -42,7 +50,7 @@ fi
 
 echo -n "{\"key\": \"some-cache-true-bom-content\"}" > ${layers_dir}/some-cache-layer.sbom.cdx.json
 
-cat <<EOF > "$layers_dir"/some-cache-layer.toml
+cat <<EOF > ${layers_dir}/some-cache-layer.toml
 [types]
   cache = true
 EOF
@@ -56,7 +64,7 @@ fi
 
 echo -n "{\"key\": \"some-launch-true-cache-true-bom-content\"}" > ${layers_dir}/some-launch-cache-layer.sbom.cdx.json
 
-cat <<EOF > "$layers_dir"/some-launch-cache-layer.toml
+cat <<EOF > ${layers_dir}/some-launch-cache-layer.toml
 [types]
   launch = true
   cache = true
@@ -72,7 +80,7 @@ fi
 
 echo -n "{\"key\": \"some-bom-content\"}" > ${layers_dir}/some-build-layer.sbom.cdx.json
 
-cat <<EOF > "$layers_dir"/some-build-layer.toml
+cat <<EOF > ${layers_dir}/some-build-layer.toml
 [types]
   build = true
 EOF

--- a/cache/caching_image.go
+++ b/cache/caching_image.go
@@ -93,6 +93,17 @@ func (c *CachingImage) Save(additionalNames ...string) error {
 	return err
 }
 
+func (c *CachingImage) SaveAs(name string, additionalNames ...string) error {
+	err := c.Image.SaveAs(name, additionalNames...)
+
+	if saveSucceededFor(c.Name(), err) {
+		if err := c.cache.Commit(); err != nil {
+			return errors.Wrap(err, "failed to commit cache")
+		}
+	}
+	return err
+}
+
 func saveSucceededFor(imageName string, err error) bool {
 	if err == nil {
 		return true


### PR DESCRIPTION
On shared hardware it's not guaranteed for the second build to take less than 3 seconds 
We can at least test that the second build is faster than the first