### PR TITLE
Improved matching when selecting run image metadata

### DIFF
--- a/platform/run_image.go
+++ b/platform/run_image.go
@@ -32,14 +32,15 @@ func GetRunImageForExport(inputs LifecycleInputs) (files.RunImageForExport, erro
 		return files.RunImageForExport{}, err
 	}
 	if len(runMD.Images) == 0 {
-		return files.RunImageForExport{}, err
+		return files.RunImageForExport{}, nil
 	}
+	inputRef := parseMaybe(inputs.RunImageRef)
 	for _, runImage := range runMD.Images {
-		if runImage.Image == inputs.RunImageRef {
+		if parseMaybe(runImage.Image) == inputRef {
 			return runImage, nil
 		}
 		for _, mirror := range runImage.Mirrors {
-			if mirror == inputs.RunImageRef {
+			if parseMaybe(mirror) == inputRef {
 				return runImage, nil
 			}
 		}
@@ -53,6 +54,13 @@ func GetRunImageForExport(inputs LifecycleInputs) (files.RunImageForExport, erro
 		return files.RunImageForExport{Image: inputs.RunImageRef}, nil
 	}
 	return runMD.Images[0], nil
+}
+
+func parseMaybe(ref string) string {
+	if nameRef, err := name.ParseReference(ref); err == nil {
+		return nameRef.Context().Name()
+	}
+	return ref
 }
 
 func BestRunImageMirrorFor(targetRegistry string, runImageMD files.RunImageForExport, checkReadAccess CheckReadAccess) (string, error) {

--- a/platform/run_image_test.go
+++ b/platform/run_image_test.go
@@ -52,27 +52,53 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("contains an image matching run image ref", func() {
-				inputs.RunImageRef = "some-run-image-from-run-toml"
+				inputs.RunImageRef = "some-run-image-from-run-toml-1"
 
 				it("returns the image", func() {
 					result, err := platform.GetRunImageForExport(inputs)
 					h.AssertNil(t, err)
 					h.AssertEq(t, result, files.RunImageForExport{
-						Image:   "some-run-image-from-run-toml",
-						Mirrors: []string{"some-run-image-mirror-from-run-toml", "some-other-run-image-mirror-from-run-toml"},
+						Image:   "some-run-image-from-run-toml-1",
+						Mirrors: []string{"some-run-image-mirror-from-run-toml-1", "some-other-run-image-mirror-from-run-toml-1"},
+					})
+				})
+
+				when("reference includes docker registry", func() {
+					inputs.RunImageRef = "index.docker.io/some-run-image-from-run-toml-1"
+
+					it("still matches", func() {
+						result, err := platform.GetRunImageForExport(inputs)
+						h.AssertNil(t, err)
+						h.AssertEq(t, result, files.RunImageForExport{
+							Image:   "some-run-image-from-run-toml-1",
+							Mirrors: []string{"some-run-image-mirror-from-run-toml-1", "some-other-run-image-mirror-from-run-toml-1"},
+						})
 					})
 				})
 			})
 
 			when("contains an image mirror matching run image ref", func() {
-				inputs.RunImageRef = "some-other-run-image-mirror-from-run-toml"
+				inputs.RunImageRef = "some-other-run-image-mirror-from-run-toml-1"
 
 				it("returns the image", func() {
 					result, err := platform.GetRunImageForExport(inputs)
 					h.AssertNil(t, err)
 					h.AssertEq(t, result, files.RunImageForExport{
-						Image:   "some-run-image-from-run-toml",
-						Mirrors: []string{"some-run-image-mirror-from-run-toml", "some-other-run-image-mirror-from-run-toml"},
+						Image:   "some-run-image-from-run-toml-1",
+						Mirrors: []string{"some-run-image-mirror-from-run-toml-1", "some-other-run-image-mirror-from-run-toml-1"},
+					})
+				})
+
+				when("reference includes docker registry", func() {
+					inputs.RunImageRef = "index.docker.io/some-other-run-image-mirror-from-run-toml-1"
+
+					it("still matches", func() {
+						result, err := platform.GetRunImageForExport(inputs)
+						h.AssertNil(t, err)
+						h.AssertEq(t, result, files.RunImageForExport{
+							Image:   "some-run-image-from-run-toml-1",
+							Mirrors: []string{"some-run-image-mirror-from-run-toml-1", "some-other-run-image-mirror-from-run-toml-1"},
+						})
 					})
 				})
 			})


### PR DESCRIPTION
We need to parse the reference in case the registry is not specified (defaults to Docker Hub)