### PR TITLE
Preserves test output for easier grepping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ unit: out
 unit: UNIT_PACKAGES=$(shell $(GOCMD) list ./... | grep -v acceptance)
 unit: format lint tidy install-yj
 	@echo "> Running unit tests..."
-	$(GOTEST) $(GOTESTFLAGS) -v -count=1 $(UNIT_PACKAGES)
+	$(GOTEST) $(GOTESTFLAGS) -v -count=1 $(UNIT_PACKAGES) | tee out/unit
 
 out:
 	@mkdir out || (exit 0)
@@ -294,7 +294,7 @@ out:
 
 acceptance: format tidy
 	@echo "> Running acceptance tests..."
-	$(GOTEST) -v -count=1 -tags=acceptance -timeout=$(ACCEPTANCE_TIMEOUT) ./acceptance/...
+	$(GOTEST) -v -count=1 -tags=acceptance -timeout=$(ACCEPTANCE_TIMEOUT) ./acceptance/... | tee out/acceptance
 
 clean:
 	@echo "> Cleaning workspace..."


### PR DESCRIPTION

- unit and acceptances tests are tee'd to a file in /out (which is already .gitignore-d)
- this makes it easier to grep for failures after the test run, if you're into that kind of thing
- rhymes with a previous change in pack: https://github.com/buildpacks/pack/pull/1585