### PR TITLE
Fix buildpacksio/lifecycle manifest create

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,8 +212,6 @@ jobs:
           WINDOWS_AMD64_SHA=$(go run ./tools/image/main.go -lifecyclePath ./out/lifecycle-v*+windows.x86-64.tgz -tag buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-windows -os windows | awk '{print $NF}')
           echo "WINDOWS_AMD64_SHA: $WINDOWS_AMD64_SHA"
 
-          sleep 5
-
           docker manifest create buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG} \
               buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux-x86-64@${LINUX_AMD64_SHA} \
               buildpacksio/lifecycle:${LIFECYCLE_IMAGE_TAG}-linux-arm64@${LINUX_ARM64_SHA} \

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/buildpacks/lifecycle
 
-// FIXME: update imgutil to `main` branch if https://github.com/buildpacks/imgutil/pull/187 is merged
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/GoogleContainerTools/kaniko v1.9.2-0.20220928141902-4d077e2a4084
 	github.com/apex/log v1.9.0
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230110223219-40efa3093a22
-	github.com/buildpacks/imgutil v0.0.0-20230323151547-eaefdf2f68c4
+	github.com/buildpacks/imgutil v0.0.0-20230324153732-a6c0ed910692
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20221129204813-6a4d6ed5d396
 	github.com/containerd/containerd v1.6.15
 	github.com/docker/docker v20.10.23+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/buildpacks/lifecycle
 
+// FIXME: update imgutil to `main` branch if https://github.com/buildpacks/imgutil/pull/187 is merged
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/GoogleContainerTools/kaniko v1.9.2-0.20220928141902-4d077e2a4084
 	github.com/apex/log v1.9.0
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230110223219-40efa3093a22
-	github.com/buildpacks/imgutil v0.0.0-20230120191822-4d50b9a7e215
+	github.com/buildpacks/imgutil v0.0.0-20230323151547-eaefdf2f68c4
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20221129204813-6a4d6ed5d396
 	github.com/containerd/containerd v1.6.15
 	github.com/docker/docker v20.10.23+incompatible

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildpacks/imgutil v0.0.0-20230120191822-4d50b9a7e215 h1:V/fmMFCX0jA73zqnKxmHnYq2dsWefpdTkytsorowbG0=
-github.com/buildpacks/imgutil v0.0.0-20230120191822-4d50b9a7e215/go.mod h1:zL5lZzgFuv9l36n52FjomVrUHpyuZf6r1UHKaZ4LeSQ=
+github.com/buildpacks/imgutil v0.0.0-20230323151547-eaefdf2f68c4 h1:aswlLMQs3aOQj8nEPHusTR5BLKZUTjS1LA3gFIWeV3M=
+github.com/buildpacks/imgutil v0.0.0-20230323151547-eaefdf2f68c4/go.mod h1:zL5lZzgFuv9l36n52FjomVrUHpyuZf6r1UHKaZ4LeSQ=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
-github.com/buildpacks/imgutil v0.0.0-20230323151547-eaefdf2f68c4 h1:aswlLMQs3aOQj8nEPHusTR5BLKZUTjS1LA3gFIWeV3M=
-github.com/buildpacks/imgutil v0.0.0-20230323151547-eaefdf2f68c4/go.mod h1:zL5lZzgFuv9l36n52FjomVrUHpyuZf6r1UHKaZ4LeSQ=
+github.com/buildpacks/imgutil v0.0.0-20230324153732-a6c0ed910692 h1:QaSg0ifVdMjapbMAuyGjzHTP1d7Jf3xOop3qDnzhhRg=
+github.com/buildpacks/imgutil v0.0.0-20230324153732-a6c0ed910692/go.mod h1:zL5lZzgFuv9l36n52FjomVrUHpyuZf6r1UHKaZ4LeSQ=
 github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGrrHhcQw=
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=

--- a/tools/image/main.go
+++ b/tools/image/main.go
@@ -100,10 +100,15 @@ func main() {
 		}
 	} else {
 		var err error
-		img, err = remote.NewImage(tags[0], authn.DefaultKeychain, remote.FromBaseImage(baseImage), remote.WithDefaultPlatform(imgutil.Platform{
-			Architecture: targetArch,
-			OS:           targetOS,
-		}))
+		img, err = remote.NewImage(
+			tags[0], authn.DefaultKeychain,
+			remote.FromBaseImage(baseImage),
+			remote.WithDefaultPlatform(imgutil.Platform{
+				Architecture: targetArch,
+				OS:           targetOS,
+			}),
+			remote.WithMediaTypes(imgutil.DockerTypes),
+		)
 		if err != nil {
 			log.Fatal("Failed to create remote image:", err)
 		}


### PR DESCRIPTION
Further context in Slack: https://cloud-native.slack.com/archives/C0331B5QS02/p1679426001027039

Now that `gcr.io/distroless/static` has OCI media types, our lifecycle image, which is built from that image, has OCI media types. This causes `docker manifest create` on older versions of `docker` to fail with `manifest unknown: OCI manifest found, but accept header does not support OCI manifests `. 

We could create our own tooling to make the manifest list with OCI media types, avoiding the need to use `docker`, but `docker manifest inspect` may fail if the resulting index has OCI media types. This will be [fixed](https://github.com/moby/moby/issues/43126) in newer versions of docker but may cause problems for users who haven't yet upgraded.

Given that it's a fairly annoying failure with no easy workaround it seems prudent to ship a lifecycle image with Docker media types in the next patch release and switch over to OCI media types on at least a minor version upgrade. This PR circumvents the problem by forcing individual lifecycle images to have Docker media types, so that `docker manifest create` reliably succeeds. 