### PR TITLE
WIP: Send dispatch event to buildpacks/samples on lifecycle release

### DIFF
--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -15,3 +15,4 @@ jobs:
           token: ${{ secrets.PLATFORM_GITHUB_TOKEN }}
           event-type: lifecycle-release
           repository: buildpacks/samples
+          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.PLATFORM_GITHUB_TOKEN }}
+          token: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}
           event-type: lifecycle-release
           repository: buildpacks/samples
           client-payload: '{"version": "${{ github.event.release.tag_name }}"}'

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -3,7 +3,7 @@ name: release-dispatch
 on:
   release:
     types:
-      - published
+      - released
 
 jobs:
   send-release-dispatch:

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,0 +1,17 @@
+name: release-dispatch
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  send-release-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.PLATFORM_GITHUB_TOKEN }}
+          event-type: lifecycle-release
+          repository: buildpacks/samples


### PR DESCRIPTION
Adds workflow to send dispatch event to `buildpacks/samples` on lifecycle releases. This will be used as a trigger on the receiving end to rebuild the samples and update their `builder.toml` files with the latest lifecycle version.

Lifecycle version is sent in dispatch payload.

Resolves #801 

**Question:** Am I correct in thinking the activity type of `release` should be `released` and not `published`? I took it from the `post-release.yml` file but I presume we want to send the dispatch event only for (stable) releases, not pre-releases or draft releases?