### PR TITLE
Fixes for rebase

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -6,9 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/go-containerregistry/pkg/name"
-
 	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/internal/name"
 	"github.com/buildpacks/lifecycle/platform"
 
 	"github.com/buildpacks/lifecycle/buildpack"
@@ -198,18 +197,11 @@ func satisfies(images []files.RunImageForExport, imageName string) bool {
 		return true
 	}
 	for _, image := range images {
-		if parseMaybe(image.Image) == parseMaybe(imageName) {
+		if name.ParseMaybe(image.Image) == name.ParseMaybe(imageName) {
 			return true
 		}
 	}
 	return false
-}
-
-func parseMaybe(ref string) string {
-	if nameRef, err := name.ParseReference(ref); err == nil {
-		return nameRef.Context().Name()
-	}
-	return ref
 }
 
 func (g *Generator) getGenerateInputs() buildpack.GenerateInputs {

--- a/internal/name/ref.go
+++ b/internal/name/ref.go
@@ -4,7 +4,7 @@ import "github.com/google/go-containerregistry/pkg/name"
 
 func ParseMaybe(ref string) string {
 	if nameRef, err := name.ParseReference(ref); err == nil {
-		return nameRef.Context().Name()
+		return nameRef.Name()
 	}
 	return ref
 }

--- a/internal/name/ref_test.go
+++ b/internal/name/ref_test.go
@@ -1,0 +1,62 @@
+package name_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+
+	"github.com/buildpacks/lifecycle/internal/name"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+func TestRef(t *testing.T) {
+	spec.Run(t, "Ref", testRef)
+}
+
+func testRef(t *testing.T, when spec.G, it spec.S) {
+	when(".ParseMaybe", func() {
+		when("provided reference", func() {
+			when("invalid", func() {
+				it("returns the provided reference", func() {
+					got := name.ParseMaybe("!@#$")
+					h.AssertEq(t, got, "!@#$")
+				})
+			})
+
+			when("has implicit registry", func() {
+				it("returns the fully qualified reference", func() {
+					got := name.ParseMaybe("some-library/some-repo:latest")
+					h.AssertEq(t, got, "index.docker.io/some-library/some-repo:latest")
+				})
+			})
+
+			when("has implicit library", func() {
+				it("returns the provided reference", func() {
+					got := name.ParseMaybe("some.registry/some-repo:latest")
+					h.AssertEq(t, got, "some.registry/some-repo:latest")
+				})
+
+				when("registry is docker.io", func() {
+					it("returns the fully qualified reference", func() {
+						got := name.ParseMaybe("index.docker.io/some-repo:latest")
+						h.AssertEq(t, got, "index.docker.io/library/some-repo:latest")
+					})
+				})
+			})
+
+			when("has implicit tag", func() {
+				it("returns the fully qualified reference", func() {
+					got := name.ParseMaybe("some.registry/some-library/some-repo")
+					h.AssertEq(t, got, "some.registry/some-library/some-repo:latest")
+				})
+			})
+
+			when("is fully qualified", func() {
+				it("returns the provided reference", func() {
+					got := name.ParseMaybe("some.registry/some-library/some-repo:some-tag")
+					h.AssertEq(t, got, "some.registry/some-library/some-repo:some-tag")
+				})
+			})
+		})
+	})
+}

--- a/platform/files/analyzed.go
+++ b/platform/files/analyzed.go
@@ -7,7 +7,6 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/buildpacks/lifecycle/buildpack"
-	"github.com/buildpacks/lifecycle/internal/name"
 	"github.com/buildpacks/lifecycle/log"
 )
 
