### PR TITLE
When rebasing, update stack/runImage key in lifecycle metadata label

### DIFF
--- a/platform/files.go
+++ b/platform/files.go
@@ -229,6 +229,26 @@ type RunImageForRebase struct {
 	Mirrors []string `toml:"mirrors,omitempty" json:"mirrors,omitempty"`
 }
 
+func (r *RunImageForRebase) Contains(ref string) bool {
+	ref = parseMaybe(ref)
+	if parseMaybe(r.Image) == ref {
+		return true
+	}
+	for _, m := range r.Mirrors {
+		if parseMaybe(m) == ref {
+			return true
+		}
+	}
+	return false
+}
+
+func parseMaybe(ref string) string {
+	if nameRef, err := name.ParseReference(ref); err == nil {
+		return nameRef.Context().Name()
+	}
+	return ref
+}
+
 func (r *RunImageForRebase) ToStackMetadata() StackMetadata {
 	return StackMetadata{
 		RunImage: RunImageForExport{

--- a/rebaser.go
+++ b/rebaser.go
@@ -77,6 +77,16 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	}
 	origMetadata.RunImage.Reference = identifier.String()
 
+	if r.PlatformAPI.AtLeast("0.12") {
+		// update stack and runImage if needed
+		if !origMetadata.RunImage.Contains(newBaseImage.Name()) {
+			origMetadata.RunImage.Image = newBaseImage.Name()
+			origMetadata.RunImage.Mirrors = []string{}
+			newStackMD := origMetadata.RunImage.ToStackMetadata()
+			origMetadata.Stack = &newStackMD
+		}
+	}
+
 	data, err := json.Marshal(origMetadata)
 	if err != nil {
 		return RebaseReport{}, errors.Wrap(err, "marshall metadata")

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -130,7 +130,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, md.App, []interface{}{map[string]interface{}{"sha": "123456"}})
 			})
 
-			when("new base image has no run image metadata", func() {
+			when("new base image is not found in run image metadata", func() {
 				it.Before(func() {
 					lifecycleMD := platform.LayersMetadata{
 						RunImage: platform.RunImageForRebase{


### PR DESCRIPTION
if the provided run image does not match existing metadata.

See https://github.com/buildpacks/spec/pull/360