### PR TITLE
Fixes for run image extension

### DIFF
--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -396,7 +396,7 @@ fail: fail_detect_buildpack@some_version
 			var analyzed files.Analyzed
 			_, err = toml.DecodeFile(foundAnalyzedTOML, &analyzed)
 			h.AssertNil(t, err)
-			h.AssertEq(t, analyzed.RunImage.Reference, "some-run-image-from-extension")
+			h.AssertEq(t, analyzed.RunImage.Image, "some-run-image-from-extension")
 		})
 	})
 

--- a/acceptance/testdata/restorer/container/layers/some-extend-false-analyzed.toml.placeholder
+++ b/acceptance/testdata/restorer/container/layers/some-extend-false-analyzed.toml.placeholder
@@ -1,3 +1,3 @@
 [run-image]
-  reference = "REPLACE"
+  reference = ""
   image = "REPLACE"

--- a/acceptance/testdata/restorer/container/layers/some-extend-true-analyzed.toml.placeholder
+++ b/acceptance/testdata/restorer/container/layers/some-extend-true-analyzed.toml.placeholder
@@ -1,4 +1,4 @@
 [run-image]
-  reference = "REPLACE"
+  reference = ""
   extend = true
   image = "REPLACE"

--- a/analyzer.go
+++ b/analyzer.go
@@ -242,8 +242,14 @@ func (a *Analyzer) Analyze() (files.Analyzed, error) {
 	}
 
 	return files.Analyzed{
-		PreviousImage:  &files.ImageIdentifier{Reference: previousImageRef},
-		RunImage:       &files.RunImage{Reference: runImageRef, TargetMetadata: atm, Image: runImageName},
+		PreviousImage: &files.ImageIdentifier{
+			Reference: previousImageRef,
+		},
+		RunImage: &files.RunImage{
+			Reference:      runImageRef, // the image identifier, e.g. "s0m3d1g3st" (the image identifier) when exporting to a daemon, or "some.registry/some-repo@sha256:s0m3d1g3st" when exporting to a registry
+			TargetMetadata: atm,
+			Image:          runImageName, // the provided tag, e.g., "some.registry/some-repo:some-tag" if supported by the platform
+		},
 		LayersMetadata: appMeta,
 	}, nil
 }

