### PR TITLE
Verify read access while selecting best `run-image` mirror

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -47,8 +47,8 @@ func TestAnalyzer(t *testing.T) {
 	analyzeDaemonFixtures = analyzeTest.targetDaemon.fixtures
 	analyzeRegFixtures = analyzeTest.targetRegistry.fixtures
 
-	for _, platformAPI := range []string{"0.12"} {
-		spec.Run(t, "acceptance-analyzer/"+platformAPI, testAnalyzerFunc(platformAPI), spec.Parallel(), spec.Report(report.Terminal{}))
+	for _, platformAPI := range api.Platform.Supported {
+		spec.Run(t, "acceptance-analyzer/"+platformAPI.String(), testAnalyzerFunc(platformAPI.String()), spec.Parallel(), spec.Report(report.Terminal{}))
 	}
 }
 

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -47,8 +47,8 @@ func TestAnalyzer(t *testing.T) {
 	analyzeDaemonFixtures = analyzeTest.targetDaemon.fixtures
 	analyzeRegFixtures = analyzeTest.targetRegistry.fixtures
 
-	for _, platformAPI := range api.Platform.Supported {
-		spec.Run(t, "acceptance-analyzer/"+platformAPI.String(), testAnalyzerFunc(platformAPI.String()), spec.Parallel(), spec.Report(report.Terminal{}))
+	for _, platformAPI := range []string{"0.12"} {
+		spec.Run(t, "acceptance-analyzer/"+platformAPI, testAnalyzerFunc(platformAPI), spec.Parallel(), spec.Report(report.Terminal{}))
 	}
 }
 
@@ -271,7 +271,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				output, err := cmd.CombinedOutput()
 
 				h.AssertNotNil(t, err)
-				expected := "ensure registry read access to some-run-image-from-run-toml"
+				expected := "failed to find accessible run image"
 				h.AssertStringContains(t, string(output), expected)
 			})
 		})

--- a/acceptance/creator_test.go
+++ b/acceptance/creator_test.go
@@ -74,7 +74,7 @@ func testCreatorFunc(platformAPI string) func(t *testing.T, when spec.G, it spec
 				output, err := cmd.CombinedOutput()
 
 				h.AssertNotNil(t, err)
-				expected := "ensure registry read access to some-run-image-from-run-toml"
+				expected := "failed to resolve inputs: failed to find accessible run image"
 				h.AssertStringContains(t, string(output), expected)
 			})
 		})

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -67,6 +67,7 @@ func (a *analyzeCmd) Args(nargs int, args []string) error {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "parse arguments")
 	}
 	a.LifecycleInputs.OutputImageRef = args[0]
+	a.LifecycleInputs.AccessChecker = &platform.RemoteImageStrategy{}
 	if err := platform.ResolveInputs(platform.Analyze, a.LifecycleInputs, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -67,7 +67,6 @@ func (a *analyzeCmd) Args(nargs int, args []string) error {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "parse arguments")
 	}
 	a.LifecycleInputs.OutputImageRef = args[0]
