### PR TITLE
Don't print 'Ignoring cache image "cache-image-name" because it was c…

### DIFF
--- a/cache/image_cache.go
+++ b/cache/image_cache.go
@@ -81,7 +81,7 @@ func (c *ImageCache) SetMetadata(metadata platform.CacheMetadata) error {
 }
 
 func (c *ImageCache) RetrieveMetadata() (platform.CacheMetadata, error) {
-	if !c.origImage.Valid() {
+	if c.origImage.Found() && !c.origImage.Valid() {
 		c.logger.Infof("Ignoring cache image %q because it was corrupt", c.origImage.Name())
 		return platform.CacheMetadata{}, nil
 	}


### PR DESCRIPTION
…orrupt'

when the cache image is not found

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Removes erroneous log warnings when cache image is not found

---


