### PR TITLE
turn on additional linter checks including godoc comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Set up go
         uses: actions/setup-go@v3
         with:
@@ -41,6 +43,8 @@ jobs:
     runs-on: linux-arm64
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Set up go
         uses: actions/setup-go@v3
         with:
@@ -59,6 +63,8 @@ jobs:
           git config --global core.eol lf
           git config --global core.symlinks true
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Set up go
         uses: actions/setup-go@v3
         with:

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -34,6 +34,7 @@ linters-settings:
 
 
 issues:
+  exclude-use-default: false
   exclude-rules:
     # Ignore this minor optimization.
     # See https://github.com/golang/go/issues/44877#issuecomment-794565908

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -35,7 +35,7 @@ linters-settings:
 
 issues:
   exclude-use-default: false
-  new-from-rev: 28084b74124ad4484bd9e67ea4c469b05b5f38fa
+  new-from-rev: 91593cf91797ca0a98ffa31842107a9d916da37b
   exclude-rules:
     # Ignore this minor optimization.
     # See https://github.com/golang/go/issues/44877#issuecomment-794565908

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -35,6 +35,7 @@ linters-settings:
 
 issues:
   exclude-use-default: false
+  new-from-rev: 28084b74124ad4484bd9e67ea4c469b05b5f38fa
   exclude-rules:
     # Ignore this minor optimization.
     # See https://github.com/golang/go/issues/44877#issuecomment-794565908


### PR DESCRIPTION
The goal of this commit is to enforce stricter style, including godoc comments, but only going forward.

For reference, the linters enabled in this commit can be seen running against the current repo here:
https://github.com/buildpacks/lifecycle/actions/runs/5182278788/jobs/9338882119?pr=1110

but by specifying the `new-from-rev` option in golanci.yaml config we're able to say that these should only apply in the future. This functions as a "since" commit,  meaning "the linters only apply to commits since this one."

The soft-agreement of turning this on would be something like:
- the "since" commit is allowed to be bumped forward for large refactors where fixing 10s or 100s of linter errors is an unreasonable additional burden
- new features and bugfixes that incur only a handful of linter fixes should perform those linter fixes without moving the "since" commit.


In particular the linter that we're most interested in is enforcing godocs for Exported fields going forwards, which looks like this:

`exported: exported const TargetLabel should have comment (or a comment on this block) or be unexported (revive)`