### PR TITLE
Print the build environment given --verbose option

### DIFF
--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -99,6 +99,9 @@ func (e *DefaultBuildExecutor) Build(d BpDescriptor, inputs BuildInputs, logger 
 	if err := d.setupEnv(createdLayers, inputs.Env); err != nil {
 		return BuildOutputs{}, err
 	}
+	for _, envVar := range inputs.Env.List() {
+		logger.Debug(fmt.Sprintf("\t%s", envVar))
+	}
 
 	logger.Debug("Reading output files")
 	return d.readOutputFilesBp(bpLayersDir, planPath, inputs.Plan, createdLayers, logger)


### PR DESCRIPTION
Allow developers to see the environment that is set from any BuildConfigDir settings.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
In https://github.com/buildpacks/rfcs/blob/main/text/0109-build-config.md?plain=1#L15 we proposed platform defined environment settings.  This PR allows `lifecycle` users to see the values of the environment.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
When verbose output is selected, print the computed build environment.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

