### PR TITLE
Enable pre-releases in addition to release candidates

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -104,11 +104,11 @@ jobs:
           cat *.sha256 | sort > lifecycle-v${{ env.LIFECYCLE_VERSION }}-checksums.txt
           rm *.sha256
       - name: Set pre-release kind
-        if: contains(env.LIFECYCLE_VERSION, 'rc') # e.g., 0.99.0-rc.1
+        if: "contains(env.LIFECYCLE_VERSION, 'rc') || contains(env.LIFECYCLE_VERSION, 'pre')" # e.g., 0.99.0-rc.1
         run: |
           echo "RELEASE_KIND=pre-release" >> $GITHUB_ENV
       - name: Set release kind
-        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc') && !contains(env.LIFECYCLE_VERSION, 'pre')"
         run: |
           echo "RELEASE_KIND=release" >> $GITHUB_ENV
       - name: Set release body text
@@ -131,7 +131,7 @@ jobs:
           An OCI image containing the lifecycle binaries is available at buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}.
           EOF
       - name: Create Pre Release
-        if: contains(env.LIFECYCLE_VERSION, 'rc') # e.g., 0.99.0-rc.1
+        if: "contains(env.LIFECYCLE_VERSION, 'rc') || contains(env.LIFECYCLE_VERSION, 'pre')" # e.g., 0.99.0-rc.1
         run: |
           cd ${{ env.ARTIFACTS_PATH }}
           gh release create v${{ env.LIFECYCLE_VERSION }} \
@@ -144,7 +144,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release
-        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc') && !contains(env.LIFECYCLE_VERSION, 'pre')"
         run: |
           cd ${{ env.ARTIFACTS_PATH }}
           gh release create v${{ env.LIFECYCLE_VERSION }} \

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -76,7 +76,7 @@ jobs:
             buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}@${MANIFEST_SHA}
           cosign verify -key cosign.pub -a tag=${{ env.LIFECYCLE_VERSION }} -attachment sbom buildpacksio/lifecycle:${{ env.LIFECYCLE_VERSION }}@${MANIFEST_SHA}
       - name: Retag lifecycle images & create manifest list - latest
-        if: "!contains(env.LIFECYCLE_VERSION, 'rc')"
+        if: "!contains(env.LIFECYCLE_VERSION, 'rc') && !contains(env.LIFECYCLE_VERSION, 'pre')"
         run: |
           DOCKER_CLI_EXPERIMENTAL=enabled
 


### PR DESCRIPTION
While "release candidate" is still a pre-release, it conveys more readiness than a "pre-release" or "preview release".
We'd like to ship pre-release lifecycle artifacts
so that users can test out new features without them being fully implemented as they would in a release candidate.