@@ -123,23 +122,11 @@ type LayerMetadata struct {
 type RunImageForRebase struct {
 	TopLayer  string `json:"topLayer" toml:"top-layer"`
 	Reference string `json:"reference" toml:"reference"`
-
-	// added in Platform 0.12
-	Image   string   `toml:"image,omitempty" json:"image,omitempty"`
-	Mirrors []string `toml:"mirrors,omitempty" json:"mirrors,omitempty"`
+	RunImageForExport
 }
 
 func (r *RunImageForRebase) Contains(ref string) bool {
-	ref = name.ParseMaybe(ref)
-	if name.ParseMaybe(r.Image) == ref {
-		return true
-	}
-	for _, m := range r.Mirrors {
-		if name.ParseMaybe(m) == ref {
-			return true
-		}
-	}
-	return false
+	return r.RunImageForExport.Contains(ref)
 }
 
 func (r *RunImageForRebase) ToStack() Stack {

--- a/platform/files/stack.go
+++ b/platform/files/stack.go
@@ -17,6 +17,13 @@ type Stack struct {
 	RunImage RunImageForExport `json:"runImage" toml:"run-image"`
 }
 
+func (s *Stack) ToRunImageForRebase() *RunImageForRebase {
+	return &RunImageForRebase{
+		Image:   s.RunImage.Image,
+		Mirrors: s.RunImage.Mirrors,
+	}
+}
+
 type RunImageForExport struct {
 	Image   string   `toml:"image" json:"image"`
 	Mirrors []string `toml:"mirrors" json:"mirrors,omitempty"`

--- a/platform/files/stack.go
+++ b/platform/files/stack.go
@@ -23,6 +23,8 @@ type RunImageForExport struct {
 	Mirrors []string `toml:"mirrors,omitempty" json:"mirrors,omitempty"`
 }
 
+// Contains returns true if the provided reference matches either the primary image,
+// or the image mirrors.
 func (r *RunImageForExport) Contains(ref string) bool {
 	ref = name.ParseMaybe(ref)
 	if name.ParseMaybe(r.Image) == ref {

--- a/platform/labels.go
+++ b/platform/labels.go
@@ -5,6 +5,6 @@ const (
 	LifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
 	MixinsLabel            = "io.buildpacks.stack.mixins"
 	ProjectMetadataLabel   = "io.buildpacks.project.metadata"
-	RebaseableLabel        = "io.buildpacks.rebasable"
+	RebasableLabel         = "io.buildpacks.rebasable"
 	StackIDLabel           = "io.buildpacks.stack.id"
 )

--- a/rebaser.go
+++ b/rebaser.go
@@ -148,7 +148,7 @@ func containsName(origMetadata files.LayersMetadataCompat, newBaseName string) b
 	if origMetadata.Stack == nil {
 		return false
 	}
-	return origMetadata.Stack.ToRunImageForRebase().Contains(newBaseName)
+	return origMetadata.Stack.RunImage.Contains(newBaseName)
 }
 
 func validateStackID(appImg, newBaseImage imgutil.Image) error {

--- a/rebaser.go
+++ b/rebaser.go
@@ -92,6 +92,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 					newBaseImage.Name(),
 					existingRunImageMD,
 				)
+				// update original metadata
 				origMetadata.RunImage.Image = newBaseImage.Name()
 				origMetadata.RunImage.Mirrors = []string{}
 				newStackMD := origMetadata.RunImage.ToStack()

--- a/rebaser.go
+++ b/rebaser.go
@@ -74,7 +74,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 		return RebaseReport{}, fmt.Errorf("get run image id or digest: %w", err)
 	}
 	origMetadata.RunImage.Reference = identifier.String()
-	if appPlatformAPI != "" && r.PlatformAPI.AtLeast("0.12") {
+	if r.PlatformAPI.AtLeast("0.12") {
 		// update stack and runImage if needed
 		if !containsName(origMetadata, newBaseImage.Name()) {
 			var existingRunImageMD string

--- a/rebaser.go
+++ b/rebaser.go
@@ -18,6 +18,12 @@ import (
 	"github.com/buildpacks/lifecycle/platform/files"
 )
 
+var (
+	msgAppImageNotMarkedRebasable       = "app image is not marked as rebasable"
+	msgRunImageMDNotContainsName        = "rebase app image: new base image '%s' not found in existing run image metadata: %s"
+	msgUnableToSatisfyTargetConstraints = "unable to satisfy target os/arch constraints; new run image: %s, old run image: %s"
+)
+
 type Rebaser struct {
 	Logger      log.Logger
 	PlatformAPI *api.Version
@@ -50,41 +56,63 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	// get existing metadata label
 	var origMetadata files.LayersMetadataCompat
 	if err = image.DecodeLabel(workingImage, platform.LifecycleMetadataLabel, &origMetadata); err != nil {
-		return RebaseReport{}, errors.Wrap(err, "get image metadata")
+		return RebaseReport{}, fmt.Errorf("get image metadata: %w", err)
 	}
 
 	// rebase
 	if err = workingImage.Rebase(origMetadata.RunImage.TopLayer, newBaseImage); err != nil {
-		return RebaseReport{}, errors.Wrap(err, "rebase app image")
+		return RebaseReport{}, fmt.Errorf("rebase app image: %w", err)
 	}
 
 	// update metadata label
 	origMetadata.RunImage.TopLayer, err = newBaseImage.TopLayer()
 	if err != nil {
-		return RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
+		return RebaseReport{}, fmt.Errorf("get rebase run image top layer SHA: %w", err)
 	}
 	identifier, err := newBaseImage.Identifier()
 	if err != nil {
-		return RebaseReport{}, errors.Wrap(err, "get run image id or digest")
+		return RebaseReport{}, fmt.Errorf("get run image id or digest: %w", err)
 	}
 	origMetadata.RunImage.Reference = identifier.String()
-	if appPlatformAPI != "" && api.MustParse(appPlatformAPI).AtLeast("0.12") {
+	if appPlatformAPI != "" && r.PlatformAPI.AtLeast("0.12") {
 		// update stack and runImage if needed
-		if !origMetadata.RunImage.Contains(newBaseImage.Name()) {
-			origMetadata.RunImage.Image = newBaseImage.Name()
-			origMetadata.RunImage.Mirrors = []string{}
-			newStackMD := origMetadata.RunImage.ToStack()
-			origMetadata.Stack = &newStackMD
+		if !containsName(origMetadata, newBaseImage.Name()) {
+			var existingRunImageMD string
+			switch {
+			case origMetadata.RunImage.Image != "":
+				existingRunImageMD = encoding.ToJSONMaybe(origMetadata.RunImage)
+			case origMetadata.Stack != nil:
+				existingRunImageMD = encoding.ToJSONMaybe(origMetadata.Stack.RunImage)
+			default:
+				existingRunImageMD = "not found"
+			}
+			if r.Force {
+				r.Logger.Warnf(
+					msgRunImageMDNotContainsName,
+					newBaseImage.Name(),
+					existingRunImageMD,
+				)
+				origMetadata.RunImage.Image = newBaseImage.Name()
+				origMetadata.RunImage.Mirrors = []string{}
+				newStackMD := origMetadata.RunImage.ToStack()
+				origMetadata.Stack = &newStackMD
+			} else {
+				return RebaseReport{}, fmt.Errorf(
+					msgRunImageMDNotContainsName,
+					newBaseImage.Name(),
+					existingRunImageMD,
+				)
+			}
 		}
 	}
 
 	// set metadata label
 	data, err := json.Marshal(origMetadata)
 	if err != nil {
-		return RebaseReport{}, errors.Wrap(err, "marshall metadata")
+		return RebaseReport{}, fmt.Errorf("marshall metadata: %w", err)
 	}
 	if err := workingImage.SetLabel(platform.LifecycleMetadataLabel, string(data)); err != nil {
-		return RebaseReport{}, errors.Wrap(err, "set app image metadata label")
+		return RebaseReport{}, fmt.Errorf("set app image metadata label: %w", err)
 	}
 
 	// update other labels
@@ -95,7 +123,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 		return strings.HasPrefix(l, "io.buildpacks.stack.")
 	}
 	if err := image.SyncLabels(newBaseImage, workingImage, hasPrefix); err != nil {
-		return RebaseReport{}, errors.Wrap(err, "set stack labels")
+		return RebaseReport{}, fmt.Errorf("set stack labels: %w", err)
 	}
 
 	// save
@@ -112,15 +140,25 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	return report, err
 }
 
+func containsName(origMetadata files.LayersMetadataCompat, newBaseName string) bool {
+	if origMetadata.RunImage.Contains(newBaseName) {
+		return true
+	}
+	if origMetadata.Stack == nil {
+		return false
+	}
+	return origMetadata.Stack.ToRunImageForRebase().Contains(newBaseName)
+}
+
 func validateStackID(appImg, newBaseImage imgutil.Image) error {
 	appStackID, err := appImg.Label(platform.StackIDLabel)
 	if err != nil {
-		return errors.Wrap(err, "get app image stack")
+		return fmt.Errorf("get app image stack: %w", err)
 	}
 
 	newBaseStackID, err := newBaseImage.Label(platform.StackIDLabel)
 	if err != nil {
-		return errors.Wrap(err, "get new base image stack")
+		return fmt.Errorf("get new base image stack: %w", err)
 	}
 
 	if appStackID == "" {
@@ -142,11 +180,11 @@ func validateMixins(appImg, newBaseImg imgutil.Image) error {
 	var newBaseImageMixins []string
 
 	if err := image.DecodeLabel(appImg, platform.MixinsLabel, &appImageMixins); err != nil {
-		return errors.Wrap(err, "get app image mixins")
+		return fmt.Errorf("get app image mixins: %w", err)
 	}
 
 	if err := image.DecodeLabel(newBaseImg, platform.MixinsLabel, &newBaseImageMixins); err != nil {
-		return errors.Wrap(err, "get run image mixins")
+		return fmt.Errorf("get run image mixins: %w", err)
 	}
 
 	appImageMixins = removeStagePrefixes(appImageMixins)
@@ -163,34 +201,42 @@ func validateMixins(appImg, newBaseImg imgutil.Image) error {
 }
 
 func (r *Rebaser) validateTarget(appImg imgutil.Image, newBaseImg imgutil.Image) error {
-	rebaseable, err := appImg.Label(platform.RebaseableLabel)
+	rebasable, err := appImg.Label(platform.RebasableLabel)
 	if err != nil {
-		return errors.Wrap(err, "get app image rebaseable label")
+		return fmt.Errorf("get app image rebasable label: %w", err)
 	}
-	if !r.Force && rebaseable == "false" {
-		return fmt.Errorf("app image is not marked as rebaseable")
+	if rebasable == "false" {
+		if !r.Force {
+			return fmt.Errorf(msgAppImageNotMarkedRebasable)
+		}
+		r.Logger.Warn(msgAppImageNotMarkedRebasable)
 	}
 
 	// check the OS, architecture, and variant values
 	// if they are not the same, the image cannot be rebased unless the force flag is set
-	if !r.Force {
-		appTarget, err := platform.GetTargetMetadata(appImg)
-		if err != nil {
-			return errors.Wrap(err, "get app image target")
-		}
+	appTarget, err := platform.GetTargetMetadata(appImg)
+	if err != nil {
+		return fmt.Errorf("get app image target: %w", err)
+	}
 
-		newBaseTarget, err := platform.GetTargetMetadata(newBaseImg)
-		if err != nil {
-			return errors.Wrap(err, "get new base image target")
-		}
+	newBaseTarget, err := platform.GetTargetMetadata(newBaseImg)
+	if err != nil {
+		return fmt.Errorf("get new base image target: %w", err)
+	}
 
-		if !platform.TargetSatisfiedForRebase(*newBaseTarget, *appTarget) {
+	if !platform.TargetSatisfiedForRebase(*newBaseTarget, *appTarget) {
+		if !r.Force {
 			return fmt.Errorf(
-				"unable to satisfy target os/arch constraints; new run image: %s, old run image: %s",
+				msgUnableToSatisfyTargetConstraints,
 				encoding.ToJSONMaybe(newBaseTarget),
 				encoding.ToJSONMaybe(appTarget),
 			)
 		}
+		r.Logger.Warnf(
+			msgUnableToSatisfyTargetConstraints,
+			encoding.ToJSONMaybe(newBaseTarget),
+			encoding.ToJSONMaybe(appTarget),
+		)
 	}
 	return nil
 }

--- a/rebaser.go
+++ b/rebaser.go
@@ -19,6 +19,7 @@ import (
 )
 
 var (
+	msgProvideForceToOverride           = "please provide -force to override"
 	msgAppImageNotMarkedRebasable       = "app image is not marked as rebasable"
 	msgRunImageMDNotContainsName        = "rebase app image: new base image '%s' not found in existing run image metadata: %s"
 	msgUnableToSatisfyTargetConstraints = "unable to satisfy target os/arch constraints; new run image: %s, old run image: %s"
@@ -99,7 +100,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 				origMetadata.Stack = &newStackMD
 			} else {
 				return RebaseReport{}, fmt.Errorf(
-					msgRunImageMDNotContainsName,
+					msgRunImageMDNotContainsName+"; "+msgProvideForceToOverride,
 					newBaseImage.Name(),
 					existingRunImageMD,
 				)
@@ -208,7 +209,7 @@ func (r *Rebaser) validateTarget(appImg imgutil.Image, newBaseImg imgutil.Image)
 	}
 	if rebasable == "false" {
 		if !r.Force {
-			return fmt.Errorf(msgAppImageNotMarkedRebasable)
+			return fmt.Errorf(msgAppImageNotMarkedRebasable + "; " + msgProvideForceToOverride)
 		}
 		r.Logger.Warn(msgAppImageNotMarkedRebasable)
 	}
@@ -228,7 +229,7 @@ func (r *Rebaser) validateTarget(appImg imgutil.Image, newBaseImg imgutil.Image)
 	if !platform.TargetSatisfiedForRebase(*newBaseTarget, *appTarget) {
 		if !r.Force {
 			return fmt.Errorf(
-				msgUnableToSatisfyTargetConstraints,
+				msgUnableToSatisfyTargetConstraints+"; "+msgProvideForceToOverride,
 				encoding.ToJSONMaybe(newBaseTarget),
 				encoding.ToJSONMaybe(appTarget),
 			)

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -194,6 +194,24 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 									h.AssertError(t, err, `rebase app image: new base image 'some-repo/new-base-image' not found in existing run image metadata: {"topLayer":"new-top-layer-sha","reference":"new-run-id","image":"some-run-image-tag-reference","mirrors":["some-run-image-mirror"]}`)
 								})
 
+								when("tag is different", func() {
+									it.Before(func() {
+										fakeNewBaseImage = fakes.NewImage(
+											"some-run-image-mirror:new-tag",
+											"new-top-layer-sha",
+											local.IDIdentifier{
+												ImageID: "new-run-id",
+											},
+										)
+										h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
+									})
+
+									it("doesn't match", func() {
+										_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+										h.AssertError(t, err, `rebase app image: new base image 'some-run-image-mirror:new-tag' not found in existing run image metadata: {"topLayer":"new-top-layer-sha","reference":"new-run-id","image":"some-run-image-tag-reference","mirrors":["some-run-image-mirror"]}`)
+									})
+								})
+
 								when("platform API < 0.12", func() {
 									it.Before(func() {
 										rebaser.PlatformAPI = api.MustParse("0.11")

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -146,8 +146,10 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						RunImage: files.RunImageForRebase{
 							TopLayer:  "some-top-layer",
 							Reference: "some-run-image-digest-reference",
-							Image:     "some-run-image-tag-reference",
-							Mirrors:   []string{"some-run-image-mirror"},
+							RunImageForExport: files.RunImageForExport{
+								Image:   "some-run-image-tag-reference",
+								Mirrors: []string{"some-run-image-mirror"},
+							},
 						},
 						Stack: &files.Stack{RunImage: files.RunImageForExport{
 							Image:   "some-run-image-tag-reference",

--- a/rebaser_test.go
+++ b/rebaser_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/apex/log/handlers/discard"
+	"github.com/apex/log/handlers/memory"
 	"github.com/buildpacks/imgutil/fakes"
 	"github.com/buildpacks/imgutil/local"
 	"github.com/buildpacks/imgutil/remote"
@@ -33,6 +33,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		fakePreviousImage *fakes.Image
 		additionalNames   []string
 		md                files.LayersMetadataCompat
+		logHandler        *memory.Handler
 	)
 
 	it.Before(func() {
@@ -63,12 +64,22 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		)
 		h.AssertNil(t, fakePreviousImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 
+		lifecycleMD := files.LayersMetadata{
+			Stack: &files.Stack{RunImage: files.RunImageForExport{
+				Image: fakeNewBaseImage.Name(),
+			}},
+		}
+		label, err := json.Marshal(lifecycleMD)
+		h.AssertNil(t, err)
+		h.AssertNil(t, fakeAppImage.SetLabel(platform.LifecycleMetadataLabel, string(label)))
 		h.AssertNil(t, fakeAppImage.SetEnv(platform.EnvPlatformAPI, api.Platform.Latest().String()))
 
 		additionalNames = []string{"some-repo/app-image:foo", "some-repo/app-image:bar"}
 
+		logHandler = memory.New()
+
 		rebaser = &lifecycle.Rebaser{
-			Logger:      &log.Logger{Handler: &discard.Handler{}},
+			Logger:      &log.Logger{Handler: logHandler},
 			PlatformAPI: api.Platform.Latest(),
 		}
 	})
@@ -119,6 +130,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					platform.LifecycleMetadataLabel,
 					`{"app": [{"sha": "123456"}], "buildpacks":[{"key": "buildpack.id", "layers": {}}]}`,
 				))
+				rebaser.Force = true // skip run image validations
 				_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 				h.AssertNil(t, err)
 				h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
@@ -147,88 +159,139 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, fakeAppImage.SetLabel(platform.LifecycleMetadataLabel, string(label)))
 				})
 
-				it("overrides the existing metadata", func() {
-					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-					h.AssertNil(t, err)
+				when("existing run image metadata", func() {
+					when("includes new run image", func() {
+						it.Before(func() {
+							fakeNewBaseImage = fakes.NewImage(
+								"some-run-image-mirror",
+								"new-top-layer-sha",
+								local.IDIdentifier{
+									ImageID: "new-run-id",
+								},
+							)
+							h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
+						})
 
-					h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
-					var empty []string
-					h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
-					h.AssertEq(t, md.RunImage.Reference, "new-run-id")
-					h.AssertEq(t, md.RunImage.Image, "some-repo/new-base-image")
-					h.AssertEq(t, md.RunImage.Mirrors, empty)
-					h.AssertEq(t, md.Stack.RunImage.Image, "some-repo/new-base-image")
-					h.AssertEq(t, md.Stack.RunImage.Mirrors, empty)
-				})
+						it("preserves the existing metadata", func() {
+							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+							h.AssertNil(t, err)
 
-				when("new base image is an existing mirror", func() {
-					it.Before(func() {
-						fakeNewBaseImage = fakes.NewImage(
-							"some-run-image-mirror",
-							"new-top-layer-sha",
-							local.IDIdentifier{
-								ImageID: "new-run-id",
-							},
-						)
-						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
+							h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
+							h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
+							h.AssertEq(t, md.RunImage.Reference, "new-run-id")
+							h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
+							h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
+							h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
+							h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
+						})
+
+						when("reference includes docker registry", func() {
+							it.Before(func() {
+								fakeNewBaseImage = fakes.NewImage(
+									"index.docker.io/some-run-image-mirror",
+									"new-top-layer-sha",
+									local.IDIdentifier{
+										ImageID: "new-run-id",
+									},
+								)
+								h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
+							})
+
+							it("still matches", func() {
+								_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+								h.AssertNil(t, err)
+
+								h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
+								h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
+								h.AssertEq(t, md.RunImage.Reference, "new-run-id")
+								h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
+								h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
+								h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
+								h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
+							})
+						})
 					})
 
-					it("preserves the existing metadata", func() {
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertNil(t, err)
+					when("includes new run image as mirror", func() {
+						it.Before(func() {
+							fakeNewBaseImage = fakes.NewImage(
+								"some-run-image-mirror",
+								"new-top-layer-sha",
+								local.IDIdentifier{
+									ImageID: "new-run-id",
+								},
+							)
+							h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
+						})
 
-						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
-						h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
-						h.AssertEq(t, md.RunImage.Reference, "new-run-id")
-						h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
-						h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
-						h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
-						h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
-					})
-				})
+						it("preserves the existing metadata", func() {
+							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+							h.AssertNil(t, err)
 
-				when("reference includes docker registry", func() {
-					it.Before(func() {
-						fakeNewBaseImage = fakes.NewImage(
-							"index.docker.io/some-run-image-mirror",
-							"new-top-layer-sha",
-							local.IDIdentifier{
-								ImageID: "new-run-id",
-							},
-						)
-						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
-					})
-
-					it("still matches", func() {
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertNil(t, err)
-
-						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
-						h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
-						h.AssertEq(t, md.RunImage.Reference, "new-run-id")
-						h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
-						h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
-						h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
-						h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
-					})
-				})
-
-				when("previous image was built using platform API < 0.12", func() {
-					it.Before(func() {
-						h.AssertNil(t, fakeAppImage.SetEnv(platform.EnvPlatformAPI, "0.11"))
+							h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
+							h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
+							h.AssertEq(t, md.RunImage.Reference, "new-run-id")
+							h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
+							h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
+							h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
+							h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
+						})
 					})
 
-					it("preserves the existing metadata", func() {
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertNil(t, err)
+					when("does not include new run image", func() {
+						when("force", func() {
+							when("true", func() {
+								it.Before(func() {
+									rebaser.Force = true
+								})
 
-						h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
-						h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
-						h.AssertEq(t, md.RunImage.Reference, "new-run-id")
-						h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
-						h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
-						h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
-						h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
+								it("warns and overrides the existing metadata", func() {
+									_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+									h.AssertNil(t, err)
+
+									assertLogEntry(t, logHandler, `new base image 'some-repo/new-base-image' not found in existing run image metadata: {"topLayer":"new-top-layer-sha","reference":"new-run-id","image":"some-run-image-tag-reference","mirrors":["some-run-image-mirror"]}`)
+
+									h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
+									var empty []string
+									h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
+									h.AssertEq(t, md.RunImage.Reference, "new-run-id")
+									h.AssertEq(t, md.RunImage.Image, "some-repo/new-base-image")
+									h.AssertEq(t, md.RunImage.Mirrors, empty)
+									h.AssertEq(t, md.Stack.RunImage.Image, "some-repo/new-base-image")
+									h.AssertEq(t, md.Stack.RunImage.Mirrors, empty)
+								})
+							})
+
+							when("false", func() {
+								it.Before(func() {
+									rebaser.Force = false
+								})
+
+								it("errors", func() {
+									_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+									h.AssertError(t, err, `rebase app image: new base image 'some-repo/new-base-image' not found in existing run image metadata: {"topLayer":"new-top-layer-sha","reference":"new-run-id","image":"some-run-image-tag-reference","mirrors":["some-run-image-mirror"]}`)
+								})
+
+								when("platform API < 0.12", func() {
+									it.Before(func() {
+										rebaser.PlatformAPI = api.MustParse("0.11")
+									})
+
+									it("preserves the existing metadata", func() {
+										_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+										h.AssertNil(t, err)
+
+										h.AssertNil(t, image.DecodeLabel(fakeAppImage, platform.LifecycleMetadataLabel, &md))
+										h.AssertEq(t, md.RunImage.TopLayer, "new-top-layer-sha")
+										h.AssertEq(t, md.RunImage.Reference, "new-run-id")
+										h.AssertEq(t, md.RunImage.Image, "some-run-image-tag-reference")
+										h.AssertEq(t, md.RunImage.Mirrors, []string{"some-run-image-mirror"})
+										h.AssertEq(t, md.Stack.RunImage.Image, "some-run-image-tag-reference")
+										h.AssertEq(t, md.Stack.RunImage.Mirrors, []string{"some-run-image-mirror"})
+									})
+								})
+							})
+						})
 					})
 				})
 			})
@@ -398,28 +461,41 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("validating rebasable", func() {
-			when("rebaseable label is false", func() {
+			when("rebasable label is false", func() {
 				it.Before(func() {
-					h.AssertNil(t, fakeAppImage.SetLabel(platform.RebaseableLabel, "false"))
+					h.AssertNil(t, fakeAppImage.SetLabel(platform.RebasableLabel, "false"))
 				})
 
-				it("returns an error", func() {
-					_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-					h.AssertError(t, err, "app image is not marked as rebaseable")
-				})
+				when("force", func() {
+					when("false", func() {
+						it.Before(func() {
+							rebaser.Force = false
+						})
 
-				when("force is true", func() {
-					it("allows rebase", func() {
-						rebaser.Force = true
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertNil(t, err)
+						it("errors", func() {
+							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+							h.AssertError(t, err, "app image is not marked as rebasable")
+						})
+					})
+
+					when("true", func() {
+						it.Before(func() {
+							rebaser.Force = true
+						})
+
+						it("warns and allows rebase", func() {
+							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+							h.AssertNil(t, err)
+
+							assertLogEntry(t, logHandler, "app image is not marked as rebasable")
+						})
 					})
 				})
 			})
 
-			when("rebaseable label is not false", func() {
+			when("rebasable label is not false", func() {
 				it.Before(func() {
-					h.AssertNil(t, fakeAppImage.SetLabel(platform.RebaseableLabel, "true"))
+					h.AssertNil(t, fakeAppImage.SetLabel(platform.RebasableLabel, "true"))
 				})
 
 				it("allows rebase", func() {
@@ -428,9 +504,9 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 
-			when("rebaseable label is empty", func() {
+			when("rebasable label is empty", func() {
 				it.Before(func() {
-					h.AssertNil(t, fakeAppImage.SetLabel(platform.RebaseableLabel, ""))
+					h.AssertNil(t, fakeAppImage.SetLabel(platform.RebasableLabel, ""))
 				})
 
 				it("allows rebase", func() {
@@ -444,9 +520,9 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNil(t, fakeAppImage.SetEnv(platform.EnvPlatformAPI, "0.11"))
 				})
 
-				when("rebaseable label is false", func() {
+				when("rebasable label is false", func() {
 					it.Before(func() {
-						h.AssertNil(t, fakeAppImage.SetLabel(platform.RebaseableLabel, "false"))
+						h.AssertNil(t, fakeAppImage.SetLabel(platform.RebasableLabel, "false"))
 					})
 
 					it("allows rebase", func() {
@@ -482,7 +558,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("there are invalid mixin labels", func() {
-					it("returns an error", func() {
+					it("errors", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.MixinsLabel, "thisisn'tvalid!"))
 						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
 						h.AssertError(t, err, "get app image mixins: failed to unmarshal context of label 'io.buildpacks.stack.mixins': invalid character 'h' in literal true (expecting 'r')")
@@ -561,6 +637,10 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("validating targets and stacks", func() {
+			it.Before(func() {
+				rebaser.Force = false
+			})
+
 			when("previous image was built using unknown platform API", func() {
 				it.Before(func() {
 					h.AssertNil(t, fakeAppImage.SetEnv(platform.EnvPlatformAPI, ""))
@@ -585,7 +665,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("stacks are different", func() {
-					it("returns an error and prevents the rebase from taking place when the stacks are different", func() {
+					it("errors and prevents the rebase from taking place when the stacks are different", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
@@ -593,7 +673,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						h.AssertError(t, err, "incompatible stack: 'io.buildpacks.stacks.cflinuxfs3' is not compatible with 'io.buildpacks.stacks.bionic'")
 					})
 
-					it("returns an error and prevents the rebase from taking place when the new base image has no stack defined", func() {
+					it("errors and prevents the rebase from taking place when the new base image has no stack defined", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, ""))
 
@@ -601,7 +681,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						h.AssertError(t, err, "stack not defined on new base image")
 					})
 
-					it("returns an error and prevents the rebase from taking place when the app image has no stack defined", func() {
+					it("errors and prevents the rebase from taking place when the app image has no stack defined", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, ""))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
@@ -635,7 +715,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 				})
 
 				when("stacks are different", func() {
-					it("returns an error and prevents the rebase from taking place when the stacks are different", func() {
+					it("errors and prevents the rebase from taking place when the stacks are different", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
@@ -643,7 +723,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						h.AssertError(t, err, "incompatible stack: 'io.buildpacks.stacks.cflinuxfs3' is not compatible with 'io.buildpacks.stacks.bionic'")
 					})
 
-					it("returns an error and prevents the rebase from taking place when the new base image has no stack defined", func() {
+					it("errors and prevents the rebase from taking place when the new base image has no stack defined", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.bionic"))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, ""))
 
@@ -651,7 +731,7 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 						h.AssertError(t, err, "stack not defined on new base image")
 					})
 
-					it("returns an error and prevents the rebase from taking place when the app image has no stack defined", func() {
+					it("errors and prevents the rebase from taking place when the app image has no stack defined", func() {
 						h.AssertNil(t, fakeAppImage.SetLabel(platform.StackIDLabel, ""))
 						h.AssertNil(t, fakeNewBaseImage.SetLabel(platform.StackIDLabel, "io.buildpacks.stacks.cflinuxfs3"))
 
@@ -663,44 +743,68 @@ func testRebaser(t *testing.T, when spec.G, it spec.S) {
 
 			when("previous image was built using platform API >= 0.12", func() {
 				when("targets are different", func() {
-					it("returns an error and prevents the rebase from taking place when the os are different", func() {
-						h.AssertNil(t, fakeAppImage.SetOS("linux"))
-						h.AssertNil(t, fakeNewBaseImage.SetOS("notlinux"))
+					when("force", func() {
+						when("false", func() {
+							it.Before(func() {
+								rebaser.Force = false
+							})
 
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"notlinux","arch":"amd64"}, old run image: {"os":"linux","arch":"amd64"}`)
+							it("errors and prevents the rebase from taking place when the os are different", func() {
+								h.AssertNil(t, fakeAppImage.SetOS("linux"))
+								h.AssertNil(t, fakeNewBaseImage.SetOS("notlinux"))
+
+								_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+								h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"notlinux","arch":"amd64"}, old run image: {"os":"linux","arch":"amd64"}`)
+							})
+
+							it("errors and prevents the rebase from taking place when the architecture are different", func() {
+								h.AssertNil(t, fakeAppImage.SetArchitecture("amd64"))
+								h.AssertNil(t, fakeNewBaseImage.SetArchitecture("arm64"))
+
+								_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+								h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"arm64"}, old run image: {"os":"linux","arch":"amd64"}`)
+							})
+
+							it("errors and prevents the rebase from taking place when the architecture variant are different", func() {
+								h.AssertNil(t, fakeAppImage.SetVariant("variant1"))
+								h.AssertNil(t, fakeNewBaseImage.SetVariant("variant2"))
+
+								_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+								h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"amd64","arch-variant":"variant2"}, old run image: {"os":"linux","arch":"amd64","arch-variant":"variant1"}`)
+							})
+
+							it("errors and prevents the rebase from taking place when the io.buildpacks.distribution.name are different", func() {
+								h.AssertNil(t, fakeAppImage.SetLabel("io.buildpacks.distribution.name", "distro1"))
+								h.AssertNil(t, fakeNewBaseImage.SetLabel("io.buildpacks.distribution.name", "distro2"))
+
+								_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+								h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"amd64","distribution":{"name":"distro2","version":""}}, old run image: {"os":"linux","arch":"amd64","distribution":{"name":"distro1","version":""}}`)
+							})
+
+							it("errors and prevents the rebase from taking place when the io.buildpacks.distribution.version are different", func() {
+								h.AssertNil(t, fakeAppImage.SetLabel("io.buildpacks.distribution.version", "version1"))
+								h.AssertNil(t, fakeNewBaseImage.SetLabel("io.buildpacks.distribution.version", "version2"))
+
+								_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+								h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"amd64","distribution":{"name":"","version":"version2"}}, old run image: {"os":"linux","arch":"amd64","distribution":{"name":"","version":"version1"}}`)
+							})
+						})
 					})
 
-					it("returns an error and prevents the rebase from taking place when the architecture are different", func() {
-						h.AssertNil(t, fakeAppImage.SetArchitecture("amd64"))
-						h.AssertNil(t, fakeNewBaseImage.SetArchitecture("arm64"))
+					when("true", func() {
+						it.Before(func() {
+							rebaser.Force = true
+						})
 
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"arm64"}, old run image: {"os":"linux","arch":"amd64"}`)
-					})
+						it("warns and allows rebase when the os are different", func() {
+							h.AssertNil(t, fakeAppImage.SetOS("linux"))
+							h.AssertNil(t, fakeNewBaseImage.SetOS("notlinux"))
 
-					it("returns an error and prevents the rebase from taking place when the architecture variant are different", func() {
-						h.AssertNil(t, fakeAppImage.SetVariant("variant1"))
-						h.AssertNil(t, fakeNewBaseImage.SetVariant("variant2"))
+							_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
+							h.AssertNil(t, err)
 
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"amd64","arch-variant":"variant2"}, old run image: {"os":"linux","arch":"amd64","arch-variant":"variant1"}`)
-					})
-
-					it("returns an error and prevents the rebase from taking place when the io.buildpacks.distribution.name are different", func() {
-						h.AssertNil(t, fakeAppImage.SetLabel("io.buildpacks.distribution.name", "distro1"))
-						h.AssertNil(t, fakeNewBaseImage.SetLabel("io.buildpacks.distribution.name", "distro2"))
-
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"amd64","distribution":{"name":"distro2","version":""}}, old run image: {"os":"linux","arch":"amd64","distribution":{"name":"distro1","version":""}}`)
-					})
-
-					it("returns an error and prevents the rebase from taking place when the io.buildpacks.distribution.version are different", func() {
-						h.AssertNil(t, fakeAppImage.SetLabel("io.buildpacks.distribution.version", "version1"))
-						h.AssertNil(t, fakeNewBaseImage.SetLabel("io.buildpacks.distribution.version", "version2"))
-
-						_, err := rebaser.Rebase(fakeAppImage, fakeNewBaseImage, fakeAppImage.Name(), additionalNames)
-						h.AssertError(t, err, `unable to satisfy target os/arch constraints; new run image: {"os":"linux","arch":"amd64","distribution":{"name":"","version":"version2"}}, old run image: {"os":"linux","arch":"amd64","distribution":{"name":"","version":"version1"}}`)
+							assertLogEntry(t, logHandler, `unable to satisfy target os/arch constraints; new run image: {"os":"notlinux","arch":"amd64"}, old run image: {"os":"linux","arch":"amd64"}`)
+						})
 					})
 				})
 


### PR DESCRIPTION
* When deciding whether to update run image metadata, consider the platform API __of the rebaser__ vs the platform API of the previous image
* Warn whenever `--force` (that is provided) is needed to successfully complete the operation

Related discussion: https://github.com/buildpacks/lifecycle/issues/1098#issuecomment-1602849946