--- a/buildpack/dockerfile.go
+++ b/buildpack/dockerfile.go
@@ -150,10 +150,8 @@ func ValidateRunDockerfile(dInfo *DockerfileInfo, logger log.Logger) error {
 		if stage.BaseName != baseImageArgRef {
 			newBase = stage.BaseName
 		}
-		for idx, command := range stage.Commands {
-			if idx > 0 {
-				extend = true
-			}
+		for _, command := range stage.Commands {
+			extend = true
 			found := false
 			for _, rc := range recommendedCommands {
 				if rc == strings.ToUpper(command.Name()) {

--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -131,6 +131,8 @@ func (a *analyzeCmd) Exec() error {
 	if err != nil {
 		return cmd.FailErrCode(err, a.CodeFor(platform.AnalyzeError), "analyze")
 	}
+	cmd.DefaultLogger.Debugf("Run image info in analyzed metadata is: ")
+	cmd.DefaultLogger.Debugf(encoding.ToJSONMaybe(analyzedMD.RunImage))
 	if err = encoding.WriteTOML(a.AnalyzedPath, analyzedMD); err != nil {
 		return cmd.FailErr(err, "write analyzed")
 	}

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -182,6 +182,8 @@ func (d *detectCmd) writeDetectData(group buildpack.Group, plan files.Plan) erro
 
 // writeGenerateData re-outputs the analyzedMD that we read previously, but now we've added the RunImage, if a custom runImage was configured
 func (d *detectCmd) writeGenerateData(analyzedMD files.Analyzed) error {
+	cmd.DefaultLogger.Debugf("Run image info in analyzed metadata is: ")
+	cmd.DefaultLogger.Debugf(encoding.ToJSONMaybe(analyzedMD.RunImage))
 	if err := encoding.WriteTOML(d.AnalyzedPath, analyzedMD); err != nil {
 		return cmd.FailErr(err, "write analyzed metadata")
 	}

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -234,16 +234,6 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore lifecycle.Cache, an
 }
 
 func (e *exportCmd) initDaemonAppImage(analyzedMD files.Analyzed) (imgutil.Image, string, error) {
-	if isDigestRef(e.RunImageRef) {
-		// If extensions were used to extend the runtime base image, the run image reference will contain a digest.
-		// The restorer uses a name reference to pull the image from the registry (because the extender needs a manifest),
-		// and writes a digest reference to analyzed.toml.
-		// For remote images, this works perfectly well.
-		// However for local images, the daemon can't find the image when the reference contains a digest,
-		// so we use image name from analyzed.toml which is the reference written by the extension.
-		e.RunImageRef = analyzedMD.RunImageImage()
-	}
-
 	var opts = []local.ImageOption{
 		local.FromBaseImage(e.RunImageRef),
 	}

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -295,14 +295,6 @@ func (e *exportCmd) initDaemonAppImage(analyzedMD files.Analyzed) (imgutil.Image
 	return appImage, runImageID.String(), nil
 }
 
-func isDigestRef(ref string) bool {
-	digest, err := name.NewDigest(ref)
-	if err != nil {
-		return false
-	}
-	return digest.DigestStr() != ""
-}
-
 func toContainerConfig(v1C *v1.Config) *container.Config {
 	return &container.Config{
 		ArgsEscaped:     v1C.ArgsEscaped,

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -356,6 +356,7 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 			return nil, "", cmd.FailErr(err, "get extended image config")
 		}
 		if extendedConfig != nil {
+			cmd.DefaultLogger.Debugf("Using config from extensions...")
 			opts = append(opts, remote.WithConfig(extendedConfig))
 		}
 	}

--- a/generator_test.go
+++ b/generator_test.go
@@ -394,21 +394,22 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 
 				generator.AnalyzedMD = files.Analyzed{
 					RunImage: &files.RunImage{
-						Reference: "some-existing-run-image",
+						Reference: "some-existing-run-image@sha256:s0m3d1g3st",
+						Image:     "some-existing-run-image",
 					},
 				}
 			})
 
 			type testCase struct {
-				before                    func()
-				descCondition             string
-				descResult                string
-				aDockerfiles              []buildpack.DockerfileInfo
-				bDockerfiles              []buildpack.DockerfileInfo
-				expectedRunImageReference string
-				expectedRunImageExtend    bool
-				expectedErr               string
-				assertAfter               func()
+				before                 func()
+				descCondition          string
+				descResult             string
+				aDockerfiles           []buildpack.DockerfileInfo
+				bDockerfiles           []buildpack.DockerfileInfo
+				expectedRunImageImage  string
+				expectedRunImageExtend bool
+				expectedErr            string
+				assertAfter            func()
 			}
 			for _, tc := range []testCase{
 				{
@@ -428,8 +429,8 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 						WithBase:    "",
 						Extend:      true,
 					}},
-					expectedRunImageReference: "some-existing-run-image",
-					expectedRunImageExtend:    true,
+					expectedRunImageImage:  "some-existing-run-image",
+					expectedRunImageExtend: true,
 				},
 				{
 					descCondition: "a run.Dockerfile declares a new base image and run.Dockerfiles follow",
@@ -452,8 +453,8 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							Extend:      true,
 						},
 					},
-					expectedRunImageReference: "some-new-run-image",
-					expectedRunImageExtend:    true,
+					expectedRunImageImage:  "some-new-run-image",
+					expectedRunImageExtend: true,
 				},
 				{
 					descCondition: "a run.Dockerfile declares a new base image (only) and no run.Dockerfiles follow",
@@ -476,8 +477,8 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							Extend:      false,
 						},
 					},
-					expectedRunImageReference: "some-other-base-image",
-					expectedRunImageExtend:    false,
+					expectedRunImageImage:  "some-other-base-image",
+					expectedRunImageExtend: false,
 					assertAfter: func() {
 						t.Log("copies Dockerfiles to the correct locations")
 						t.Log("renames earlier run.Dockerfiles to Dockerfile.ignore in the output directory")
@@ -499,9 +500,9 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							Extend:      true,
 						},
 					},
-					bDockerfiles:              []buildpack.DockerfileInfo{},
-					expectedRunImageReference: "some-new-run-image",
-					expectedRunImageExtend:    true,
+					bDockerfiles:           []buildpack.DockerfileInfo{},
+					expectedRunImageImage:  "some-new-run-image",
+					expectedRunImageExtend: true,
 				},
 				{
 					before: func() {
@@ -522,9 +523,9 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							Extend:      false,
 						},
 					},
