### PR TITLE
Require the CNB_PLATFORM_API env var to be set

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -142,6 +142,7 @@ func testVersion(t *testing.T, when spec.G, it spec.S) {
 				w(tc.description, func() {
 					it("only prints the version", func() {
 						cmd := lifecycleCmd(tc.command, tc.args...)
+						cmd.Env = []string{fmt.Sprintf("CNB_PLATFORM_API=%s", api.Platform.Latest().String())}
 						output, err := cmd.CombinedOutput()
 						if err != nil {
 							t.Fatalf("failed to run %v\n OUTPUT: %s\n ERROR: %s\n", cmd.Args, output, err)

--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -69,6 +69,23 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 			os.RemoveAll(copyDir)
 		})
 
+		when("CNB_PLATFORM_API not provided", func() {
+			it("errors", func() {
+				cmd := exec.Command(
+					"docker", "run", "--rm",
+					"--env", "CNB_PLATFORM_API= ",
+					analyzeImage,
+					ctrPath(analyzerPath),
+					"some-image",
+				) // #nosec G204
+				output, err := cmd.CombinedOutput()
+
+				h.AssertNotNil(t, err)
+				expected := "please set 'CNB_PLATFORM_API'"
+				h.AssertStringContains(t, string(output), expected)
+			})
+		})
+
 		when("called without an app image", func() {
 			it("errors", func() {
 				cmd := exec.Command(

--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -89,10 +89,12 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("appends any args to the process args", func() {
-				cmd := exec.Command("docker", "run", "--rm",
+				cmd := exec.Command( //nolint
+					"docker", "run", "--rm",
 					"--entrypoint=web",
 					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
-					launchImage, "with user provided args")
+					launchImage, "with user provided args",
+				)
 				if runtime.GOOS == "windows" {
 					assertOutput(t, cmd, `Executing web process-type "with user provided args"`)
 				} else {
@@ -103,15 +105,20 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 		when("entrypoint is a not a process", func() {
 			it("builds a process from the arguments", func() {
-				cmd := exec.Command("docker", "run", "--rm",
+				cmd := exec.Command( //nolint
+					"docker", "run", "--rm",
 					"--entrypoint=launcher",
 					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
-					launchImage, "--", "env")
+					launchImage, "--",
+					"env",
+				)
 				if runtime.GOOS == "windows" {
-					cmd = exec.Command("docker", "run", "--rm",
+					cmd = exec.Command( //nolint
+						"docker", "run", "--rm",
 						`--entrypoint=launcher`,
 						"--env=CNB_PLATFORM_API=0.4",
-						launchImage, "--", "cmd", "/c", "set",
+						launchImage, "--",
+						"cmd", "/c", "set",
 					)
 				}
 
@@ -254,14 +261,29 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 	when("provided CMD is not a process-type", func() {
 		it("sources profiles and executes the command in a shell", func() {
-			cmd := exec.Command("docker", "run", "--rm", launchImage, "echo", "something")
+			cmd := exec.Command( //nolint
+				"docker", "run", "--rm",
+				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+				launchImage,
+				"echo", "something",
+			)
 			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsomething")
 		})
 
 		it("sets env vars from layers", func() {
-			cmd := exec.Command("docker", "run", "--rm", launchImage, "echo", "$SOME_VAR", "$OTHER_VAR", "$WORKER_VAR")
+			cmd := exec.Command( //nolint
+				"docker", "run", "--rm",
+				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+				launchImage,
+				"echo", "$SOME_VAR", "$OTHER_VAR", "$WORKER_VAR",
+			)
 			if runtime.GOOS == "windows" {
-				cmd = exec.Command("docker", "run", "--rm", launchImage, "echo", "%SOME_VAR%", "%OTHER_VAR%", "%WORKER_VAR%")
+				cmd = exec.Command( //nolint
+					"docker", "run", "--rm",
+					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+					launchImage,
+					"echo", "%SOME_VAR%", "%OTHER_VAR%", "%WORKER_VAR%",
+				)
 			}
 			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsome-bp-val other-bp-val worker-no-process-val")
 		})
@@ -276,6 +298,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 					[]string{
 						"run", "--rm",
 						"--env", "CNB_APP_DIR=" + ctrPath("/workspace"),
+						"--env=CNB_PLATFORM_API=" + latestPlatformAPI,
 						"--env", "SOME_USER_VAR=some-user-val",
 						"--env", "OTHER_VAR=other-user-val",
 						launchImage,
@@ -293,7 +316,12 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("adds buildpack bin dirs to the path", func() {
-			cmd := exec.Command("docker", "run", "--rm", launchImage, "bp-executable")
+			cmd := exec.Command( //nolint
+				"docker", "run", "--rm",
+				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+				launchImage,
+				"bp-executable",
+			)
 			assertOutput(t, cmd, "bp executable")
 		})
 	})
@@ -301,18 +329,38 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 	when("CMD provided starts with --", func() {
 		it("launches command directly", func() {
 			if runtime.GOOS == "windows" {
-				cmd := exec.Command("docker", "run", "--rm", launchImage, "--", "ping", "/?")
+				cmd := exec.Command( //nolint
+					"docker", "run", "--rm",
+					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+					launchImage, "--",
+					"ping", "/?",
+				)
 				assertOutput(t, cmd, "Usage: ping")
 			} else {
-				cmd := exec.Command("docker", "run", "--rm", launchImage, "--", "echo", "something")
+				cmd := exec.Command( //nolint
+					"docker", "run", "--rm",
+					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+					launchImage, "--",
+					"echo", "something",
+				)
 				assertOutput(t, cmd, "something")
 			}
 		})
 
 		it("sets env vars from layers", func() {
-			cmd := exec.Command("docker", "run", "--rm", launchImage, "--", "env")
+			cmd := exec.Command( //nolint
+				"docker", "run", "--rm",
+				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+				launchImage, "--",
+				"env",
+			)
 			if runtime.GOOS == "windows" {
-				cmd = exec.Command("docker", "run", "--rm", launchImage, "--", "cmd", "/c", "set")
+				cmd = exec.Command( //nolint
+					"docker", "run", "--rm",
+					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+					launchImage, "--",
+					"cmd", "/c", "set",
+				)
 			}
 
 			assertOutput(t, cmd,
@@ -322,15 +370,19 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("passes through env vars from user, excluding excluded vars", func() {
-			cmd := exec.Command("docker", "run", "--rm",
+			cmd := exec.Command( //nolint
+				"docker", "run", "--rm",
 				"--env", "CNB_APP_DIR=/workspace",
+				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
 				"--env", "SOME_USER_VAR=some-user-val",
 				launchImage, "--",
 				"env",
 			)
 			if runtime.GOOS == "windows" {
-				cmd = exec.Command("docker", "run", "--rm",
+				cmd = exec.Command( //nolint
+					"docker", "run", "--rm",
 					"--env", "CNB_APP_DIR=/workspace",
+					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
 					"--env", "SOME_USER_VAR=some-user-val",
 					launchImage, "--",
 					"cmd", "/c", "set",
@@ -352,7 +404,12 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("adds buildpack bin dirs to the path before looking up command", func() {
-			cmd := exec.Command("docker", "run", "--rm", launchImage, "--", "bp-executable")
+			cmd := exec.Command( //nolint
+				"docker", "run", "--rm",
+				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
+				launchImage, "--",
+				"bp-executable",
+			)
 			assertOutput(t, cmd, "bp executable")
 		})
 	})

--- a/acceptance/phase_test.go
+++ b/acceptance/phase_test.go
@@ -127,7 +127,12 @@ func (p *PhaseTest) Start(t *testing.T, phaseOp ...func(*testing.T, *PhaseTest))
 
 	h.MakeAndCopyLifecycle(t, p.targetDaemon.os, p.targetDaemon.arch, p.containerBinaryDir)
 	copyFakeSboms(t)
-	h.DockerBuild(t, p.testImageRef, p.testImageDockerContext, h.WithArgs("-f", filepath.Join(p.testImageDockerContext, dockerfileName)))
+	h.DockerBuild(
+		t,
+		p.testImageRef,
+		p.testImageDockerContext,
+		h.WithArgs("-f", filepath.Join(p.testImageDockerContext, dockerfileName)),
+	)
 }
 
 func (p *PhaseTest) Stop(t *testing.T) {

--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -70,7 +70,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 
 		when("called with arguments", func() {
 			it("errors", func() {
-				command := exec.Command("docker", "run", "--rm", restoreImage, "some-arg")
+				command := exec.Command("docker", "run", "--rm", "--env", "CNB_PLATFORM_API="+platformAPI, restoreImage, "some-arg")
 				output, err := command.CombinedOutput()
 				h.AssertNotNil(t, err)
 				expected := "failed to parse arguments: received unexpected Args"
@@ -81,7 +81,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 		when("called with -analyzed (on older platforms)", func() {
 			it("errors", func() {
 				h.SkipIf(t, api.MustParse(platformAPI).AtLeast("0.7"), "Platform API >= 0.7 supports -analyzed flag")
-				command := exec.Command("docker", "run", "--rm", restoreImage, "-analyzed some-file-location")
+				command := exec.Command("docker", "run", "--rm", "--env", "CNB_PLATFORM_API="+platformAPI, restoreImage, "-analyzed some-file-location")
 				output, err := command.CombinedOutput()
 				h.AssertNotNil(t, err)
 				expected := "flag provided but not defined: -analyzed"
@@ -92,7 +92,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 		when("called with -skip-layers (on older platforms)", func() {
 			it("errors", func() {
 				h.SkipIf(t, api.MustParse(platformAPI).AtLeast("0.7"), "Platform API >= 0.7 supports -skip-layers flag")
-				command := exec.Command("docker", "run", "--rm", restoreImage, "-skip-layers true")
+				command := exec.Command("docker", "run", "--rm", "--env", "CNB_PLATFORM_API="+platformAPI, restoreImage, "-skip-layers true")
 				output, err := command.CombinedOutput()
 				h.AssertNotNil(t, err)
 				expected := "flag provided but not defined: -skip-layers"

--- a/acceptance/testdata/analyzer/Dockerfile
+++ b/acceptance/testdata/analyzer/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:bionic
-ARG cnb_platform_api
 
 RUN apt-get update && apt-get install -y ca-certificates
 
@@ -11,6 +10,7 @@ ENV CNB_USER_ID=2222
 
 ENV CNB_GROUP_ID=3333
 
+ARG cnb_platform_api
 ENV CNB_PLATFORM_API=${cnb_platform_api}
 
 RUN chown -R $CNB_USER_ID:$CNB_GROUP_ID /some-dir

--- a/cmd/apis.go
+++ b/cmd/apis.go
@@ -10,6 +10,8 @@ import (
 )
 
 const (
+	// EnvPlatformAPI configures the Platform API version.
+	EnvPlatformAPI         = "CNB_PLATFORM_API"
 	EnvDeprecationMode     = "CNB_DEPRECATION_MODE"
 	DefaultDeprecationMode = ModeWarn
 
@@ -64,6 +66,13 @@ func buildpackAPIError(moduleKind string, name string, requested string) error {
 }
 
 func VerifyPlatformAPI(requested string, logger log.Logger) error {
+	if strings.TrimSpace(requested) == "" {
+		return FailErrCode(
+			nil,
+			CodeForIncompatiblePlatformAPI,
+			fmt.Sprintf("get platform API version; please set '%s' to specify the desired platform API version", EnvPlatformAPI),
+		)
+	}
 	requestedAPI, err := api.NewVersion(requested)
 	if err != nil {
 		return FailErrCode(

--- a/cmd/apis_test.go
+++ b/cmd/apis_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/apex/log"
@@ -12,6 +13,7 @@ import (
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/cmd"
 	llog "github.com/buildpacks/lifecycle/log"
+	"github.com/buildpacks/lifecycle/platform"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -37,8 +39,20 @@ func testVerifyAPIs(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, err)
 		})
 
+		when("is empty", func() {
+			it("errors with exit code 11", func() {
+				err := cmd.VerifyPlatformAPI(" ", logger)
+				failErr, ok := err.(*cmd.ErrorFail)
+				if !ok {
+					t.Fatalf("expected an error of type cmd.ErrorFail")
+				}
+				h.AssertEq(t, failErr.Code, 11)
+				h.AssertError(t, err, fmt.Sprintf("get platform API version; please set '%s' to specify the desired platform API version", platform.EnvPlatformAPI)) // uses platform.EnvPlatformAPI instead of cmd.EnvPlatformAPI to verify the constants are equal
+			})
+		})
+
 		when("is invalid", func() {
-			it("error with exit code 11", func() {
+			it("errors with exit code 11", func() {
 				err := cmd.VerifyPlatformAPI("bad-api", logger)
 				failErr, ok := err.(*cmd.ErrorFail)
 				if !ok {
@@ -49,7 +63,7 @@ func testVerifyAPIs(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("is unsupported", func() {
-			it("error with exit code 11", func() {
+			it("errors with exit code 11", func() {
 				err := cmd.VerifyPlatformAPI("2.2", logger)
 				failErr, ok := err.(*cmd.ErrorFail)
 				if !ok {
@@ -81,7 +95,7 @@ func testVerifyAPIs(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("CNB_DEPRECATION_MODE=error", func() {
-				it("error with exit code 11", func() {
+				it("errors with exit code 11", func() {
 					cmd.DeprecationMode = cmd.ModeError
 					err := cmd.VerifyPlatformAPI("1.1", logger)
 					failErr, ok := err.(*cmd.ErrorFail)
@@ -102,7 +116,7 @@ func testVerifyAPIs(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("is invalid", func() {
-			it("error with exit code 12", func() {
+			it("errors with exit code 12", func() {
 				err := cmd.VerifyBuildpackAPI(buildpack.KindBuildpack, "some-buildpack", "bad-api", logger)
 				failErr, ok := err.(*cmd.ErrorFail)
 				if !ok {
@@ -113,7 +127,7 @@ func testVerifyAPIs(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("is unsupported", func() {
-			it("error with exit code 11", func() {
+			it("errors with exit code 11", func() {
 				err := cmd.VerifyBuildpackAPI(buildpack.KindBuildpack, "some-buildpack", "2.2", logger)
 				failErr, ok := err.(*cmd.ErrorFail)
 				if !ok {
@@ -145,7 +159,7 @@ func testVerifyAPIs(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			when("CNB_DEPRECATION_MODE=error", func() {
-				it("error with exit code 11", func() {
+				it("errors with exit code 11", func() {
 					cmd.DeprecationMode = cmd.ModeError
 					err := cmd.VerifyBuildpackAPI(buildpack.KindBuildpack, "some-buildpack", "1.1", logger)
 					failErr, ok := err.(*cmd.ErrorFail)

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -19,7 +19,7 @@ import (
 // the default version is used.
 const (
 	EnvPlatformAPI     = "CNB_PLATFORM_API"
-	DefaultPlatformAPI = "0.3"
+	DefaultPlatformAPI = ""
 )
 
 // Most configuration options for the lifecycle can be provided as either command-line flags or environment variables.

--- a/platform/launch/defaults.go
+++ b/platform/launch/defaults.go
@@ -13,7 +13,7 @@ const (
 	EnvPlatformAPI = "CNB_PLATFORM_API"
 	EnvProcessType = "CNB_PROCESS_TYPE"
 
-	DefaultPlatformAPI = "0.3"
+	DefaultPlatformAPI = ""
 	DefaultProcessType = "web"
 
 	DefaultExecExt = path.ExecExt


### PR DESCRIPTION
Instead of defaulting to (deprecated) version 0.3

Instead of defaulting to a newer Platform API version, which would silently change behavior for platforms that do not currently set this env var

First PR in support of https://github.com/buildpacks/rfcs/blob/main/text/0110-deprecate-apis.md