-	a.LifecycleInputs.AccessChecker = &platform.RemoteImageStrategy{}
 	if err := platform.ResolveInputs(platform.Analyze, a.LifecycleInputs, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -176,7 +176,7 @@ func (r *rebaseCmd) setAppImage() error {
 		}
 
 		// for older platforms, we find the best mirror for the run image as this point
-		r.RunImageRef, err = md.Stack.BestRunImageMirror(registry, &platform.RemoteImageStrategy{})
+		r.RunImageRef, err = md.Stack.BestRunImageMirror(registry, r.LifecycleInputs.AccessChecker)
 		if err != nil {
 			return err
 		}

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -176,7 +176,7 @@ func (r *rebaseCmd) setAppImage() error {
 		}
 
 		// for older platforms, we find the best mirror for the run image as this point
-		r.RunImageRef, err = md.Stack.BestRunImageMirror(registry)
+		r.RunImageRef, err = md.Stack.BestRunImageMirror(registry, &platform.RemoteImageStrategy{})
 		if err != nil {
 			return err
 		}

--- a/platform/files.go
+++ b/platform/files.go
@@ -433,6 +433,14 @@ func (a *RemoteImageStrategy) CheckReadAccess(repo string, keychain authn.Keycha
 	return img.CheckReadAccess(), nil
 }
 
+type LocalImageStrategy struct{}
+
+var _ ImageStrategy = &LocalImageStrategy{}
+
+func (a *LocalImageStrategy) CheckReadAccess(_ string, _ authn.Keychain) (bool, error) {
+	return true, nil
+}
+
 func (rm *RunImageForExport) BestRunImageMirror(registry string, accessChecker ImageStrategy) (string, error) {
 	if rm.Image == "" {
 		return "", errors.New("missing run-image metadata")

--- a/platform/files_test.go
+++ b/platform/files_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/platform"
+	"github.com/buildpacks/lifecycle/platform/testhelpers"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -119,7 +120,7 @@ func testFiles(t *testing.T, when spec.G, it spec.S) {
 
 			when("repoName is dockerhub", func() {
 				it("returns the dockerhub image", func() {
-					name, err := stackMD.BestRunImageMirror("index.docker.io")
+					name, err := stackMD.BestRunImageMirror("index.docker.io", &testhelpers.SimpleImageStrategy{})
 					h.AssertNil(t, err)
 					h.AssertEq(t, name, "myorg/myrepo")
 				})
@@ -127,14 +128,14 @@ func testFiles(t *testing.T, when spec.G, it spec.S) {
 
 			when("registry is gcr.io", func() {
 				it("returns the gcr.io image", func() {
-					name, err := stackMD.BestRunImageMirror("gcr.io")
+					name, err := stackMD.BestRunImageMirror("gcr.io", &testhelpers.SimpleImageStrategy{})
 					h.AssertNil(t, err)
 					h.AssertEq(t, name, "gcr.io/org/repo")
 				})
 
 				when("registry is zonal.gcr.io", func() {
 					it("returns the gcr image", func() {
-						name, err := stackMD.BestRunImageMirror("zonal.gcr.io")
+						name, err := stackMD.BestRunImageMirror("zonal.gcr.io", &testhelpers.SimpleImageStrategy{})
 						h.AssertNil(t, err)
 						h.AssertEq(t, name, "zonal.gcr.io/org/repo")
 					})
@@ -142,9 +143,15 @@ func testFiles(t *testing.T, when spec.G, it spec.S) {
 
 				when("registry is missingzone.gcr.io", func() {
 					it("returns the run image", func() {
-						name, err := stackMD.BestRunImageMirror("missingzone.gcr.io")
+						name, err := stackMD.BestRunImageMirror("missingzone.gcr.io", &testhelpers.SimpleImageStrategy{})
 						h.AssertNil(t, err)
 						h.AssertEq(t, name, "first.com/org/repo")
+					})
+
+					it("returns the first readable mirror", func() {
+						name, err := stackMD.BestRunImageMirror("missingzone.gcr.io", &testhelpers.StubImageStrategy{AllowedRepo: "zonal.gcr.io"})
+						h.AssertNil(t, err)
+						h.AssertEq(t, name, "zonal.gcr.io/org/repo")
 					})
 				})
 			})
@@ -155,7 +162,7 @@ func testFiles(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("skips over it", func() {
-					name, err := stackMD.BestRunImageMirror("gcr.io")
+					name, err := stackMD.BestRunImageMirror("gcr.io", &testhelpers.SimpleImageStrategy{})
 					h.AssertNil(t, err)
 					h.AssertEq(t, name, "gcr.io/myorg/myrepo")
 				})

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -16,6 +16,7 @@ import (
 // Fields are the cumulative total of inputs across all lifecycle phases and all supported Platform APIs.
 type LifecycleInputs struct {
 	PlatformAPI           *api.Version
+	AccessChecker         ImageStrategy
 	AnalyzedPath          string
 	AppDir                string
 	BuildConfigDir        string

--- a/platform/resolve_analyze_inputs_test.go
+++ b/platform/resolve_analyze_inputs_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildpacks/lifecycle/internal/str"
 	llog "github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
-	"github.com/buildpacks/lifecycle/platform/testhelpers"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -37,7 +36,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 			inputs.OutputImageRef = "some-output-image" // satisfy validation
 			logHandler = memory.New()
 			logger = &log.Logger{Handler: logHandler}
-			inputs.AccessChecker = &testhelpers.SimpleImageStrategy{}
+			inputs.UseDaemon = true // to prevent access checking of run images
 		})
 
 		when("latest Platform API(s)", func() {
@@ -126,6 +125,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 			it.Before(func() {
 				h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.7"), "")
 				inputs.RunImageRef = "some-run-image" // satisfy validation
+				inputs.UseDaemon = false
 			})
 
 			when("provided destination tags are on different registries", func() {

--- a/platform/resolve_analyze_inputs_test.go
+++ b/platform/resolve_analyze_inputs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildpacks/lifecycle/internal/str"
 	llog "github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
+	"github.com/buildpacks/lifecycle/platform/testhelpers"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -36,6 +37,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 			inputs.OutputImageRef = "some-output-image" // satisfy validation
 			logHandler = memory.New()
 			logger = &log.Logger{Handler: logHandler}
+			inputs.AccessChecker = &testhelpers.SimpleImageStrategy{}
 		})
 
 		when("latest Platform API(s)", func() {

--- a/platform/resolve_create_inputs_test.go
+++ b/platform/resolve_create_inputs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/buildpacks/lifecycle/internal/str"
 	llog "github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
+	"github.com/buildpacks/lifecycle/platform/testhelpers"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -37,6 +38,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 			inputs.RunImageRef = "some-run-image"       // satisfy validation
 			logHandler = memory.New()
 			logger = &log.Logger{Handler: logHandler}
+			inputs.AccessChecker = &testhelpers.SimpleImageStrategy{}
 		})
 
 		when("latest Platform API(s)", func() {

--- a/platform/resolve_create_inputs_test.go
+++ b/platform/resolve_create_inputs_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/buildpacks/lifecycle/internal/str"
 	llog "github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
-	"github.com/buildpacks/lifecycle/platform/testhelpers"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -38,7 +37,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 			inputs.RunImageRef = "some-run-image"       // satisfy validation
 			logHandler = memory.New()
 			logger = &log.Logger{Handler: logHandler}
-			inputs.AccessChecker = &testhelpers.SimpleImageStrategy{}
+			inputs.UseDaemon = true // to prevent read access check for run image
 		})
 
 		when("latest Platform API(s)", func() {
@@ -124,6 +123,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 		when("Platform API >= 0.7", func() {
 			it.Before(func() {
 				h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.7"), "")
+				inputs.UseDaemon = false
 			})
 
 			when("provided destination tags are on different registries", func() {

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -20,6 +20,12 @@ var (
 )
 
 func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) error {
+	if i.UseDaemon || i.UseLayout {
+		i.AccessChecker = &LocalImageStrategy{}
+	} else {
+		i.AccessChecker = &RemoteImageStrategy{}
+	}
+
 	// order of operations is important
 	ops := []LifecycleInputsOperation{UpdatePlaceholderPaths, ResolveAbsoluteDirPaths}
 	switch phase {

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -185,10 +185,7 @@ func fillRunImageFromRunTOMLIfNeeded(i *LifecycleInputs, logger log.Logger) erro
 		return errors.New(ErrRunImageRequiredWhenNoRunMD)
 	}
 	i.RunImageRef, err = runMD.Images[0].BestRunImageMirror(targetRegistry, i.AccessChecker)
-	if err != nil {
-		return errors.New(ErrRunImageRequiredWhenNoRunMD)
-	}
-	return nil
+	return err
 }
 
 // fillRunImageFromStackTOMLIfNeeded updates the provided lifecycle inputs to include the run image from stack.toml if the run image input it is missing.

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -178,7 +178,7 @@ func fillRunImageFromRunTOMLIfNeeded(i *LifecycleInputs, logger log.Logger) erro
 	if len(runMD.Images) == 0 {
 		return errors.New(ErrRunImageRequiredWhenNoRunMD)
 	}
-	i.RunImageRef, err = runMD.Images[0].BestRunImageMirror(targetRegistry)
+	i.RunImageRef, err = runMD.Images[0].BestRunImageMirror(targetRegistry, i.AccessChecker)
 	if err != nil {
 		return errors.New(ErrRunImageRequiredWhenNoRunMD)
 	}
@@ -199,7 +199,7 @@ func fillRunImageFromStackTOMLIfNeeded(i *LifecycleInputs, logger log.Logger) er
 	if err != nil {
 		return err
 	}
-	i.RunImageRef, err = stackMD.BestRunImageMirror(targetRegistry)
+	i.RunImageRef, err = stackMD.BestRunImageMirror(targetRegistry, i.AccessChecker)
 	if err != nil {
 		return errors.New(ErrRunImageRequiredWhenNoStackMD)
 	}

--- a/platform/testhelpers/image_strategy.go
+++ b/platform/testhelpers/image_strategy.go
@@ -1,0 +1,44 @@
+package testhelpers
+
+import (
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+
+	"github.com/buildpacks/lifecycle/platform"
+)
+
+type TestResource struct {
+	Repo string
+}
+
+var _ authn.Resource = &TestResource{}
+
+func (t *TestResource) String() string {
+	return t.Repo
+}
+
+func (t *TestResource) RegistryStr() string {
+	return t.Repo
+}
+
+type SimpleImageStrategy struct{}
+
+var _ platform.ImageStrategy = &SimpleImageStrategy{}
+
+func (t *SimpleImageStrategy) CheckReadAccess(repo string, keychain authn.Keychain) (bool, error) {
+	resource := &TestResource{Repo: repo}
+	_, err := keychain.Resolve(resource)
+
+	return (err == nil), err
+}
+
+type StubImageStrategy struct {
+	AllowedRepo string
+}
+
+var _ platform.ImageStrategy = &StubImageStrategy{}
+
+func (s *StubImageStrategy) CheckReadAccess(repo string, keychain authn.Keychain) (bool, error) {
+	return strings.Contains(repo, s.AllowedRepo), nil
+}

--- a/platform/testhelpers/image_strategy.go
+++ b/platform/testhelpers/image_strategy.go
@@ -39,6 +39,6 @@ type StubImageStrategy struct {
 
 var _ platform.ImageStrategy = &StubImageStrategy{}
 
-func (s *StubImageStrategy) CheckReadAccess(repo string, keychain authn.Keychain) (bool, error) {
+func (s *StubImageStrategy) CheckReadAccess(repo string, _ authn.Keychain) (bool, error) {
 	return strings.Contains(repo, s.AllowedRepo), nil
 }


### PR DESCRIPTION
Instead of simply picking the first run-image, the lifecycle will select the first **accessible** reference, if there's no match by registry.

See https://github.com/buildpacks/spec/pull/357