### PR TITLE
Add -daemon to restorer

### DIFF
--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -20,6 +20,8 @@ import (
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
+const emptyImageSHA = "03cbce912ef1a8a658f73c660ab9c539d67188622f00b15c4f15b89b884f0e10"
+
 var (
 	restoreImage          string
 	restoreRegAuthConfig  string
@@ -240,7 +242,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 				h.AssertEq(t, analyzedMD.RunImage.Image, restoreRegFixtures.ReadOnlyRunImage)
 				h.AssertEq(t, analyzedMD.RunImage.TargetMetadata.OS, "linux")
 				t.Log("does not return the digest for an empty image")
-				h.AssertStringDoesNotContain(t, analyzedMD.RunImage.Reference, restoreRegFixtures.ReadOnlyRunImage+"@sha256:03cbce912ef1a8a658f73c660ab9c539d67188622f00b15c4f15b89b884f0e10")
+				h.AssertStringDoesNotContain(t, analyzedMD.RunImage.Reference, restoreRegFixtures.ReadOnlyRunImage+"@sha256:"+emptyImageSHA)
 				t.Log("writes run image manifest and config to the kaniko cache")
 				ref, err := name.ParseReference(analyzedMD.RunImage.Reference)
 				h.AssertNil(t, err)
@@ -277,7 +279,7 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					h.AssertEq(t, analyzedMD.RunImage.Image, restoreRegFixtures.ReadOnlyRunImage)
 					h.AssertEq(t, analyzedMD.RunImage.TargetMetadata.OS, "linux")
 					t.Log("does not return the digest for an empty image")
-					h.AssertStringDoesNotContain(t, analyzedMD.RunImage.Reference, restoreRegFixtures.ReadOnlyRunImage+"@sha256:03cbce912ef1a8a658f73c660ab9c539d67188622f00b15c4f15b89b884f0e10")
+					h.AssertStringDoesNotContain(t, analyzedMD.RunImage.Reference, restoreRegFixtures.ReadOnlyRunImage+"@sha256:"+emptyImageSHA)
 					t.Log("does not write run image manifest and config to the kaniko cache")
 					fis, err := os.ReadDir(filepath.Join(copyDir, "kaniko"))
 					h.AssertNil(t, err)
@@ -288,6 +290,39 @@ func testRestorerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 					h.AssertNil(t, err)
 					h.AssertNil(t, analyzedMD.RunImage.TargetMetadata)
 				}
+			})
+
+			when("-daemon", func() {
+				it("updates run image reference in analyzed.toml to include digest and target data on newer platforms", func() {
+					h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.12"), "Platform API < 0.12 does not support -daemon flag")
+					h.DockerRunAndCopy(t,
+						containerName,
+						copyDir,
+						"/",
+						restoreImage,
+						h.WithFlags(append(
+							dockerSocketMount,
+							"--env", "CNB_PLATFORM_API="+platformAPI,
+							"--env", "DOCKER_CONFIG=/docker-config",
+							"--network", restoreRegNetwork,
+						)...),
+						h.WithArgs(
+							"-analyzed", "/layers/some-extend-false-analyzed.toml",
+							"-daemon",
+							"-log-level", "debug",
+						),
+					)
+					t.Log("updates run image reference in analyzed.toml to include digest and target data")
+					analyzedMD, err := lifecycle.Config.ReadAnalyzed(filepath.Join(copyDir, "layers", "some-extend-false-analyzed.toml"), cmd.DefaultLogger)
+					h.AssertNil(t, err)
+					h.AssertStringDoesNotContain(t, analyzedMD.RunImage.Reference, "@sha256:") // daemon image ID
+					h.AssertEq(t, analyzedMD.RunImage.Image, restoreRegFixtures.ReadOnlyRunImage)
+					h.AssertEq(t, analyzedMD.RunImage.TargetMetadata.OS, "linux")
+					t.Log("does not write run image manifest and config to the kaniko cache")
+					fis, err := os.ReadDir(filepath.Join(copyDir, "kaniko"))
+					h.AssertNil(t, err)
+					h.AssertEq(t, len(fis), 1) // .gitkeep
+				})
 			})
 		})
 	}


### PR DESCRIPTION
See https://github.com/buildpacks/spec/pull/347#issuecomment-1658451549

This is needed when extensions were used to switch (but not extend) the run image and we need to re-read the target data from the image config.

In such cases, we don't need the run image to exist in a registry, because we don't need a manifest for kaniko.

