### PR TITLE
Fix check release workflow by giving write permissions to the token

### DIFF
--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -9,6 +9,8 @@ jobs:
   check-release:
     runs-on:
       - ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Our check-release workflow has been [failing](https://github.com/buildpacks/lifecycle/actions/runs/6687443320/job/18168086995#step:8:34) with errors such as `HTTP 403: Resource not accessible by integration (https://api.github.com/repos/buildpacks/lifecycle/labels)`. I think it is because the default permissions for GITHUB_TOKEN are too restrictive. 

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

n/a