### PR TITLE
metadata label is more clearly named and always has stacks

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -302,7 +302,7 @@ func (a *Analyzer) retrieveAppMetadata() (files.LayersMetadata, string, error) {
 
 	var appMeta files.LayersMetadata
 	// continue even if the label cannot be decoded
-	if err = image.DecodeLabel(a.PreviousImage, platform.LayerMetadataLabel, &appMeta); err != nil {
+	if err = image.DecodeLabel(a.PreviousImage, platform.LifecycleMetadataLabel, &appMeta); err != nil {
 		return files.LayersMetadata{}, "", nil
 	}
 	return appMeta, previousImageRef, nil

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -216,7 +216,6 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore lifecycle.Cache, an
 		Project:            projectMD,
 		RunImageRef:        runImageID,
 		RunImageForExport:  runImageForExport,
-		Stack:              files.Stack{RunImage: runImageForExport}, // for backwards compat
 		WorkingImage:       appImage,
 	})
 	if err != nil {

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -158,7 +158,7 @@ func (r *rebaseCmd) setAppImage() error {
 	}
 
 	var md files.LayersMetadata
-	if err := image.DecodeLabel(r.appImage, platform.LayerMetadataLabel, &md); err != nil {
+	if err := image.DecodeLabel(r.appImage, platform.LifecycleMetadataLabel, &md); err != nil {
 		return err
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -123,9 +123,7 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 		meta.RunImage.Image = opts.RunImageForExport.Image
 		meta.RunImage.Mirrors = opts.RunImageForExport.Mirrors
 		// ensure we always copy the new RunImage into the old stack to preserve old behavior
-		meta.Stack = &files.Stack{}
-		meta.Stack.RunImage.Image = meta.RunImage.Image
-		meta.Stack.RunImage.Mirrors = meta.RunImage.Mirrors
+		meta.Stack = opts.Stack
 	} else { // the past was a simpler time, but in fairness the eventual stack-less future will also be simpler.
 		meta.Stack = &opts.Stack
 	}

--- a/exporter.go
+++ b/exporter.go
@@ -115,11 +115,6 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	meta.RunImage.Reference = opts.RunImageRef
 
 	if e.PlatformAPI.AtLeast("0.12") {
-		// if it's new API version but only using Stack still, then normalize the model by copying stack into the RunImage
-		if opts.RunImageForExport.Image == "" && len(opts.RunImageForExport.Mirrors) == 0 {
-			opts.RunImageForExport.Image = opts.Stack.RunImage.Image
-			opts.RunImageForExport.Mirrors = opts.Stack.RunImage.Mirrors
-		}
 		meta.RunImage.Image = opts.RunImageForExport.Image
 		meta.RunImage.Mirrors = opts.RunImageForExport.Mirrors
 		// ensure we always copy the new RunImage into the old stack to preserve old behavior

--- a/exporter.go
+++ b/exporter.go
@@ -80,8 +80,6 @@ type ExportOptions struct {
 	DefaultProcessType string
 	// RunImageRef is the run image reference for the layer metadata label.
 	RunImageRef string
-	// Stack is run image metadata for the layer metadata label for Platform API < 0.12.
-	Stack files.Stack
 	// RunImageForExport is run image metadata for the layer metadata label for Platform API >= 0.12.
 	RunImageForExport files.RunImageForExport
 	// Project is project metadata for the project metadata label.
@@ -117,11 +115,9 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	if e.PlatformAPI.AtLeast("0.12") {
 		meta.RunImage.Image = opts.RunImageForExport.Image
 		meta.RunImage.Mirrors = opts.RunImageForExport.Mirrors
-		// ensure we always copy the new RunImage into the old stack to preserve old behavior
-		meta.Stack = opts.Stack
-	} else { // the past was a simpler time, but in fairness the eventual stack-less future will also be simpler.
-		meta.Stack = &opts.Stack
 	}
+	// ensure we always copy the new RunImage into the old stack to preserve old behavior
+	meta.Stack = &files.Stack{RunImage: opts.RunImageForExport}
 
 	buildMD := &files.BuildMetadata{}
 	if err := files.DecodeBuildMetadata(launch.GetMetadataFilePath(opts.LayersDir), e.PlatformAPI, buildMD); err != nil {

--- a/exporter.go
+++ b/exporter.go
@@ -115,9 +115,18 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	meta.RunImage.Reference = opts.RunImageRef
 
 	if e.PlatformAPI.AtLeast("0.12") {
+		// if it's new API version but only using Stack still, then normalize the model by copying stack into the RunImage
+		if opts.RunImageForExport.Image == "" && len(opts.RunImageForExport.Mirrors) == 0 {
+			opts.RunImageForExport.Image = opts.Stack.RunImage.Image
+			opts.RunImageForExport.Mirrors = opts.Stack.RunImage.Mirrors
+		}
 		meta.RunImage.Image = opts.RunImageForExport.Image
 		meta.RunImage.Mirrors = opts.RunImageForExport.Mirrors
-	} else {
+		// ensure we always copy the new RunImage into the old stack to preserve old behavior
+		meta.Stack = &files.Stack{}
+		meta.Stack.RunImage.Image = meta.RunImage.Image
+		meta.Stack.RunImage.Mirrors = meta.RunImage.Mirrors
+	} else { // the past was a simpler time, but in fairness the eventual stack-less future will also be simpler.
 		meta.Stack = &opts.Stack
 	}
 
@@ -528,8 +537,8 @@ func (e *Exporter) setLabels(opts ExportOptions, meta files.LayersMetadata, buil
 		return errors.Wrap(err, "marshall metadata")
 	}
 
-	e.Logger.Infof("Adding label '%s'", platform.LayerMetadataLabel)
-	if err = opts.WorkingImage.SetLabel(platform.LayerMetadataLabel, string(data)); err != nil {
+	e.Logger.Infof("Adding label '%s'", platform.LifecycleMetadataLabel)
+	if err = opts.WorkingImage.SetLabel(platform.LifecycleMetadataLabel, string(data)); err != nil {
 		return errors.Wrap(err, "set app image metadata label")
 	}
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -415,11 +415,9 @@ func testExporter(t *testing.T, when spec.G, it spec.S) {
 				when("platform api < 0.12", func() {
 					platformAPI = api.MustParse("0.11")
 					it("doesnt add new keys to the json", func() {
-						opts.Stack = files.Stack{
-							RunImage: files.RunImageForExport{
-								Image:   "some/run",
-								Mirrors: []string{"registry.example.com/some/run", "other.example.com/some/run"},
-							},
+						opts.RunImageForExport = files.RunImageForExport{
+							Image:   "some/run",
+							Mirrors: []string{"registry.example.com/some/run", "other.example.com/some/run"},
 						}
 						_, err := exporter.Export(opts)
 						h.AssertNil(t, err)

--- a/platform/labels.go
+++ b/platform/labels.go
@@ -1,10 +1,10 @@
 package platform
 
 const (
-	BuildMetadataLabel   = "io.buildpacks.build.metadata"
-	LayerMetadataLabel   = "io.buildpacks.lifecycle.metadata"
-	MixinsLabel          = "io.buildpacks.stack.mixins"
-	ProjectMetadataLabel = "io.buildpacks.project.metadata"
-	RebaseableLabel      = "io.buildpacks.rebasable"
-	StackIDLabel         = "io.buildpacks.stack.id"
+	BuildMetadataLabel     = "io.buildpacks.build.metadata"
+	LifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
+	MixinsLabel            = "io.buildpacks.stack.mixins"
+	ProjectMetadataLabel   = "io.buildpacks.project.metadata"
+	RebaseableLabel        = "io.buildpacks.rebasable"
+	StackIDLabel           = "io.buildpacks.stack.id"
 )

--- a/rebaser.go
+++ b/rebaser.go
@@ -29,7 +29,7 @@ type RebaseReport struct {
 
 func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image, outputImageRef string, additionalNames []string) (RebaseReport, error) {
 	var origMetadata files.LayersMetadataCompat
-	if err := image.DecodeLabel(workingImage, platform.LayerMetadataLabel, &origMetadata); err != nil {
+	if err := image.DecodeLabel(workingImage, platform.LifecycleMetadataLabel, &origMetadata); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "get image metadata")
 	}
 
@@ -93,7 +93,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 		return RebaseReport{}, errors.Wrap(err, "marshall metadata")
 	}
 
-	if err := workingImage.SetLabel(platform.LayerMetadataLabel, string(data)); err != nil {
+	if err := workingImage.SetLabel(platform.LifecycleMetadataLabel, string(data)); err != nil {
 		return RebaseReport{}, errors.Wrap(err, "set app image metadata label")
 	}
 

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -104,7 +104,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			it("sets the top layer in the metadata", func() {
 				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
-				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 
 				h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
 			})
@@ -112,19 +112,19 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 			it("sets the run image reference in the metadata", func() {
 				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
-				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 
 				h.AssertEq(t, md.RunImage.Reference, "new-run-id")
 			})
 
 			it("preserves other existing metadata", func() {
 				h.AssertNil(t, fakeAppImage.SetLabel(
-					platform.LayerMetadataLabel,
+					platform.LifecycleMetadataLabel,
 					`{"app": [{"sha": "123456"}], "buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
 				))
 				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
-				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 
 				h.AssertEq(t, len(md.Buildpacks), 1)
 				h.AssertEq(t, md.Buildpacks[0].ID, "buildpack.id")
@@ -147,7 +147,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					}
 					label, err := json.Marshal(lifecycleMD)
 					h.AssertNil(t, err)
-					h.AssertNil(t, fakeAppImage.SetLabel(platform.LayerMetadataLabel, string(label)))
+					h.AssertNil(t, fakeAppImage.SetLabel(platform.LifecycleMetadataLabel, string(label)))
 				})
 
 				when("platform API < 0.12", func() {
@@ -159,7 +159,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 
-						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 						h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
 						h.AssertEq(t, md.RunImage.Reference, "new-run-id")
 						h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
@@ -178,7 +178,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertNil(t, err)
 
-						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 						var empty []string
 						h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
 						h.AssertEq(t, md.RunImage.Reference, "new-run-id")
@@ -204,7 +204,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 							h.AssertNil(t, err)
 
-							h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+							h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 							h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
 							h.AssertEq(t, md.RunImage.Reference, "new-run-id")
 							h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
@@ -230,7 +230,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 							h.AssertNil(t, err)
 
-							h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LayerMetadataLabel, &md))
+							h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
 							h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
 							h.AssertEq(t, md.RunImage.Reference, "new-run-id")
 							h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")


### PR DESCRIPTION
see: https://github.com/buildpacks/lifecycle/issues/1057