### PR TITLE
Refactor lifecycle phase factories

### DIFF
--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -103,7 +103,7 @@ func (a *analyzeCmd) Exec() error {
 		image.NewHandler(a.docker, a.keychain, a.LayoutDir, a.UseLayout, a.InsecureRegistries),
 		image.NewRegistryHandler(a.keychain, a.InsecureRegistries),
 	)
-	analyzer, err := factory.NewAnalyzer(*a.LifecycleInputs, cmd.DefaultLogger)
+	analyzer, err := factory.NewAnalyzer(a.Inputs(), cmd.DefaultLogger)
 	if err != nil {
 		return unwrapErrorFailWithMessage(err, "initialize analyzer")
 	}

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -131,7 +131,7 @@ func (c *createCmd) Exec() error {
 		image.NewHandler(c.docker, c.keychain, c.LayoutDir, c.UseLayout, c.InsecureRegistries),
 		image.NewRegistryHandler(c.keychain, c.InsecureRegistries),
 	)
-	analyzer, err := analyzerFactory.NewAnalyzer(*c.LifecycleInputs, cmd.DefaultLogger)
+	analyzer, err := analyzerFactory.NewAnalyzer(c.Inputs(), cmd.DefaultLogger)
 	if err != nil {
 		return unwrapErrorFailWithMessage(err, "initialize analyzer")
 	}
@@ -151,7 +151,7 @@ func (c *createCmd) Exec() error {
 		phase.NewConfigHandler(),
 		dirStore,
 	)
-	detector, err := detectorFactory.NewDetector(*c.LifecycleInputs, cmd.DefaultLogger)
+	detector, err := detectorFactory.NewDetector(c.Inputs(), cmd.DefaultLogger)
 	if err != nil {
 		return unwrapErrorFailWithMessage(err, "initialize detector")
 	}

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -123,7 +123,7 @@ func (c *createCmd) Exec() error {
 		plan       files.Plan
 	)
 	cmd.DefaultLogger.Phase("ANALYZING")
