### PR TITLE
Replace print with logger in image_cache.go, fixes formatting

### DIFF
--- a/cache/image_cache.go
+++ b/cache/image_cache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/lifecycle/image"
+	"github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
 )
 
@@ -21,16 +22,18 @@ type ImageCache struct {
 	committed bool
 	origImage imgutil.Image
 	newImage  imgutil.Image
+	logger    log.Logger
 }
 
-func NewImageCache(origImage imgutil.Image, newImage imgutil.Image) *ImageCache {
+func NewImageCache(origImage imgutil.Image, newImage imgutil.Image, logger log.Logger) *ImageCache {
 	return &ImageCache{
 		origImage: origImage,
 		newImage:  newImage,
+		logger:    logger,
 	}
 }
 
-func NewImageCacheFromName(name string, keychain authn.Keychain) (*ImageCache, error) {
+func NewImageCacheFromName(name string, keychain authn.Keychain, logger log.Logger) (*ImageCache, error) {
 	origImage, err := remote.NewImage(
 		name,
 		keychain,
@@ -51,7 +54,7 @@ func NewImageCacheFromName(name string, keychain authn.Keychain) (*ImageCache, e
 		return nil, fmt.Errorf("creating new cache image %q: %v", name, err)
 	}
 
-	return NewImageCache(origImage, emptyImage), nil
+	return NewImageCache(origImage, emptyImage, logger), nil
 }
 
 func (c *ImageCache) Exists() bool {
@@ -115,7 +118,7 @@ func (c *ImageCache) Commit() error {
 	if origImgExists {
 		// Deleting the original image is for cleanup only and should not fail the commit.
 		if err := c.DeleteOrigImage(); err != nil {
-			fmt.Printf("Unable to delete previous cache image: %v", err)
+			c.logger.Warnf("Unable to delete previous cache image: %v", err)
 		}
 	}
 	c.origImage = c.newImage

--- a/cache/image_cache_test.go
+++ b/cache/image_cache_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/cache"
+	"github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
@@ -33,6 +34,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 		subject           *cache.ImageCache
 		testLayerTarPath  string
 		testLayerSHA      string
+		testLogger        log.Logger
 	)
 
 	it.Before(func() {
@@ -44,7 +46,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 		fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOriginalImage"})
 		fakeNewImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeImage"})
 
-		subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
+		subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage, testLogger)
 
 		testLayerTarPath = filepath.Join(tmpDir, "some-layer.tar")
 		h.AssertNil(t, os.WriteFile(testLayerTarPath, []byte("dummy data"), 0600))
@@ -295,7 +297,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 				it.Before(func() {
 					fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOrigImage"})
 					fakeNewImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeNewImage"})
-					subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
+					subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage, testLogger)
 				})
 				it("should delete original image", func() {
 					err := subject.DeleteOrigImage()
@@ -308,7 +310,7 @@ func testImageCache(t *testing.T, when spec.G, it spec.S) {
 				it.Before(func() {
 					fakeOriginalImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOrigImage"})
 					fakeNewImage = fakes.NewImage("fake-image", "", local.IDIdentifier{ImageID: "fakeOrigImage"})
-					subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage)
+					subject = cache.NewImageCache(fakeOriginalImage, fakeNewImage, testLogger)
 				})
 				it("should not delete original image", func() {
 					err := subject.DeleteOrigImage()

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -99,7 +99,7 @@ func (ch *DefaultCacheHandler) InitCache(cacheImageRef string, cacheDir string) 
 		err        error
 	)
 	if cacheImageRef != "" {
-		cacheStore, err = cache.NewImageCacheFromName(cacheImageRef, ch.keychain)
+		cacheStore, err = cache.NewImageCacheFromName(cacheImageRef, ch.keychain, cmd.DefaultLogger)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating image cache")
 		}
@@ -206,7 +206,7 @@ func initCache(cacheImageTag, cacheDir string, keychain authn.Keychain) (lifecyc
 		err        error
 	)
 	if cacheImageTag != "" {
-		cacheStore, err = cache.NewImageCacheFromName(cacheImageTag, keychain)
+		cacheStore, err = cache.NewImageCacheFromName(cacheImageTag, keychain, cmd.DefaultLogger)
 		if err != nil {
 			return nil, cmd.FailErr(err, "create image cache")
 		}


### PR DESCRIPTION
This attempts to fix https://github.com/buildpacks/lifecycle/issues/880

Hey @jjbustamante, @natalieparellano, 
To test invocation of `logger.Warnf()` in `image_cache.go`, method `c.DeleteOrigImage()` must return a non-nil error. I tried to simulate this using a spy for `ImageCache` and mock method `DeleteOrigImage()` that returns an error, but it didn't help.  Please provide your valuable feedback