### PR TITLE
WIP: make image handler an access checker

### DIFF
--- a/cmd/lifecycle/builder.go
+++ b/cmd/lifecycle/builder.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/lifecycle/cmd/lifecycle/cli"
+	"github.com/buildpacks/lifecycle/image"
 	"github.com/buildpacks/lifecycle/internal/encoding"
 	"github.com/buildpacks/lifecycle/launch"
 	"github.com/buildpacks/lifecycle/platform"
@@ -45,7 +46,7 @@ func (b *buildCmd) Args(nargs int, _ []string) error {
 	if nargs != 0 {
 		return cmd.FailErrCode(errors.New("received unexpected arguments"), cmd.CodeForInvalidArgs, "parse arguments")
 	}
-	if err := platform.ResolveInputs(platform.Build, b.LifecycleInputs, cmd.DefaultLogger); err != nil {
+	if err := platform.ResolveInputs(platform.Build, b.LifecycleInputs, &image.NopHandler{}, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}
 	return nil

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/lifecycle/cmd/lifecycle/cli"
+	"github.com/buildpacks/lifecycle/image"
 	"github.com/buildpacks/lifecycle/internal/encoding"
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/buildpacks/lifecycle/priv"
@@ -43,7 +44,7 @@ func (d *detectCmd) Args(nargs int, _ []string) error {
 	if nargs != 0 {
 		return cmd.FailErrCode(errors.New("received unexpected arguments"), cmd.CodeForInvalidArgs, "parse arguments")
 	}
-	if err := platform.ResolveInputs(platform.Detect, d.LifecycleInputs, cmd.DefaultLogger); err != nil {
+	if err := platform.ResolveInputs(platform.Detect, d.LifecycleInputs, &image.NopHandler{}, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}
 	return nil

--- a/cmd/lifecycle/extender.go
+++ b/cmd/lifecycle/extender.go
@@ -7,6 +7,7 @@ import (
 	"github.com/buildpacks/lifecycle"
 	"github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/lifecycle/cmd/lifecycle/cli"
+	"github.com/buildpacks/lifecycle/image"
 	"github.com/buildpacks/lifecycle/internal/extend/kaniko"
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/buildpacks/lifecycle/priv"
@@ -36,7 +37,7 @@ func (e *extendCmd) Args(nargs int, _ []string) error {
 	if nargs != 0 {
 		return cmd.FailErrCode(errors.New("received unexpected arguments"), cmd.CodeForInvalidArgs, "parse arguments")
 	}
-	if err := platform.ResolveInputs(platform.Extend, e.LifecycleInputs, cmd.DefaultLogger); err != nil {
+	if err := platform.ResolveInputs(platform.Extend, e.LifecycleInputs, &image.NopHandler{}, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}
 	return nil

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -51,7 +51,7 @@ func (r *rebaseCmd) Args(nargs int, args []string) error {
 	}
 	r.OutputImageRef = args[0]
 	r.AdditionalTags = args[1:]
-	if err := platform.ResolveInputs(platform.Rebase, r.LifecycleInputs, cmd.DefaultLogger); err != nil {
+	if err := platform.ResolveInputs(platform.Rebase, r.LifecycleInputs, &image.NopHandler{}, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}
 	if err := r.setAppImage(); err != nil {

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/lifecycle/cmd/lifecycle/cli"
+	"github.com/buildpacks/lifecycle/image"
 	"github.com/buildpacks/lifecycle/internal/encoding"
 	"github.com/buildpacks/lifecycle/internal/layer"
 	"github.com/buildpacks/lifecycle/internal/selective"
@@ -68,7 +69,7 @@ func (r *restoreCmd) Args(nargs int, _ []string) error {
 	if nargs > 0 {
 		return cmd.FailErrCode(errors.New("received unexpected Args"), cmd.CodeForInvalidArgs, "parse arguments")
 	}
-	if err := platform.ResolveInputs(platform.Restore, r.LifecycleInputs, cmd.DefaultLogger); err != nil {
+	if err := platform.ResolveInputs(platform.Restore, r.LifecycleInputs, &image.NopHandler{}, cmd.DefaultLogger); err != nil {
 		return cmd.FailErrCode(err, cmd.CodeForInvalidArgs, "resolve inputs")
 	}
 	return nil

--- a/image/layout_handler.go
+++ b/image/layout_handler.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"errors"
 	"path/filepath"
 
 	"github.com/buildpacks/imgutil"
@@ -13,10 +14,16 @@ type LayoutHandler struct {
 	layoutDir string
 }
 
-func NewLayoutImageHandler(layoutDir string) *LayoutHandler {
-	return &LayoutHandler{
-		layoutDir: layoutDir,
+func NewLayoutHandler(opts HandlerOptions) (*LayoutHandler, error) {
+	if opts.LayoutDir == "" {
+		return nil, errors.New("layout directory must be provided when exporting to OCI layout format")
 	}
+	return &LayoutHandler{layoutDir: opts.LayoutDir}, nil
+}
+
+func (h *LayoutHandler) CheckReadAccess(imageRef string) (bool, error) {
+	// TODO: verify that we can find the image on disk
+	return true, nil
 }
 
 func (h *LayoutHandler) InitImage(imageRef string) (imgutil.Image, error) {

--- a/image/layout_handler_test.go
+++ b/image/layout_handler_test.go
@@ -36,7 +36,7 @@ func testLayoutImageHandler(t *testing.T, when spec.G, it spec.S) {
 	when("layout handler", func() {
 		it.Before(func() {
 			layoutDir = "layout-repo"
-			imageHandler = image.NewHandler(nil, nil, layoutDir, true)
+			imageHandler, _ = image.NewHandler(image.HandlerOptions{UseLayout: true, LayoutDir: layoutDir})
 			h.AssertNotNil(t, imageHandler)
 		})
 

--- a/image/local_handler.go
+++ b/image/local_handler.go
@@ -1,6 +1,8 @@
 package image
 
 import (
+	"errors"
+
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/local"
 	"github.com/docker/docker/client"
@@ -10,6 +12,19 @@ const LocalKind = "docker"
 
 type LocalHandler struct {
 	docker client.CommonAPIClient
+}
+
+func NewLocalHandler(opts HandlerOptions) (*LocalHandler, error) {
+	if opts.DockerClient == nil {
+		// we only ever have one docker client, so it must be provided when instantiating the handler
+		return nil, errors.New("docker client must be provided when exporting to daemon")
+	}
+	return &LocalHandler{docker: opts.DockerClient}, nil
+}
+
+func (h *LocalHandler) CheckReadAccess(imageRef string) (bool, error) {
+	// TODO: verify that we can find the image in the daemon
+	return true, nil
 }
 
 func (h *LocalHandler) InitImage(imageRef string) (imgutil.Image, error) {

--- a/image/local_handler_test.go
+++ b/image/local_handler_test.go
@@ -24,7 +24,7 @@ func testLocalImageHandler(t *testing.T, when spec.G, it spec.S) {
 	when("Local handler", func() {
 		it.Before(func() {
 			dockerClient = h.DockerCli(t)
-			imageHandler = image.NewHandler(dockerClient, nil, "", false)
+			imageHandler, _ = image.NewHandler(image.HandlerOptions{UseDaemon: true, DockerClient: dockerClient})
 			h.AssertNotNil(t, imageHandler)
 		})
 

--- a/image/remote_handler.go
+++ b/image/remote_handler.go
@@ -1,6 +1,9 @@
 package image
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/remote"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -12,11 +15,25 @@ type RemoteHandler struct {
 	keychain authn.Keychain
 }
 
+func NewRemoteHandler(opts HandlerOptions) (*RemoteHandler, error) {
+	if opts.RegistryKeychain == nil {
+		return nil, errors.New("keychain must be provided when exporting to registry")
+	}
+	return &RemoteHandler{keychain: opts.RegistryKeychain}, nil
+}
+
+func (h *RemoteHandler) CheckReadAccess(imageRef string) (bool, error) {
+	img, err := remote.NewImage(imageRef, h.keychain)
+	if err != nil {
+		return false, fmt.Errorf("failed to get remote image: %w", err)
+	}
+	return img.CheckReadAccess(), nil
+}
+
 func (h *RemoteHandler) InitImage(imageRef string) (imgutil.Image, error) {
 	if imageRef == "" {
 		return nil, nil
 	}
-
 	return remote.NewImage(
 		imageRef,
 		h.keychain,

--- a/image/remote_handler_test.go
+++ b/image/remote_handler_test.go
@@ -24,7 +24,7 @@ func testRemoteImageHandler(t *testing.T, when spec.G, it spec.S) {
 	when("Remote handler", func() {
 		it.Before(func() {
 			auth = authn.DefaultKeychain
-			imageHandler = image.NewHandler(nil, auth, "", false)
+			imageHandler, _ = image.NewHandler(image.HandlerOptions{RegistryKeychain: auth})
 			h.AssertNotNil(t, imageHandler)
 		})
 

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -236,7 +236,7 @@ func timeEnvOrDefault(key string, defaultVal time.Duration) time.Duration {
 
 // operations
 
-func UpdatePlaceholderPaths(i *LifecycleInputs, _ log.Logger) error {
+func UpdatePlaceholderPaths(i *LifecycleInputs, _ AccessChecker, _ log.Logger) error {
 	toUpdate := i.placeholderPaths()
 	for _, path := range toUpdate {
 		if *path == "" {
@@ -281,7 +281,7 @@ func (i *LifecycleInputs) placeholderPaths() []*string {
 	}
 }
 
-func ResolveAbsoluteDirPaths(i *LifecycleInputs, _ log.Logger) error {
+func ResolveAbsoluteDirPaths(i *LifecycleInputs, _ AccessChecker, _ log.Logger) error {
 	toUpdate := i.directoryPaths()
 	for _, dir := range toUpdate {
 		if *dir == "" {

--- a/platform/lifecycle_inputs_test.go
+++ b/platform/lifecycle_inputs_test.go
@@ -224,7 +224,7 @@ func testLifecycleInputs(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("updates all placeholder paths", func() {
-			h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil))
+			h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil, nil))
 			v := reflect.ValueOf(inputs).Elem()
 			for i := 0; i < v.NumField(); i++ {
 				field := v.Field(i)
@@ -241,7 +241,7 @@ func testLifecycleInputs(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("does nothing", func() {
-				h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil))
+				h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil, nil))
 				h.AssertEq(t, inputs.AnalyzedPath, "")
 			})
 		})
@@ -250,7 +250,7 @@ func testLifecycleInputs(t *testing.T, when spec.G, it spec.S) {
 			when("custom", func() {
 				it("doesn't override it", func() {
 					inputs.OrderPath = "some-order-path"
-					h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil))
+					h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil, nil))
 					h.AssertEq(t, inputs.OrderPath, inputs.OrderPath)
 				})
 			})
@@ -271,14 +271,14 @@ func testLifecycleInputs(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				it("expects order.toml in the layers directory", func() {
-					h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil))
+					h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil, nil))
 					h.AssertEq(t, inputs.OrderPath, filepath.Join(tmpDir, "order.toml"))
 				})
 			})
 
 			when("not exists in layers directory", func() {
 				it("expects order.toml in the /cnb directory", func() {
-					h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil))
+					h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil, nil))
 					h.AssertEq(t, inputs.OrderPath, platform.CNBOrderPath)
 				})
 			})
@@ -290,7 +290,7 @@ func testLifecycleInputs(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("expects and writes files in the working directory", func() {
-				h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil))
+				h.AssertNil(t, platform.UpdatePlaceholderPaths(inputs, nil, nil))
 				h.AssertEq(t, inputs.AnalyzedPath, "analyzed.toml")
 			})
 		})

--- a/platform/resolve_analyze_inputs_test.go
+++ b/platform/resolve_analyze_inputs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/image"
 	"github.com/buildpacks/lifecycle/internal/path"
 	"github.com/buildpacks/lifecycle/internal/str"
 	llog "github.com/buildpacks/lifecycle/log"
@@ -52,7 +53,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 
 					it("falls back to run.toml", func() {
 						inputs.RunPath = filepath.Join("testdata", "cnb", "run.toml")
-						err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+						err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 						h.AssertNil(t, err)
 						h.AssertEq(t, inputs.RunImageRef, "some-run-image")
 					})
@@ -60,7 +61,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 					when("run.toml", func() {
 						when("not provided", func() {
 							it("defaults to /cnb/run.toml", func() {
-								_ = platform.ResolveInputs(platform.Analyze, inputs, logger)
+								_ = platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 								h.AssertEq(t, inputs.RunPath, filepath.Join(path.RootDir, "cnb", "run.toml"))
 							})
 						})
@@ -69,7 +70,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 							it("errors", func() {
 								inputs.RunImageRef = ""
 								inputs.RunPath = "not-exist-run.toml"
-								err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+								err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 								h.AssertNotNil(t, err)
 								expected := "-run-image is required when there is no run metadata available"
 								h.AssertStringContains(t, err.Error(), expected)
@@ -92,7 +93,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 					it("falls back to stack.toml", func() {
 						inputs.RunImageRef = ""
 						inputs.StackPath = filepath.Join("testdata", "layers", "stack.toml")
-						err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+						err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 						h.AssertNil(t, err)
 						h.AssertEq(t, inputs.RunImageRef, "some-run-image")
 					})
@@ -100,7 +101,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 					when("stack.toml", func() {
 						when("not provided", func() {
 							it("defaults to /cnb/stack.toml", func() {
-								_ = platform.ResolveInputs(platform.Analyze, inputs, logger)
+								_ = platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 								h.AssertEq(t, inputs.StackPath, filepath.Join(path.RootDir, "cnb", "stack.toml"))
 							})
 						})
@@ -109,7 +110,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 							it("errors", func() {
 								inputs.RunImageRef = ""
 								inputs.StackPath = "not-exist-stack.toml"
-								err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+								err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 								h.AssertNotNil(t, err)
 								expected := "-run-image is required when there is no stack metadata available"
 								h.AssertStringContains(t, err.Error(), expected)
@@ -133,7 +134,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 						"some-other-registry.io/some-namespace/some-image",
 					}
 					inputs.OutputImageRef = "some-registry.io/some-namespace/some-image"
-					err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+					err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 					h.AssertNotNil(t, err)
 					expected := "writing to multiple registries is unsupported"
 					h.AssertStringContains(t, err.Error(), expected)
@@ -150,7 +151,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 				it("warns", func() {
 					inputs.CacheImageRef = ""
 					inputs.CacheDir = ""
-					err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+					err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 					h.AssertNil(t, err)
 					expected := "No cached data will be used, no cache specified."
 					h.AssertLogEntry(t, logHandler, expected)
@@ -161,7 +162,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 				when("not provided", func() {
 					it("does not warn", func() {
 						inputs.StackPath = "not-exist-stack.toml"
-						err := platform.ResolveInputs(platform.Analyze, inputs, logger)
+						err := platform.ResolveInputs(platform.Analyze, inputs, &image.NopHandler{}, logger)
 						h.AssertNil(t, err)
 						h.AssertNoLogEntry(t, logHandler, `no stack metadata found at path ''`)
 						h.AssertNoLogEntry(t, logHandler, `Previous image with name "" not found`)

--- a/platform/resolve_create_inputs_test.go
+++ b/platform/resolve_create_inputs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/image"
 	"github.com/buildpacks/lifecycle/internal/path"
 	"github.com/buildpacks/lifecycle/internal/str"
 	llog "github.com/buildpacks/lifecycle/log"
@@ -52,7 +53,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 
 					it("falls back to run.toml", func() {
 						inputs.RunPath = filepath.Join("testdata", "cnb", "run.toml")
-						err := platform.ResolveInputs(platform.Create, inputs, logger)
+						err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 						h.AssertNil(t, err)
 						h.AssertEq(t, inputs.RunImageRef, "some-run-image")
 					})
@@ -60,7 +61,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 					when("run.toml", func() {
 						when("not provided", func() {
 							it("defaults to /cnb/run.toml", func() {
-								_ = platform.ResolveInputs(platform.Create, inputs, logger)
+								_ = platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 								h.AssertEq(t, inputs.RunPath, filepath.Join(path.RootDir, "cnb", "run.toml"))
 							})
 						})
@@ -69,7 +70,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 							it("errors", func() {
 								inputs.RunImageRef = ""
 								inputs.RunPath = "not-exist-run.toml"
-								err := platform.ResolveInputs(platform.Create, inputs, logger)
+								err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 								h.AssertNotNil(t, err)
 								expected := "-run-image is required when there is no run metadata available"
 								h.AssertStringContains(t, err.Error(), expected)
@@ -91,7 +92,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 					it("falls back to stack.toml", func() {
 						inputs.RunImageRef = ""
 						inputs.StackPath = filepath.Join("testdata", "layers", "stack.toml")
-						err := platform.ResolveInputs(platform.Create, inputs, logger)
+						err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 						h.AssertNil(t, err)
 						h.AssertEq(t, inputs.RunImageRef, "some-run-image")
 					})
@@ -99,7 +100,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 					when("stack.toml", func() {
 						when("not provided", func() {
 							it("defaults to /cnb/stack.toml", func() {
-								_ = platform.ResolveInputs(platform.Create, inputs, logger)
+								_ = platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 								h.AssertEq(t, inputs.StackPath, filepath.Join(path.RootDir, "cnb", "stack.toml"))
 							})
 						})
@@ -108,7 +109,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 							it("errors", func() {
 								inputs.RunImageRef = ""
 								inputs.StackPath = "not-exist-stack.toml"
-								err := platform.ResolveInputs(platform.Create, inputs, logger)
+								err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 								h.AssertNotNil(t, err)
 								expected := "-run-image is required when there is no stack metadata available"
 								h.AssertStringContains(t, err.Error(), expected)
@@ -131,7 +132,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 						"some-other-registry.io/some-namespace/some-image",
 					}
 					inputs.OutputImageRef = "some-registry.io/some-namespace/some-image"
-					err := platform.ResolveInputs(platform.Create, inputs, logger)
+					err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 					h.AssertNotNil(t, err)
 					expected := "writing to multiple registries is unsupported"
 					h.AssertStringContains(t, err.Error(), expected)
@@ -148,7 +149,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 				it("warns", func() {
 					inputs.CacheImageRef = ""
 					inputs.CacheDir = ""
-					err := platform.ResolveInputs(platform.Create, inputs, logger)
+					err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 					h.AssertNil(t, err)
 					expected := "No cached data will be used, no cache specified."
 					h.AssertLogEntry(t, logHandler, expected)
@@ -159,7 +160,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 				when("not provided", func() {
 					it("does not warn", func() {
 						inputs.StackPath = "not-exist-stack.toml"
-						err := platform.ResolveInputs(platform.Create, inputs, logger)
+						err := platform.ResolveInputs(platform.Create, inputs, &image.NopHandler{}, logger)
 						h.AssertNil(t, err)
 						h.AssertNoLogEntry(t, logHandler, `no stack metadata found at path ''`)
 						h.AssertNoLogEntry(t, logHandler, `Previous image with name "" not found`)

--- a/testmock/image_handler.go
+++ b/testmock/image_handler.go
@@ -34,6 +34,21 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
+// CheckReadAccess mocks base method.
+func (m *MockHandler) CheckReadAccess(arg0 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckReadAccess", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckReadAccess indicates an expected call of CheckReadAccess.
+func (mr *MockHandlerMockRecorder) CheckReadAccess(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckReadAccess", reflect.TypeOf((*MockHandler)(nil).CheckReadAccess), arg0)
+}
+
 // InitImage mocks base method.
 func (m *MockHandler) InitImage(arg0 string) (imgutil.Image, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
To facilitate conversation around https://github.com/buildpacks/lifecycle/pull/1024

If we want to check access to images in a daemon, we need to have the client instantiated already (it is a singleton) so resolving the inputs must be done after dropping privileges.