### PR TITLE
Ignore pax global header in tar extract

### DIFF
--- a/archive/extract.go
+++ b/archive/extract.go
@@ -92,6 +92,9 @@ func Extract(tr TarReader) error {
 			if err := createSymlink(hdr); err != nil {
 				return errors.Wrapf(err, "failed to create symlink %q with target %q", hdr.Name, hdr.Linkname)
 			}
+		case tar.TypeXGlobalHeader:
+			// ignore PAX Global Extended Headers
+			return nil
 		default:
 			return fmt.Errorf("unknown file type in tar %d", hdr.Typeflag)
 		}

--- a/archive/extract.go
+++ b/archive/extract.go
@@ -94,7 +94,7 @@ func Extract(tr TarReader) error {
 			}
 		case tar.TypeXGlobalHeader:
 			// ignore PAX Global Extended Headers
-			return nil
+			continue
 		default:
 			return fmt.Errorf("unknown file type in tar %d", hdr.Typeflag)
 		}

--- a/archive/extract_test.go
+++ b/archive/extract_test.go
@@ -135,6 +135,11 @@ func newFakeTarReader(t *testing.T) (*archive.NormalizingTarReader, string) {
 
 func pushHeaders(ftr *fakeTarReader) {
 	ftr.pushHeader(&tar.Header{
+		Name:     "pax_global_header",
+		Typeflag: tar.TypeXGlobalHeader,
+		Mode:     int64(0),
+	})
+	ftr.pushHeader(&tar.Header{
 		Name:     "root/symlinkdir",
 		Typeflag: tar.TypeSymlink,
 		Linkname: filepath.Join("..", "not-in-archive-dir"),


### PR DESCRIPTION
The pax global header headers is currently not handled, but it should not cause a failure with the side effect of not uncompressing an otherwise valid tarball.