### PR TITLE
Fix setup-go by looking for go.mod within pack directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'pack/go.mod'
       - uses: actions/download-artifact@v2
         with:
           name: version
@@ -296,7 +296,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'pack/go.mod'
       - name: Add runner IP to daemon insecure-registries and firewall
         shell: powershell
         run: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
Pack acceptance has been failing since https://github.com/buildpacks/lifecycle/pull/1182 because we weren't looking for the go.mod file in the right place.