### PR TITLE
probably fixes error message that calls missing images corrupt 

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -295,7 +295,7 @@ func (a *Analyzer) retrieveAppMetadata() (platform.LayersMetadata, string, error
 	if err != nil {
 		return platform.LayersMetadata{}, "", errors.Wrap(err, "identifying previous image")
 	}
-	if !a.PreviousImage.Valid() {
+	if a.PreviousImage.Found() && !a.PreviousImage.Valid() {
 		a.Logger.Infof("Ignoring image %q because it was corrupt", a.PreviousImage.Name())
 		return platform.LayersMetadata{}, "", nil
 	}


### PR DESCRIPTION


 but honestly i'm not adding a unit test

Previously: Treat images like politicians (if you suddenly can't find them, that's evidence of corruption).

Now: Treat images like accounting errors (if you can't find any, there's no evidence of corruption)