### PR TITLE
Fix regression in Platform API 0.10

### DIFF
--- a/acceptance/testdata/restorer/container/layers/group.toml
+++ b/acceptance/testdata/restorer/container/layers/group.toml
@@ -7,3 +7,8 @@
   id = "cacher_buildpack"
   version = "cacher_v1"
   api = "0.10"
+
+[[group-extensions]]
+    id = "some-extension-id"
+    version = "v1"
+    api = "0.10"

--- a/acceptance/testdata/restorer/container/layers/some-extend-false-analyzed.toml.placeholder
+++ b/acceptance/testdata/restorer/container/layers/some-extend-false-analyzed.toml.placeholder
@@ -1,3 +1,3 @@
 [run-image]
-  reference = ""
+  reference = "some-reference-without-digest"
   image = "REPLACE"

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -96,10 +96,16 @@ func (r *restoreCmd) Privileges() error {
 }
 
 func (r *restoreCmd) Exec() error {
-	var (
-		analyzedMD files.Analyzed
-		err        error
-	)
+	group, groupExt, err := phase.Config.ReadGroup(r.GroupPath)
+	if err != nil {
+		return cmd.FailErr(err, "read buildpack group")
+	}
+	if err := verifyBuildpackApis(buildpack.Group{Group: group}); err != nil {
+		return err
+	}
+	groupFile := buildpack.Group{Group: groupExt, GroupExtensions: groupExt}
+
+	var analyzedMD files.Analyzed
 	if analyzedMD, err = files.ReadAnalyzed(r.AnalyzedPath, cmd.DefaultLogger); err == nil {
 		if r.supportsBuildImageExtension() && r.BuildImageRef != "" {
 			cmd.DefaultLogger.Debugf("Pulling builder image metadata for %s...", r.BuildImageRef)
@@ -128,17 +134,17 @@ func (r *restoreCmd) Exec() error {
 			// update analyzed metadata, even if we only needed to pull the image metadata, because
 			// the extender needs a digest reference in analyzed.toml,
 			// and daemon images will only have a daemon image ID
-			if err = updateAnalyzedMD(&analyzedMD, runImage); err != nil {
+			if err = r.updateAnalyzedMD(&analyzedMD, runImage); err != nil {
 				return cmd.FailErr(err, "update analyzed metadata")
 			}
-		} else if r.supportsTargetData() && needsUpdating(analyzedMD.RunImage) {
+		} else if r.needsUpdating(analyzedMD.RunImage, groupFile) {
 			cmd.DefaultLogger.Debugf("Updating run image info in analyzed metadata...")
 			h := image.NewHandler(r.docker, r.keychain, r.LayoutDir, r.UseLayout, r.InsecureRegistries)
 			runImage, err = h.InitImage(runImageName)
 			if err != nil || !runImage.Found() {
-				return cmd.FailErr(err, fmt.Sprintf("pull run image %s", runImageName))
+				return cmd.FailErr(err, fmt.Sprintf("get run image %s", runImageName))
 			}
-			if err = updateAnalyzedMD(&analyzedMD, runImage); err != nil {
+			if err = r.updateAnalyzedMD(&analyzedMD, runImage); err != nil {
 				return cmd.FailErr(err, "update analyzed metadata")
 			}
 		}
@@ -149,30 +155,27 @@ func (r *restoreCmd) Exec() error {
 		cmd.DefaultLogger.Warnf("Not using analyzed data, usable file not found: %s", err)
 	}
 
-	group, err := phase.ReadGroup(r.GroupPath)
-	if err != nil {
-		return cmd.FailErr(err, "read buildpack group")
-	}
-	if err := verifyBuildpackApis(group); err != nil {
-		return err
-	}
-
 	cacheStore, err := initCache(r.CacheImageRef, r.CacheDir, r.keychain, r.PlatformAPI.LessThan("0.13"))
 	if err != nil {
 		return err
 	}
-
-	return r.restore(analyzedMD.LayersMetadata, group, cacheStore)
+	return r.restore(analyzedMD.LayersMetadata, groupFile, cacheStore)
 }
 
-func updateAnalyzedMD(analyzedMD *files.Analyzed, remoteRunImage imgutil.Image) error {
-	digestRef, err := remoteRunImage.Identifier()
+func (r *restoreCmd) updateAnalyzedMD(analyzedMD *files.Analyzed, runImage imgutil.Image) error {
+	if r.PlatformAPI.LessThan("0.10") {
+		return nil
+	}
+	digestRef, err := runImage.Identifier()
 	if err != nil {
 		return cmd.FailErr(err, "get digest reference for run image")
 	}
-	targetData, err := platform.GetTargetMetadata(remoteRunImage)
-	if err != nil {
-		return cmd.FailErr(err, "read target data from run image")
+	var targetData *files.TargetMetadata
+	if r.PlatformAPI.AtLeast("0.12") {
+		targetData, err = platform.GetTargetMetadata(runImage)
+		if err != nil {
+			return cmd.FailErr(err, "read target data from run image")
+		}
 	}
 	cmd.DefaultLogger.Debugf("Run image info in analyzed metadata was: ")
 	cmd.DefaultLogger.Debugf(encoding.ToJSONMaybe(analyzedMD.RunImage))
@@ -191,12 +194,18 @@ func needsPulling(runImage *files.RunImage) bool {
 	return runImage.Extend
 }
 
-func needsUpdating(runImage *files.RunImage) bool {
+func (r *restoreCmd) needsUpdating(runImage *files.RunImage, group buildpack.Group) bool {
+	if r.PlatformAPI.LessThan("0.10") {
+		return false
+	}
+	if !group.HasExtensions() {
+		return false
+	}
 	if runImage == nil {
 		// sanity check to prevent panic, should be unreachable
 		return false
 	}
-	if runImage.Reference != "" && isPopulated(runImage.TargetMetadata) {
+	if isPopulated(runImage.TargetMetadata) {
 		return false
 	}
 	return true

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -103,7 +103,7 @@ func (r *restoreCmd) Exec() error {
 	if err := verifyBuildpackApis(buildpack.Group{Group: group}); err != nil {
 		return err
 	}
-	groupFile := buildpack.Group{Group: groupExt, GroupExtensions: groupExt}
+	groupFile := buildpack.Group{Group: group, GroupExtensions: groupExt}
 
 	var analyzedMD files.Analyzed
 	if analyzedMD, err = files.ReadAnalyzed(r.AnalyzedPath, cmd.DefaultLogger); err == nil {

--- a/phase/generator.go
+++ b/phase/generator.go
@@ -116,9 +116,10 @@ func (g *Generator) Generate() (GenerateResult, error) {
 			g.Logger.Warnf("new runtime base image '%s' not found in run metadata", generatedRunImageRef)
 		}
 		g.Logger.Debugf("Updating analyzed metadata with new run image '%s'", generatedRunImageRef)
-		finalAnalyzedMD.RunImage = &files.RunImage{ // reference and target data are cleared
-			Extend: extend,
-			Image:  generatedRunImageRef,
+		finalAnalyzedMD.RunImage = &files.RunImage{ // target data is cleared
+			Extend:    extend,
+			Reference: generatedRunImageRef,
+			Image:     generatedRunImageRef,
 		}
 	}
 	if extend {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

In lifecycle 0.17.0 we stopped writing `reference` in analyzed.toml during the generate phase when the run image was switched by extensions. This is because the restorer would "always" take the run image `image` and turn it into a `reference`. However the restorer was only doing this for Platform API 0.12 and above.

`[run-image.image]` isn't a thing in Platform API 0.10 so we have to write the image from extensions into `reference` and overwrite it with a real reference during restore.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Fixes regression in Platform API 0.10 by writing `reference` in analyzed.toml during the generate phase when the run image was switched by extensions

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

