### PR TITLE
os and arch: buildpack targets should have stars

### DIFF
--- a/platform/files.go
+++ b/platform/files.go
@@ -80,7 +80,7 @@ type OSDistribution struct {
 
 // IsSatisfiedBy treats optional fields (ArchVariant and Distributions) as wildcards if empty, returns true if
 func (t *TargetMetadata) IsSatisfiedBy(o *buildpack.TargetMetadata) bool {
-	if (t.Arch != "*" && t.Arch != o.Arch) || (t.OS != "*" && t.OS != o.OS) {
+	if (o.Arch != "*" && t.Arch != o.Arch) || (o.OS != "*" && t.OS != o.OS) {
 		return false
 	}
 	if t.ArchVariant != "" && o.ArchVariant != "" && t.ArchVariant != o.ArchVariant {

--- a/platform/files_test.go
+++ b/platform/files_test.go
@@ -271,14 +271,14 @@ func testFiles(t *testing.T, when spec.G, it spec.S) {
 				}
 			})
 			it("is cool with starry arches", func() {
-				d := platform.TargetMetadata{OS: "windows", Arch: "*"}
-				if !d.IsSatisfiedBy(&buildpack.TargetMetadata{OS: d.OS, Arch: "intel whatevsky"}) {
+				d := platform.TargetMetadata{OS: "windows", Arch: "amd64"}
+				if !d.IsSatisfiedBy(&buildpack.TargetMetadata{OS: d.OS, Arch: "*"}) {
 					t.Fatal("Arch wildcard should have been satisfied with whatever we gave it")
 				}
 			})
 			it("is down with OS stars", func() {
-				d := platform.TargetMetadata{OS: "*", Arch: "amd64"} // i mean this would be kinda weird, right? but there'll be a use-case...
-				if !d.IsSatisfiedBy(&buildpack.TargetMetadata{OS: "plan 9", Arch: d.Arch}) {
+				d := platform.TargetMetadata{OS: "plan 9", Arch: "amd64"}
+				if !d.IsSatisfiedBy(&buildpack.TargetMetadata{OS: "*", Arch: d.Arch}) {
 					t.Fatal("OS wildcard should have been satisfied by plan 9")
 				}
 			})


### PR DESCRIPTION
in a previous commit, like shakespearean teenagers in love, we got our stars crossed. 