-					bDockerfiles:              []buildpack.DockerfileInfo{},
-					expectedRunImageReference: "some-new-run-image",
-					expectedRunImageExtend:    false,
+					bDockerfiles:           []buildpack.DockerfileInfo{},
+					expectedRunImageImage:  "some-new-run-image",
+					expectedRunImageExtend: false,
 				},
 				{
 					before: func() {
@@ -545,8 +546,8 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							Extend:      false,
 						},
 					},
-					bDockerfiles:              []buildpack.DockerfileInfo{},
-					expectedRunImageReference: "some-other-run-image",
+					bDockerfiles:          []buildpack.DockerfileInfo{},
+					expectedRunImageImage: "some-other-run-image",
 					assertAfter: func() {
 						h.AssertLogEntry(t, logHandler, "new runtime base image 'some-other-run-image' not found in run metadata")
 					},
@@ -575,7 +576,7 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 						// do generate
 						result, err := generator.Generate()
 						if err == nil {
-							h.AssertEq(t, result.AnalyzedMD.RunImage.Reference, tc.expectedRunImageReference)
+							h.AssertEq(t, result.AnalyzedMD.RunImage.Image, tc.expectedRunImageImage)
 							h.AssertEq(t, result.AnalyzedMD.RunImage.Extend, tc.expectedRunImageExtend)
 						} else {
 							t.Log(err)

--- a/handlers.go
+++ b/handlers.go
@@ -39,7 +39,7 @@ type BuildpackAPIVerifier interface {
 
 //go:generate mockgen -package testmock -destination testmock/config_handler.go github.com/buildpacks/lifecycle ConfigHandler
 type ConfigHandler interface {
-	ReadAnalyzed(path string, logr log.Logger) (files.Analyzed, error)
+	ReadAnalyzed(path string, logger log.Logger) (files.Analyzed, error)
 	ReadGroup(path string) (buildpackGroup []buildpack.GroupElement, extensionsGroup []buildpack.GroupElement, err error)
 	ReadOrder(path string) (buildpack.Order, buildpack.Order, error)
 	ReadRun(runPath string, logger log.Logger) (files.Run, error)

--- a/internal/encoding/utils.go
+++ b/internal/encoding/utils.go
@@ -12,7 +12,13 @@ import (
 
 // json
 
+// ToJSONMaybe returns the provided interface as JSON if marshaling is successful,
+// or as a string if an error is encountered.
+// It is only intended to be used for logging.
 func ToJSONMaybe(v interface{}) string {
+	if v == nil {
+		return ""
+	}
 	b, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Sprintf("%s", v) // hopefully v is a Stringer

--- a/internal/name/ref.go
+++ b/internal/name/ref.go
@@ -1,10 +1,32 @@
 package name
 
-import "github.com/google/go-containerregistry/pkg/name"
+import (
+	"strings"
 
-func ParseMaybe(ref string) string {
-	if nameRef, err := name.ParseReference(ref); err == nil {
-		return nameRef.Name()
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+// ParseMaybe attempts to parse the provided reference as a GGCR `name.Reference`, returning a modified `reference.Name()` if parsing is successful.
+// Unlike GGCR's `reference.Name()`, `ParseMaybe` will strip the digest portion of the reference,
+// retaining the provided tag or adding a `latest` tag if no tag is provided.
+// This is to aid in comparing two references when we really care about image names and not about image digests,
+// such as when populating `files.RunImageForRebase` information on an exported image.
+func ParseMaybe(provided string) string {
+	toParse := provided
+	if hasDigest(provided) {
+		toParse = trimDigest(provided)
 	}
-	return ref
+	if ref, err := name.ParseReference(toParse); err == nil {
+		return ref.Name()
+	}
+	return provided
+}
+
+func hasDigest(ref string) bool {
+	return strings.Contains(ref, "@sha256:")
+}
+
+func trimDigest(ref string) string {
+	parts := strings.Split(ref, "@")
+	return parts[0]
 }

--- a/internal/name/ref_test.go
+++ b/internal/name/ref_test.go
@@ -16,47 +16,72 @@ func TestRef(t *testing.T) {
 func testRef(t *testing.T, when spec.G, it spec.S) {
 	when(".ParseMaybe", func() {
 		when("provided reference", func() {
-			when("invalid", func() {
-				it("returns the provided reference", func() {
-					got := name.ParseMaybe("!@#$")
-					h.AssertEq(t, got, "!@#$")
-				})
-			})
-
-			when("has implicit registry", func() {
-				it("returns the fully qualified reference", func() {
-					got := name.ParseMaybe("some-library/some-repo:latest")
-					h.AssertEq(t, got, "index.docker.io/some-library/some-repo:latest")
-				})
-			})
-
-			when("has implicit library", func() {
-				it("returns the provided reference", func() {
-					got := name.ParseMaybe("some.registry/some-repo:latest")
-					h.AssertEq(t, got, "some.registry/some-repo:latest")
-				})
-
-				when("registry is docker.io", func() {
-					it("returns the fully qualified reference", func() {
-						got := name.ParseMaybe("index.docker.io/some-repo:latest")
-						h.AssertEq(t, got, "index.docker.io/library/some-repo:latest")
+			type testCase struct {
+				condition string
+				provided  string
+				does      string
+				expected  string
+			}
+			testCases := []testCase{
+				{
+					condition: "is invalid",
+					provided:  "!@#$",
+					does:      "returns the provided reference",
+					expected:  "!@#$",
+				},
+				{
+					condition: "has an implicit registry",
+					provided:  "some-library/some-repo:some-tag",
+					does:      "adds an explicit registry",
+					expected:  "index.docker.io/some-library/some-repo:some-tag",
+				},
+				{
+					condition: "has an implicit library",
+					provided:  "some.registry/some-repo:some-tag",
+					does:      "returns the provided reference",
+					expected:  "some.registry/some-repo:some-tag",
+				},
+				{
+					condition: "has an implicit library and has registry index.docker.io",
+					provided:  "index.docker.io/some-repo:some-tag",
+					does:      "adds an explicit library",
+					expected:  "index.docker.io/library/some-repo:some-tag",
+				},
+				{
+					condition: "has an implicit tag",
+					provided:  "some.registry/some-library/some-repo",
+					does:      "adds an explicit tag",
+					expected:  "some.registry/some-library/some-repo:latest",
+				},
+				{
+					condition: "has an implicit tag and has a digest",
+					provided:  "some.registry/some-library/some-repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					does:      "adds an explicit tag and removes the digest",
+					expected:  "some.registry/some-library/some-repo:latest",
+				},
+				{
+					condition: "has an explicit tag",
+					provided:  "some.registry/some-library/some-repo:some-tag",
+					does:      "returns the provided reference",
+					expected:  "some.registry/some-library/some-repo:some-tag",
+				},
+				{
+					condition: "has an explicit tag and has a digest",
+					provided:  "some.registry/some-library/some-repo:some-tag@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+					does:      "removes the digest",
+					expected:  "some.registry/some-library/some-repo:some-tag",
+				},
+			}
+			for _, tc := range testCases {
+				tc := tc
+				w := when
+				w(tc.condition, func() {
+					it(tc.does, func() {
+						actual := name.ParseMaybe(tc.provided)
+						h.AssertEq(t, actual, tc.expected)
 					})
 				})
-			})
-
-			when("has implicit tag", func() {
-				it("returns the fully qualified reference", func() {
-					got := name.ParseMaybe("some.registry/some-library/some-repo")
-					h.AssertEq(t, got, "some.registry/some-library/some-repo:latest")
-				})
-			})
-
-			when("is fully qualified", func() {
-				it("returns the provided reference", func() {
-					got := name.ParseMaybe("some.registry/some-library/some-repo:some-tag")
-					h.AssertEq(t, got, "some.registry/some-library/some-repo:some-tag")
-				})
-			})
+			}
 		})
 	})
 }

--- a/platform/files/analyzed.go
+++ b/platform/files/analyzed.go
@@ -125,8 +125,10 @@ type RunImageForRebase struct {
 	RunImageForExport
 }
 
-func (r *RunImageForRebase) Contains(ref string) bool {
-	return r.RunImageForExport.Contains(ref)
+// Contains returns true if the provided image reference is found in the existing metadata,
+// removing the digest portion of the reference when determining if two image names are equivalent.
+func (r *RunImageForRebase) Contains(providedImage string) bool {
+	return r.RunImageForExport.Contains(providedImage)
 }
 
 func (r *RunImageForRebase) ToStack() Stack {

--- a/platform/files/analyzed.go
+++ b/platform/files/analyzed.go
@@ -140,9 +140,9 @@ func (r *RunImageForRebase) ToStack() Stack {
 
 type RunImage struct {
 	Reference string `toml:"reference"`
-	// Image specifies the repository name for the image.
+	// Image specifies the repository name for the image that was provided - either by the platform, or by extensions.
 	// When exporting to a daemon, the restorer uses this field to pull the run image if needed for the extender;
-	// it can't use reference because this may be a daemon image ID if analyzed.toml was last written by the analyzer.
+	// it can't use `Reference` because this may be a daemon image ID if analyzed.toml was last written by the analyzer.
 	Image string `toml:"image,omitempty"`
 	// Extend if true indicates that the run image should be extended by the extender.
 	Extend         bool            `toml:"extend,omitempty"`

--- a/platform/files/run.go
+++ b/platform/files/run.go
@@ -17,6 +17,17 @@ type Run struct {
 	Images []RunImageForExport `json:"-" toml:"images"`
 }
 
+// Contains returns true if the provided image reference is found in the existing metadata,
+// removing the digest portion of the reference when determining if two image names are equivalent.
+func (r *Run) Contains(providedImage string) bool {
+	for _, i := range r.Images {
+		if i.Contains(providedImage) {
+			return true
+		}
+	}
+	return false
+}
+
 func ReadRun(runPath string, logger log.Logger) (Run, error) {
 	var runMD Run
 	if _, err := toml.DecodeFile(runPath, &runMD); err != nil {

--- a/platform/files/stack.go
+++ b/platform/files/stack.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
-	"github.com/buildpacks/lifecycle/internal/name"
+	iname "github.com/buildpacks/lifecycle/internal/name"
 	"github.com/buildpacks/lifecycle/log"
 )
 
@@ -23,15 +23,15 @@ type RunImageForExport struct {
 	Mirrors []string `toml:"mirrors,omitempty" json:"mirrors,omitempty"`
 }
 
-// Contains returns true if the provided reference matches either the primary image,
-// or the image mirrors.
-func (r *RunImageForExport) Contains(ref string) bool {
-	ref = name.ParseMaybe(ref)
-	if name.ParseMaybe(r.Image) == ref {
+// Contains returns true if the provided image reference is found in the existing metadata,
+// removing the digest portion of the reference when determining if two image names are equivalent.
+func (r *RunImageForExport) Contains(providedImage string) bool {
+	providedImage = iname.ParseMaybe(providedImage)
+	if iname.ParseMaybe(r.Image) == providedImage {
 		return true
 	}
 	for _, m := range r.Mirrors {
-		if name.ParseMaybe(m) == ref {
+		if iname.ParseMaybe(m) == providedImage {
 			return true
 		}
 	}

--- a/platform/resolve_analyze_inputs_test.go
+++ b/platform/resolve_analyze_inputs_test.go
@@ -95,7 +95,7 @@ func testResolveAnalyzeInputs(platformAPI string) func(t *testing.T, when spec.G
 						inputs.StackPath = filepath.Join("testdata", "layers", "stack.toml")
 						err := platform.ResolveInputs(platform.Analyze, inputs, logger)
 						h.AssertNil(t, err)
-						h.AssertEq(t, inputs.RunImageRef, "some-run-image-from-stack-toml")
+						h.AssertEq(t, inputs.RunImageRef, "some-other-user-provided-run-image")
 					})
 
 					when("stack.toml", func() {

--- a/platform/resolve_create_inputs_test.go
+++ b/platform/resolve_create_inputs_test.go
@@ -94,7 +94,7 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 						inputs.StackPath = filepath.Join("testdata", "layers", "stack.toml")
 						err := platform.ResolveInputs(platform.Create, inputs, logger)
 						h.AssertNil(t, err)
-						h.AssertEq(t, inputs.RunImageRef, "some-run-image-from-stack-toml")
+						h.AssertEq(t, inputs.RunImageRef, "some-other-user-provided-run-image")
 					})
 
 					when("stack.toml", func() {

--- a/platform/run_image.go
+++ b/platform/run_image.go
@@ -63,7 +63,18 @@ func byRegistry(reg string, images []string, checkReadAccess CheckReadAccess, ke
 	return ""
 }
 
-// GetRunImageForExport TODO
+// GetRunImageForExport takes platform inputs and returns run image information
+// for populating the io.buildpacks.lifecycle.metadata on the exported app image.
+// The run image information is read from:
+// - stack.toml for older platforms
+// - run.toml for newer platforms, where the run image information returned is
+//   - the first set of image & mirrors that contains the platform-provided run image, or
+//   - the platform-provided run image if extensions were used and the image was not found, or
+//   - the first set of image & mirrors in run.toml
+//
+// The "platform-provided run image" is the run image "image" in analyzed.toml,
+// NOT the run image "reference",
+// as the run image "reference" could be a daemon image ID (which we'd not expect to find in run.toml).
 func GetRunImageForExport(inputs LifecycleInputs) (files.RunImageForExport, error) {
 	if inputs.PlatformAPI.LessThan("0.12") {
 		stackMD, err := files.ReadStack(inputs.StackPath, cmd.DefaultLogger)

--- a/platform/run_image.go
+++ b/platform/run_image.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/buildpacks/lifecycle/auth"
 	"github.com/buildpacks/lifecycle/cmd"
-	iname "github.com/buildpacks/lifecycle/internal/name"
 	"github.com/buildpacks/lifecycle/launch"
 	"github.com/buildpacks/lifecycle/platform/files"
 )
@@ -19,43 +18,6 @@ const (
 	OSDistributionNameLabel    = "io.buildpacks.distribution.name"
 	OSDistributionVersionLabel = "io.buildpacks.distribution.version"
 )
-
-func GetRunImageForExport(inputs LifecycleInputs) (files.RunImageForExport, error) {
-	if inputs.PlatformAPI.LessThan("0.12") {
-		stackMD, err := files.ReadStack(inputs.StackPath, cmd.DefaultLogger)
-		if err != nil {
-			return files.RunImageForExport{}, err
-		}
-		return stackMD.RunImage, nil
-	}
-	runMD, err := files.ReadRun(inputs.RunPath, cmd.DefaultLogger)
-	if err != nil {
-		return files.RunImageForExport{}, err
-	}
-	if len(runMD.Images) == 0 {
-		return files.RunImageForExport{}, nil
-	}
-	inputRef := iname.ParseMaybe(inputs.RunImageRef)
-	for _, runImage := range runMD.Images {
-		if iname.ParseMaybe(runImage.Image) == inputRef {
-			return runImage, nil
-		}
-		for _, mirror := range runImage.Mirrors {
-			if iname.ParseMaybe(mirror) == inputRef {
-				return runImage, nil
-			}
-		}
-	}
-	buildMD := &files.BuildMetadata{}
-	if err = files.DecodeBuildMetadata(launch.GetMetadataFilePath(inputs.LayersDir), inputs.PlatformAPI, buildMD); err != nil {
-		return files.RunImageForExport{}, err
-	}
-	if len(buildMD.Extensions) > 0 {
-		// Extensions could have switched the run image, so we can't assume the first run image in run.toml was intended
-		return files.RunImageForExport{Image: inputs.RunImageRef}, nil
-	}
-	return runMD.Images[0], nil
-}
 
 func BestRunImageMirrorFor(targetRegistry string, runImageMD files.RunImageForExport, checkReadAccess CheckReadAccess) (string, error) {
 	var runImageMirrors []string
@@ -99,4 +61,40 @@ func byRegistry(reg string, images []string, checkReadAccess CheckReadAccess, ke
 		}
 	}
 	return ""
+}
+
+// GetRunImageForExport TODO
+func GetRunImageForExport(inputs LifecycleInputs) (files.RunImageForExport, error) {
+	if inputs.PlatformAPI.LessThan("0.12") {
+		stackMD, err := files.ReadStack(inputs.StackPath, cmd.DefaultLogger)
+		if err != nil {
+			return files.RunImageForExport{}, err
+		}
+		return stackMD.RunImage, nil
+	}
+	runMD, err := files.ReadRun(inputs.RunPath, cmd.DefaultLogger)
+	if err != nil {
+		return files.RunImageForExport{}, err
+	}
+	if len(runMD.Images) == 0 {
+		return files.RunImageForExport{}, nil
+	}
+	analyzedMD, err := files.ReadAnalyzed(inputs.AnalyzedPath, cmd.DefaultLogger)
+	if err != nil {
+		return files.RunImageForExport{}, err
+	}
+	for _, runImage := range runMD.Images {
+		if runImage.Contains(analyzedMD.RunImageImage()) {
+			return runImage, nil
+		}
+	}
+	buildMD := &files.BuildMetadata{}
+	if err = files.DecodeBuildMetadata(launch.GetMetadataFilePath(inputs.LayersDir), inputs.PlatformAPI, buildMD); err != nil {
+		return files.RunImageForExport{}, err
+	}
+	if len(buildMD.Extensions) > 0 { // FIXME: try to know for sure if extensions were used to switch the run image
+		// Extensions could have switched the run image, so we can't assume the first run image in run.toml was intended
+		return files.RunImageForExport{Image: analyzedMD.RunImageImage()}, nil
+	}
+	return runMD.Images[0], nil
 }

--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -29,9 +29,6 @@ func EnvVarsFor(tm files.TargetMetadata) []string {
 
 func GetTargetMetadata(fromImage imgutil.Image) (*files.TargetMetadata, error) {
 	tm := files.TargetMetadata{}
-	if !fromImage.Found() {
-		return &tm, nil
-	}
 	var err error
 	tm.OS, err = fromImage.OS()
 	if err != nil {

--- a/platform/testdata/layers/analyzed-docker.toml
+++ b/platform/testdata/layers/analyzed-docker.toml
@@ -1,0 +1,2 @@
+[run-image]
+  image = "index.docker.io/some-user-provided-run-image"

--- a/platform/testdata/layers/analyzed-mirror.toml
+++ b/platform/testdata/layers/analyzed-mirror.toml
@@ -1,0 +1,2 @@
+[run-image]
+  image = "some-user-provided-run-image-mirror-1"

--- a/platform/testdata/layers/analyzed-other.toml
+++ b/platform/testdata/layers/analyzed-other.toml
@@ -1,0 +1,2 @@
+[run-image]
+  image = "some-new-user-provided-run-image"

--- a/platform/testdata/layers/analyzed.toml
+++ b/platform/testdata/layers/analyzed.toml
@@ -1,0 +1,2 @@
+[run-image]
+  image = "some-user-provided-run-image"

--- a/platform/testdata/layers/run.toml
+++ b/platform/testdata/layers/run.toml
@@ -1,7 +1,7 @@
 [[images]]
- image = "some-run-image-from-run-toml"
- mirrors = ["some-run-image-mirror-from-run-toml", "some-other-run-image-mirror-from-run-toml"]
+ image = "some-other-user-provided-run-image"
+ mirrors = ["some-other-user-provided-run-image-mirror-1", "some-other-user-provided-run-image-mirror-2"]
 
 [[images]]
- image = "some-run-image-from-run-toml-1"
- mirrors = ["some-run-image-mirror-from-run-toml-1", "some-other-run-image-mirror-from-run-toml-1"]
+ image = "some-user-provided-run-image"
+ mirrors = ["some-user-provided-run-image-mirror-1", "some-user-provided-run-image-mirror-2"]

--- a/platform/testdata/layers/stack.toml
+++ b/platform/testdata/layers/stack.toml
@@ -1,3 +1,3 @@
 [run-image]
- image = "some-run-image-from-stack-toml"
- mirrors = ["some-run-image-mirror-from-stack-toml", "some-other-run-image-mirror-from-stack-toml"]
+ image = "some-other-user-provided-run-image"
+ mirrors = ["some-other-user-provided-run-image-mirror-1", "some-other-user-provided-run-image-mirror-2"]


### PR DESCRIPTION
- When pulling remote image data during `restore`, fail if the remote image is not found
- When validating dockerfiles during `generate`, set extend to true if there are any instructions (vs more than one instruction)
- Update matching logic when considering if two image names are equivalent to ignore the digest portion of the reference if present (for the purpose of selecting data from run.toml to add to the lifecycle metadata label during `export` i.e., “run image for rebase”)
- During `export`, continue to use run image identifier (which could be a digest reference or daemon image ID) as the run image reference instead of falling back to image name when exporting to a daemon
- When finding the run image info during `export`, use the run image "image" (name) in analyzed.toml as the search key, because the run image "reference" could be a daemon image ID or include the digest, which isn't helpful when retrieving image names that are supposed to float