-	analyzerFactory := phase.NewAnalyzerFactory(
+	analyzerFactory := phase.NewConnectedFactory(
 		c.PlatformAPI,
 		&cmd.BuildpackAPIVerifier{},
 		NewCacheHandler(c.keychain),
@@ -131,7 +131,7 @@ func (c *createCmd) Exec() error {
 		image.NewHandler(c.docker, c.keychain, c.LayoutDir, c.UseLayout, c.InsecureRegistries),
 		image.NewRegistryHandler(c.keychain, c.InsecureRegistries),
 	)
-	analyzer, err := analyzerFactory.NewAnalyzer(c.AdditionalTags, c.CacheImageRef, c.LaunchCacheDir, c.LayersDir, c.OutputImageRef, c.PreviousImageRef, c.RunImageRef, c.SkipLayers, cmd.DefaultLogger)
+	analyzer, err := analyzerFactory.NewAnalyzer(*c.LifecycleInputs, cmd.DefaultLogger)
 	if err != nil {
 		return unwrapErrorFailWithMessage(err, "initialize analyzer")
 	}
@@ -139,16 +139,19 @@ func (c *createCmd) Exec() error {
 	if err != nil {
 		return err
 	}
+	if err := phase.Config.WriteAnalyzed(c.AnalyzedPath, &analyzedMD, cmd.DefaultLogger); err != nil {
+		return err
+	}
 
 	// Detect
 	cmd.DefaultLogger.Phase("DETECTING")
-	detectorFactory := phase.NewDetectorFactory(
+	detectorFactory := phase.NewHermeticFactory(
 		c.PlatformAPI,
 		&cmd.BuildpackAPIVerifier{},
 		phase.NewConfigHandler(),
 		dirStore,
 	)
-	detector, err := detectorFactory.NewDetector(analyzedMD, c.AppDir, c.BuildConfigDir, c.OrderPath, c.PlatformDir, cmd.DefaultLogger)
+	detector, err := detectorFactory.NewDetector(*c.LifecycleInputs, cmd.DefaultLogger)
 	if err != nil {
 		return unwrapErrorFailWithMessage(err, "initialize detector")
 	}
@@ -164,8 +167,7 @@ func (c *createCmd) Exec() error {
 			Platform: c.Platform,
 			keychain: c.keychain,
 		}
-		err := restoreCmd.restore(analyzedMD.LayersMetadata, group, cacheStore)
-		if err != nil {
+		if err := restoreCmd.restore(analyzedMD.LayersMetadata, group, cacheStore); err != nil {
 			return err
 		}
 	}

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -66,7 +66,7 @@ func (d *detectCmd) Exec() error {
 		dirStore,
 	)
 	detector, err := detectorFactory.NewDetector(
-		*d.LifecycleInputs,
+		d.Inputs(),
 		cmd.DefaultLogger,
 	)
 	if err != nil {
@@ -90,7 +90,7 @@ func (d *detectCmd) Exec() error {
 		)
 		var generator *phase.Generator
 		generator, err = generatorFactory.NewGenerator(
-			*d.LifecycleInputs,
+			d.Inputs(),
 			cmd.Stdout, cmd.Stderr,
 			cmd.DefaultLogger,
 		)

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -6,7 +6,6 @@ import (
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/lifecycle/cmd/lifecycle/cli"
-	"github.com/buildpacks/lifecycle/internal/encoding"
 	"github.com/buildpacks/lifecycle/phase"
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/buildpacks/lifecycle/platform/files"
@@ -60,22 +59,14 @@ func (d *detectCmd) Privileges() error {
 
 func (d *detectCmd) Exec() error {
 	dirStore := platform.NewDirStore(d.BuildpacksDir, d.ExtensionsDir)
-	detectorFactory := phase.NewDetectorFactory(
+	detectorFactory := phase.NewHermeticFactory(
 		d.PlatformAPI,
 		&cmd.BuildpackAPIVerifier{},
 		phase.NewConfigHandler(),
 		dirStore,
 	)
-	amd, err := files.ReadAnalyzed(d.AnalyzedPath, cmd.DefaultLogger)
-	if err != nil {
-		return unwrapErrorFailWithMessage(err, "reading analyzed.toml")
-	}
 	detector, err := detectorFactory.NewDetector(
-		amd,
-		d.AppDir,
-		d.BuildConfigDir,
-		d.OrderPath,
-		d.PlatformDir,
+		*d.LifecycleInputs,
 		cmd.DefaultLogger,
 	)
 	if err != nil {
@@ -86,27 +77,20 @@ func (d *detectCmd) Exec() error {
 			return err
 		}
 	}
-	group, plan, err := doDetect(detector, d.Platform)
+	group, _, err := doDetect(detector, d.Platform)
 	if err != nil {
 		return err // pass through error
 	}
 	if group.HasExtensions() {
-		generatorFactory := phase.NewGeneratorFactory(
+		generatorFactory := phase.NewHermeticFactory(
+			d.PlatformAPI,
 			&cmd.BuildpackAPIVerifier{},
 			phase.Config,
 			dirStore,
 		)
 		var generator *phase.Generator
 		generator, err = generatorFactory.NewGenerator(
-			d.AnalyzedPath,
-			d.AppDir,
-			d.BuildConfigDir,
-			group.GroupExtensions,
-			d.GeneratedDir,
-			plan,
-			d.PlatformAPI,
-			d.PlatformDir,
-			d.RunPath,
+			*d.LifecycleInputs,
 			cmd.Stdout, cmd.Stderr,
 			cmd.DefaultLogger,
 		)
@@ -118,16 +102,14 @@ func (d *detectCmd) Exec() error {
 		if err != nil {
 			return d.unwrapGenerateFail(err)
 		}
-
-		if err = d.writeGenerateData(result.AnalyzedMD); err != nil {
+		if err := phase.Config.WriteAnalyzed(d.AnalyzedPath, &result.AnalyzedMD, cmd.DefaultLogger); err != nil {
 			return err
 		}
-		// was the build plan updated?
-		if result.UsePlan {
-			plan = result.Plan
+		if err := phase.Config.WritePlan(d.PlanPath, &result.Plan); err != nil {
+			return err
 		}
 	}
-	return d.writeDetectData(group, plan)
+	return nil
 }
 
 func unwrapErrorFailWithMessage(err error, msg string) error {
@@ -167,25 +149,11 @@ func doDetect(detector *phase.Detector, p *platform.Platform) (buildpack.Group, 
 			return buildpack.Group{}, files.Plan{}, cmd.FailErrCode(err, p.CodeFor(platform.DetectError), "detect")
 		}
 	}
+	if err := phase.Config.WriteGroup(p.GroupPath, &group); err != nil {
+		return buildpack.Group{}, files.Plan{}, err
+	}
+	if err := phase.Config.WritePlan(p.PlanPath, &plan); err != nil {
+		return buildpack.Group{}, files.Plan{}, err
+	}
 	return group, plan, nil
-}
-
-func (d *detectCmd) writeDetectData(group buildpack.Group, plan files.Plan) error {
-	if err := encoding.WriteTOML(d.GroupPath, group); err != nil {
-		return cmd.FailErr(err, "write buildpack group")
-	}
-	if err := encoding.WriteTOML(d.PlanPath, plan); err != nil {
-		return cmd.FailErr(err, "write detect plan")
-	}
-	return nil
-}
-
-// writeGenerateData re-outputs the analyzedMD that we read previously, but now we've added the RunImage, if a custom runImage was configured
-func (d *detectCmd) writeGenerateData(analyzedMD files.Analyzed) error {
-	cmd.DefaultLogger.Debugf("Run image info in analyzed metadata is: ")
-	cmd.DefaultLogger.Debugf(encoding.ToJSONMaybe(analyzedMD.RunImage))
-	if err := encoding.WriteTOML(d.AnalyzedPath, analyzedMD); err != nil {
-		return cmd.FailErr(err, "write analyzed metadata")
-	}
-	return nil
 }

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -205,7 +205,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 		return err
 	}
 
-	runImageForExport, err := platform.GetRunImageForExport(*e.LifecycleInputs)
+	runImageForExport, err := platform.GetRunImageForExport(e.Inputs())
 	if err != nil {
 		return err
 	}

--- a/cmd/lifecycle/extender.go
+++ b/cmd/lifecycle/extender.go
@@ -58,7 +58,7 @@ func (e *extendCmd) Exec() error {
 		return err
 	}
 	extender, err := extenderFactory.NewExtender(
-		*e.LifecycleInputs,
+		e.Inputs(),
 		applier,
 		cmd.DefaultLogger,
 	)

--- a/cmd/lifecycle/extender.go
+++ b/cmd/lifecycle/extender.go
@@ -52,22 +52,14 @@ func (e *extendCmd) Privileges() error {
 }
 
 func (e *extendCmd) Exec() error {
-	extenderFactory := phase.NewExtenderFactory(&cmd.BuildpackAPIVerifier{}, phase.NewConfigHandler())
+	extenderFactory := phase.NewHermeticFactory(e.PlatformAPI, &cmd.BuildpackAPIVerifier{}, phase.NewConfigHandler(), platform.NewDirStore("", ""))
 	applier, err := kaniko.NewDockerfileApplier()
 	if err != nil {
 		return err
 	}
 	extender, err := extenderFactory.NewExtender(
-		e.AnalyzedPath,
-		e.AppDir,
-		e.ExtendedDir,
-		e.GeneratedDir,
-		e.GroupPath,
-		e.LayersDir,
-		e.PlatformDir,
-		e.KanikoCacheTTL,
+		*e.LifecycleInputs,
 		applier,
-		e.ExtendKind,
 		cmd.DefaultLogger,
 	)
 	if err != nil {

--- a/phase/connected_factory.go
+++ b/phase/connected_factory.go
@@ -1,0 +1,88 @@
+package phase
+
+import (
+	"fmt"
+
+	"github.com/buildpacks/imgutil"
+
+	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/cache"
+	"github.com/buildpacks/lifecycle/image"
+	"github.com/buildpacks/lifecycle/platform"
+)
+
+// ConnectedFactory is used to construct lifecycle phases that require access to an image repository
+// (registry, layout directory, or docker daemon) and/or a cache.
+type ConnectedFactory struct {
+	platformAPI     *api.Version
+	apiVerifier     BuildpackAPIVerifier
+	cacheHandler    CacheHandler
+	configHandler   ConfigHandler
+	imageHandler    image.Handler
+	registryHandler image.RegistryHandler
+}
+
+// NewConnectedFactory constructs a new ConnectedFactory.
+func NewConnectedFactory(
+	platformAPI *api.Version,
+	apiVerifier BuildpackAPIVerifier,
+	cacheHandler CacheHandler,
+	configHandler ConfigHandler,
+	imageHandler image.Handler,
+	registryHandler image.RegistryHandler,
+) *ConnectedFactory {
+	return &ConnectedFactory{
+		platformAPI:     platformAPI,
+		apiVerifier:     apiVerifier,
+		cacheHandler:    cacheHandler,
+		configHandler:   configHandler,
+		imageHandler:    imageHandler,
+		registryHandler: registryHandler,
+	}
+}
+
+func (f *ConnectedFactory) ensureRegistryAccess(inputs platform.LifecycleInputs) error {
+	var readImages, writeImages []string
+	writeImages = append(writeImages, inputs.CacheImageRef)
+	if f.imageHandler.Kind() == image.RemoteKind {
+		readImages = append(readImages, inputs.PreviousImageRef, inputs.RunImageRef)
+		writeImages = append(writeImages, inputs.OutputImageRef)
+		writeImages = append(writeImages, inputs.AdditionalTags...)
+	}
+	if err := f.registryHandler.EnsureReadAccess(readImages...); err != nil {
+		return fmt.Errorf("validating registry read access: %w", err)
+	}
+	if err := f.registryHandler.EnsureWriteAccess(writeImages...); err != nil {
+		return fmt.Errorf("validating registry write access: %w", err)
+	}
+	return nil
+}
+
+func (f *ConnectedFactory) getPreviousImage(imageRef string, launchCacheDir string) (imgutil.Image, error) {
+	if imageRef == "" {
+		return nil, nil
+	}
+	previousImage, err := f.imageHandler.InitImage(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("getting previous image: %w", err)
+	}
+	if launchCacheDir == "" || f.imageHandler.Kind() != image.LocalKind {
+		return previousImage, nil
+	}
+	volumeCache, err := cache.NewVolumeCache(launchCacheDir)
+	if err != nil {
+		return nil, fmt.Errorf("creating launch cache: %w", err)
+	}
+	return cache.NewCachingImage(previousImage, volumeCache), nil
+}
+
+func (f *ConnectedFactory) getRunImage(imageRef string) (imgutil.Image, error) {
+	if imageRef == "" {
+		return nil, nil
+	}
+	runImage, err := f.imageHandler.InitImage(imageRef)
+	if err != nil {
+		return nil, fmt.Errorf("getting run image: %w", err)
+	}
+	return runImage, nil
+}

--- a/phase/hermetic_factory.go
+++ b/phase/hermetic_factory.go
@@ -1,0 +1,88 @@
+package phase
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/buildpacks/lifecycle/api"
+	"github.com/buildpacks/lifecycle/buildpack"
+	"github.com/buildpacks/lifecycle/log"
+)
+
+// HermeticFactory is used to construct lifecycle phases that do NOT require access to an image repository.
+type HermeticFactory struct {
+	platformAPI   *api.Version
+	apiVerifier   BuildpackAPIVerifier
+	configHandler ConfigHandler
+	dirStore      DirStore
+}
+
+// NewHermeticFactory is used to construct a new HermeticFactory.
+func NewHermeticFactory(
+	platformAPI *api.Version,
+	apiVerifier BuildpackAPIVerifier,
+	configHandler ConfigHandler,
+	dirStore DirStore,
+) *HermeticFactory {
+	return &HermeticFactory{
+		platformAPI:   platformAPI,
+		apiVerifier:   apiVerifier,
+		configHandler: configHandler,
+		dirStore:      dirStore,
+	}
+}
+
+func (f *HermeticFactory) getExtensions(groupPath string, logger log.Logger) ([]buildpack.GroupElement, error) {
+	_, groupExt, err := f.configHandler.ReadGroup(groupPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading group: %w", err)
+	}
+	for i := range groupExt {
+		groupExt[i].Extension = true
+	}
+	if err = f.verifyGroup(groupExt, logger); err != nil {
+		return nil, err
+	}
+	return groupExt, nil
+}
+
+func (f *HermeticFactory) getOrder(path string, logger log.Logger) (order buildpack.Order, hasExtensions bool, err error) {
+	orderBp, orderExt, orderErr := f.configHandler.ReadOrder(path)
+	if orderErr != nil {
+		err = errors.Wrap(orderErr, "reading order")
+		return
+	}
+	if len(orderExt) > 0 {
+		hasExtensions = true
+	}
+	if err = f.verifyOrder(orderBp, orderExt, logger); err != nil {
+		return
+	}
+	order = PrependExtensions(orderBp, orderExt)
+	return
+}
+
+func (f *HermeticFactory) verifyGroup(group []buildpack.GroupElement, logger log.Logger) error {
+	for _, groupEl := range group {
+		if err := f.apiVerifier.VerifyBuildpackAPI(groupEl.Kind(), groupEl.String(), groupEl.API, logger); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *HermeticFactory) verifyOrder(orderBp buildpack.Order, orderExt buildpack.Order, logger log.Logger) error {
+	for _, group := range append(orderBp, orderExt...) {
+		for _, groupEl := range group.Group {
+			module, err := f.dirStore.Lookup(groupEl.Kind(), groupEl.ID, groupEl.Version)
+			if err != nil {
+				return err
+			}
+			if err = f.apiVerifier.VerifyBuildpackAPI(groupEl.Kind(), groupEl.String(), module.API(), logger); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/phase/testmock/config_handler.go
+++ b/phase/testmock/config_handler.go
@@ -84,6 +84,21 @@ func (mr *MockConfigHandlerMockRecorder) ReadOrder(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadOrder", reflect.TypeOf((*MockConfigHandler)(nil).ReadOrder), arg0)
 }
 
+// ReadPlan mocks base method.
+func (m *MockConfigHandler) ReadPlan(arg0 string) (files.Plan, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadPlan", arg0)
+	ret0, _ := ret[0].(files.Plan)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadPlan indicates an expected call of ReadPlan.
+func (mr *MockConfigHandlerMockRecorder) ReadPlan(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPlan", reflect.TypeOf((*MockConfigHandler)(nil).ReadPlan), arg0)
+}
+
 // ReadRun mocks base method.
 func (m *MockConfigHandler) ReadRun(arg0 string, arg1 log.Logger) (files.Run, error) {
 	m.ctrl.T.Helper()

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -34,3 +34,8 @@ func NewPlatformFor(platformAPI string) *Platform {
 func (p *Platform) API() *api.Version {
 	return p.PlatformAPI
 }
+
+// Inputs exposes the platform's inputs to the lifecycle.
+func (p *Platform) Inputs() LifecycleInputs {
+	return *p.LifecycleInputs
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

This PR builds off of https://github.com/buildpacks/lifecycle/pull/1205 to change lifecycle "factories" (for the phases that use them) to use `platform.LifecycleInputs` instead of a long list of arguments. This will pave the way for us adding factories for the other phases later.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Refactor: lifecycle phase factories
