### PR TITLE
Replace deprecated GHA ::set-output syntax

### DIFF
--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -31,11 +31,11 @@ jobs:
           tar xzf lifecycle.tgz
           LATEST_RELEASE_GO_VERSION=$(go version ./lifecycle/lifecycle | cut -d ' ' -f 2)
           
-          echo "::set-output name=latest-go-version::${LATEST_GO_VERSION}"
-          echo "::set-output name=latest-release-go-version::${LATEST_RELEASE_GO_VERSION}"
+          echo "latest-go-version=${LATEST_GO_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "latest-release-go-version=${LATEST_RELEASE_GO_VERSION}" >> "$GITHUB_OUTPUT"
           
           LATEST_RELEASE_VERSION=$(echo $LATEST_RELEASE_VERSION | cut -d \v -f 2)
-          echo "::set-output name=latest-release-version::${LATEST_RELEASE_VERSION}"
+          echo "latest-release-version=${LATEST_RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Create issue if needed
         if: ${{ steps.read-go.outputs.latest-go-version != steps.read-go.outputs.latest-release-go-version }}
         env:


### PR DESCRIPTION
Use the new way of producing outputs in a github action as the old way is deprecated and will be removed (31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/