### PR TITLE
be more helpful when you dont recognize the phase

### DIFF
--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -75,7 +75,7 @@ func subcommand(platformAPI string) {
 	case "extend":
 		cli.Run(&extendCmd{Platform: platform.NewPlatformFor(platformAPI)}, phase, true)
 	default:
-		cmd.Exit(cmd.FailCode(cmd.CodeForInvalidArgs, "unknown phase:", phase))
+		cmd.Exit(cmd.FailCode(cmd.CodeForInvalidArgs, "unknown phase:", phase, "\nValid phases: detect, analyze, restore, build, export, rebase, create, extend"))
 	}
 }
 


### PR DESCRIPTION
before:

```
➜ CNB_PLATFORM_API=0.12 ./out/darwin-amd64/lifecycle/lifecycle -help
ERROR: failed to unknown phase: -help

➜   CNB_PLATFORM_API=0.12 ./out/darwin-amd64/lifecycle/lifecycle creator --help
ERROR: failed to unknown phase: creator
```


after:

```
➜   CNB_PLATFORM_API=0.12 ./out/darwin-amd64/lifecycle/lifecycle creator       
ERROR: failed to recognize phase: creator
Valid phases: detect, analyze, restore, build, export, rebase, create, extend
➜  CNB_PLATFORM_API=0.12 ./out/darwin-amd64/lifecycle/lifecycle --help      
ERROR: failed to recognize phase: --help
Valid phases: detect, analyze, restore, build, export, rebase, create, extend
```