### PR TITLE
warn when a positional argument might have been a flag

### DIFF
--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -57,6 +57,12 @@ func Run(c Command, withPhaseName string, asSubcommand bool) {
 	}
 	cmd.DefaultLogger.Debugf("Starting %s...", withPhaseName)
 
+	for _, arg := range flagSet.Args() {
+		if arg[0:1] == "-" {
+			cmd.DefaultLogger.Warnf("Warning: unconsumed flag-like positional arg: \n\t%s\n\t This will not be interpreted as a flag.\n\t Did you mean to put this before the first positional argument?", arg)
+		}
+	}
+
 	// Warn when CNB_PLATFORM_API is unset
 	if os.Getenv(platform.EnvPlatformAPI) == "" {
 		cmd.DefaultLogger.Warnf("%s is unset; using Platform API version '%s'", platform.EnvPlatformAPI, platform.DefaultPlatformAPI)


### PR DESCRIPTION
I was tempted to make it a fatal error and exit but honestly someone out there probably has an app called `-minuses-are-cool-characters-to-start-my-app-name-with` or something. 

*before*

```
> ./exporter  apps/bash-script -launcher ../lifecycle/out/darwin-amd64/lifecycle/launcher
```

would result in a bunch of reasonable looking output but end with:
```
ERROR: failed to export: creating launcher layers: failed to stat launcher at path '/cnb/lifecycle/launcher': stat /cnb/lifecycle/launcher: no such file or directory
```

because we put the `-launcher` flag _after_ the app name.  
NOTE that this is much harder to notice if there's several other args, especially if the app-name positional arg is preceded by a boolean flag arg such as `-daemon`. 

*after*
Your stuff will still fail, but there'll be a big warning message towards the top saying something like
```
Warning: Warning: unconsumed flag-like positional arg:
	-launcher ../lifecycle/out/darwin-amd64/lifecycle/launcher
	 This will not be interpreted as a flag.
	 Did you mean to put this before the first positional argument?
```