### PR TITLE
Adding missing flags for OCI Layout to restorer

### DIFF
--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -40,6 +40,8 @@ func (r *restoreCmd) DefineFlags() {
 	if r.PlatformAPI.AtLeast("0.12") {
 		cli.FlagUseDaemon(&r.UseDaemon)
 		cli.FlagGeneratedDir(&r.GeneratedDir)
+		cli.FlagUseLayout(&r.UseLayout)
+		cli.FlagLayoutDir(&r.LayoutDir)
 	}
 	if r.PlatformAPI.AtLeast("0.10") {
 		cli.FlagBuildImage(&r.BuildImageRef)

--- a/image/layout_handler.go
+++ b/image/layout_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/layout"
@@ -33,11 +34,14 @@ func (h *LayoutHandler) Kind() string {
 }
 
 func (h *LayoutHandler) parseRef(imageRef string) (string, error) {
-	path, err := layout.ParseRefToPath(imageRef)
-	if err != nil {
-		return "", err
+	if !strings.HasPrefix(imageRef, h.layoutDir) {
+		path, err := layout.ParseRefToPath(imageRef)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(h.layoutDir, path), nil
 	}
-	return filepath.Join(h.layoutDir, path), nil
+	return imageRef, nil
 }
 
 // helpers

--- a/image/layout_handler_test.go
+++ b/image/layout_handler_test.go
@@ -102,6 +102,18 @@ func testLayoutImageHandler(t *testing.T, when spec.G, it spec.S) {
 					h.AssertNotNil(t, err)
 				})
 			})
+
+			when("image reference is a layout path", func() {
+				it.Before(func() {
+					imageRef = filepath.Join(layoutDir, "index.docker.io", "cnbs", "sample-stack-run", "jammy")
+				})
+
+				it("it returns the same path value", func() {
+					image, err := imageHandler.InitImage(imageRef)
+					h.AssertNil(t, err)
+					h.AssertEq(t, image.Name(), imageRef)
+				})
+			})
 		})
 	})
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
This PR adds the `layout` and `layout-dir` flags to the `restorer` phase when the PLATFORM_API version is equal or greater than 0.12.

It also fixes an issue when the `run-image` is read from the analyzed.toml file we will get something like:
```json
{
"Reference":"",
  "Image":"/layout-repo/index.docker.io/cnbs/sample-stack-run/jammy",
   "Extend":false,
   "target":{
     "os":"linux",
    "arch":"amd64"
 }
}
```
We were trying to parse the `Reference.Image` into a path, but it is already a path, so we don't need to do anything in that case.

#### Release notes

When using platform API `0.12` or greater, The layout flags  `layout` and `layout-dir` were exposed in the `restorer` binary 

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1194 

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

