### PR TITLE
Add more logging so we know when the lifecycle actually starts

### DIFF
--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -24,7 +24,7 @@ type Command interface {
 	Exec() error
 }
 
-func Run(c Command, asSubcommand bool) {
+func Run(c Command, withName string, asSubcommand bool) {
 	var (
 		printVersion bool
 		logLevel     string
@@ -55,6 +55,7 @@ func Run(c Command, asSubcommand bool) {
 	if err := cmd.DefaultLogger.SetLevel(logLevel); err != nil {
 		cmd.Exit(err)
 	}
+	cmd.DefaultLogger.Debugf("Starting %s...", withName)
 
 	// Warn when CNB_PLATFORM_API is unset
 	if os.Getenv(platform.EnvPlatformAPI) == "" {
@@ -62,11 +63,14 @@ func Run(c Command, asSubcommand bool) {
 		cmd.DefaultLogger.Infof("%s should be set to avoid breaking changes when upgrading the lifecycle", platform.EnvPlatformAPI)
 	}
 
+	cmd.DefaultLogger.Debugf("Parsing flags...")
 	if err := c.Args(flagSet.NArg(), flagSet.Args()); err != nil {
 		cmd.Exit(err)
 	}
+	cmd.DefaultLogger.Debugf("Ensuring privileges...")
 	if err := c.Privileges(); err != nil {
 		cmd.Exit(err)
 	}
+	cmd.DefaultLogger.Debugf("Executing command...")
 	cmd.Exit(c.Exec())
 }

--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -63,7 +63,7 @@ func Run(c Command, withPhaseName string, asSubcommand bool) {
 		cmd.DefaultLogger.Infof("%s should be set to avoid breaking changes when upgrading the lifecycle", platform.EnvPlatformAPI)
 	}
 
-	cmd.DefaultLogger.Debugf("Parsing flags...")
+	cmd.DefaultLogger.Debugf("Parsing inputs...")
 	if err := c.Args(flagSet.NArg(), flagSet.Args()); err != nil {
 		cmd.Exit(err)
 	}

--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -24,7 +24,7 @@ type Command interface {
 	Exec() error
 }
 
-func Run(c Command, withName string, asSubcommand bool) {
+func Run(c Command, withPhaseName string, asSubcommand bool) {
 	var (
 		printVersion bool
 		logLevel     string
@@ -55,7 +55,7 @@ func Run(c Command, withName string, asSubcommand bool) {
 	if err := cmd.DefaultLogger.SetLevel(logLevel); err != nil {
 		cmd.Exit(err)
 	}
-	cmd.DefaultLogger.Debugf("Starting %s...", withName)
+	cmd.DefaultLogger.Debugf("Starting %s...", withPhaseName)
 
 	// Warn when CNB_PLATFORM_API is unset
 	if os.Getenv(platform.EnvPlatformAPI) == "" {

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -21,21 +21,21 @@ func main() {
 	phase := strings.TrimSuffix(filepath.Base(os.Args[0]), filepath.Ext(os.Args[0]))
 	switch phase {
 	case "detector":
-		cli.Run(&detectCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&detectCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "analyzer":
-		cli.Run(&analyzeCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&analyzeCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "restorer":
-		cli.Run(&restoreCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&restoreCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "builder":
-		cli.Run(&buildCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&buildCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "exporter":
-		cli.Run(&exportCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&exportCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "creator":
-		cli.Run(&createCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&createCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "extender":
-		cli.Run(&extendCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&extendCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	case "rebaser":
-		cli.Run(&rebaseCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, false)
+		cli.Run(&rebaseCmd{Platform: platform.NewPlatformFor(platformAPIWithExitOnError())}, phase, false)
 	default:
 		if len(os.Args) < 2 {
 			cmd.Exit(cmd.FailCode(cmd.CodeForInvalidArgs, "parse arguments"))
@@ -59,21 +59,21 @@ func subcommand(platformAPI string) {
 	phase := filepath.Base(os.Args[1])
 	switch phase {
 	case "detect":
-		cli.Run(&detectCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&detectCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "analyze":
-		cli.Run(&analyzeCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&analyzeCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "restore":
-		cli.Run(&restoreCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&restoreCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "build":
-		cli.Run(&buildCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&buildCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "export":
-		cli.Run(&exportCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&exportCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "rebase":
-		cli.Run(&rebaseCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&rebaseCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "create":
-		cli.Run(&createCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&createCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	case "extend":
-		cli.Run(&extendCmd{Platform: platform.NewPlatformFor(platformAPI)}, true)
+		cli.Run(&extendCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	default:
 		cmd.Exit(cmd.FailCode(cmd.CodeForInvalidArgs, "unknown phase:", phase))
 	}


### PR DESCRIPTION
In working through https://github.com/buildpacks/lifecycle/issues/1007 it was hard to know if the lifecycle had even started when we were stuck in a loop trying to get the auth, because the first log lines emitted by the lifecycle were emitted after the Analyzer had started.

If we had this logging in place beforehand,
we would have known the problem was somewhere in Privileges()