### PR TITLE
Export cache image and app image in parallel

### DIFF
--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -314,8 +314,11 @@ func testExporterFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							)
 							h.AssertStringContains(t, output, "Saving "+exportedImageName)
 
+							// To detect whether the export of cacheImage and exportedImage is successful
 							h.Run(t, exec.Command("docker", "pull", exportedImageName))
 							assertImageOSAndArchAndCreatedAt(t, exportedImageName, exportTest, imgutil.NormalizedDateTime)
+
+							h.Run(t, exec.Command("docker", "pull", cacheImageName))
 						})
 
 						it("is created with empty layer", func() {

--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -108,6 +108,11 @@ func FlagPlanPath(planPath *string) {
 	flagSet.StringVar(planPath, "plan", *planPath, "path to plan.toml")
 }
 
+// FlagParallelExport parses `parallel` flag
+func FlagParallelExport(parallelExport *bool) {
+	flagSet.BoolVar(parallelExport, "parallel", *parallelExport, "export app image and cache image in parallel")
+}
+
 func FlagPlatformDir(platformDir *string) {
 	flagSet.StringVar(platformDir, "platform", *platformDir, "path to platform directory")
 }

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -48,6 +48,7 @@ func (c *createCmd) DefineFlags() {
 	cli.FlagLauncherPath(&c.LauncherPath)
 	cli.FlagLayersDir(&c.LayersDir)
 	cli.FlagOrderPath(&c.OrderPath)
+	cli.FlagParallelExport(&c.ParallelExport)
 	cli.FlagPlatformDir(&c.PlatformDir)
 	cli.FlagPreviousImage(&c.PreviousImageRef)
 	cli.FlagProcessType(&c.DefaultProcessType)
@@ -73,6 +74,11 @@ func (c *createCmd) Args(nargs int, args []string) error {
 	if c.UseLayout {
 		if err := platform.GuardExperimental(platform.LayoutFormat, cmd.DefaultLogger); err != nil {
 			return err
+		}
+	}
+	if c.ParallelExport {
+		if c.CacheImageRef == "" {
+			cmd.DefaultLogger.Warn("parallel export has been enabled, but it has not taken effect because cache image (-cache-image) has not been specified.")
 		}
 	}
 	return nil

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -70,6 +70,7 @@ func (e *exportCmd) DefineFlags() {
 	cli.FlagLaunchCacheDir(&e.LaunchCacheDir)
 	cli.FlagLauncherPath(&e.LauncherPath)
 	cli.FlagLayersDir(&e.LayersDir)
+	cli.FlagParallelExport(&e.ParallelExport)
 	cli.FlagProcessType(&e.DefaultProcessType)
 	cli.FlagProjectMetadataPath(&e.ProjectMetadataPath)
 	cli.FlagReportPath(&e.ReportPath)
@@ -228,6 +229,11 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore lifecycle.Cache, an
 			WorkingImage:       appImage,
 		})
 	}()
+
+	// waiting here if parallel export is not enabled
+	if !e.ParallelExport {
+		exportWaitGroup.Wait()
+	}
 
 	exportWaitGroup.Add(1)
 	go func() {

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -186,6 +186,9 @@ const (
 
 	// EnvKanikoCacheTTL is the amount of time to persist layers cached by kaniko during the `extend` phase.
 	EnvKanikoCacheTTL = "CNB_KANIKO_CACHE_TTL"
+
+	// EnvParallelExport is a flag used to instruct the lifecycle to export of application image and cache image in parallel, if true.
+	EnvParallelExport = "CNB_PARALLEL_EXPORT"
 )
 
 // DefaultKanikoCacheTTL is the default kaniko cache TTL (2 weeks).

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -54,6 +54,7 @@ type LifecycleInputs struct {
 	UID                   int
 	GID                   int
 	ForceRebase           bool
+	ParallelExport        bool
 	SkipLayers            bool
 	UseDaemon             bool
 	UseLayout             bool
@@ -129,6 +130,7 @@ func NewLifecycleInputs(platformAPI *api.Version) *LifecycleInputs {
 		KanikoDir:      "/kaniko",
 		LaunchCacheDir: os.Getenv(EnvLaunchCacheDir),
 		SkipLayers:     skipLayers,
+		ParallelExport: boolEnv(EnvParallelExport),
 
 		// Images used by the lifecycle during the build
 
@@ -147,6 +149,7 @@ func NewLifecycleInputs(platformAPI *api.Version) *LifecycleInputs {
 		ProjectMetadataPath: envOrDefault(EnvProjectMetadataPath, filepath.Join(PlaceholderLayers, DefaultProjectMetadataFile)),
 
 		// Configuration options for rebasing
+
 		ForceRebase: boolEnv(EnvForceRebase),
 	}
 


### PR DESCRIPTION
In our scenario, the app image and the cache image need to be exported at the same time, but this process is serial in the lifecycle, which means that after the app image is exported, we have to wait for the cache image to be exported. After calculation, the time to export the app image is about the same as the time to export the cache, but we don’t need to wait for the export of cache image, only after the app is exported, we can proceed to the next steps (distribution and deployment).

So we tried to parallelize this step (this PR) and compare it with the serial exporting. We used several projects for testing and pushed app images and cache images to the same self-hosting registry.

- Java (app image is 202.361MB, cache image is 157.525MB, with a same layer: 107.648MB): 
  - Before: total 18.34s, app 8.96s, cache 9.38s
  - After: total 14.70s, app 11.42s, cache 13.93s
  - app image: 0+1.103MB+15.153MB+107.648MB+49.953MB+0+0+28.502MB
  - cache image: 9.411MB+40.465MB+107.648MB

- Go (app image is 114.273MB, cache is 175.833MB, no same layer): 
  - Before: total 16.57s, app 5.92s, cache 10.65s
  - After: total 12.02s, app 7.31s, cache 11.48s
  - app image: 0+1MB+25.72MB+8.993MB+49.953MB+0+0+28.502MB
  - cache image: 70.87MB+104.964MB

We can get some improvements here, although the export time of app image and cache image has significantly increased, the total time has decreased. The effect will be more pronounced if we export to different registry or use faster bandwidth.

But my confusion is, if the app image and cache image contain same layeres, will this method no longer resue layeres when pushing to the registry. Or we should detece / specify whether to use a parallel pushing strategy. Thx.
