### PR TITLE
Export cache image and app image in parallel

### DIFF
--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -320,10 +320,8 @@ func testExporterFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							)
 							h.AssertStringContains(t, output, "Saving "+exportedImageName)
 
-							// To detect whether the export of cacheImage and exportedImage is successful
 							h.Run(t, exec.Command("docker", "pull", exportedImageName))
 							assertImageOSAndArchAndCreatedAt(t, exportedImageName, exportTest, imgutil.NormalizedDateTime)
-							h.Run(t, exec.Command("docker", "pull", cacheImageName))
 						})
 
 						it("is created with empty layer", func() {

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -320,8 +320,10 @@ func testExporterFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 							)
 							h.AssertStringContains(t, output, "Saving "+exportedImageName)
 
+							// To detect whether the export of cacheImage and exportedImage is successful
 							h.Run(t, exec.Command("docker", "pull", exportedImageName))
 							assertImageOSAndArchAndCreatedAt(t, exportedImageName, exportTest, imgutil.NormalizedDateTime)
+							h.Run(t, exec.Command("docker", "pull", cacheImageName))
 						})
 
 						it("is created with empty layer", func() {

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -319,9 +319,10 @@ func testExporterFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 								h.WithArgs(exportArgs...),
 							)
 							h.AssertStringContains(t, output, "Saving "+exportedImageName)
-
+							// To detect whether the export of cacheImage and exportedImage is successful
 							h.Run(t, exec.Command("docker", "pull", exportedImageName))
 							assertImageOSAndArchAndCreatedAt(t, exportedImageName, exportTest, imgutil.NormalizedDateTime)
+							h.Run(t, exec.Command("docker", "pull", cacheImageName))
 						})
 
 						it("is created with empty layer", func() {

--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -108,6 +108,11 @@ func FlagPlanPath(planPath *string) {
 	flagSet.StringVar(planPath, "plan", *planPath, "path to plan.toml")
 }
 
+// FlagParallelExport parses `parallel` flag
+func FlagParallelExport(parallelExport *bool) {
+	flagSet.BoolVar(parallelExport, "parallel", *parallelExport, "export app image and cache image in parallel")
+}
+
 func FlagPlatformDir(platformDir *string) {
 	flagSet.StringVar(platformDir, "platform", *platformDir, "path to platform directory")
 }

--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -108,11 +108,6 @@ func FlagPlanPath(planPath *string) {
 	flagSet.StringVar(planPath, "plan", *planPath, "path to plan.toml")
 }
 
-// FlagParallelExport parses `parallel` flag
-func FlagParallelExport(parallelExport *bool) {
-	flagSet.BoolVar(parallelExport, "parallel", *parallelExport, "export app image and cache image in parallel")
-}
-
 func FlagPlatformDir(platformDir *string) {
 	flagSet.StringVar(platformDir, "platform", *platformDir, "path to platform directory")
 }

--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -112,6 +112,11 @@ func FlagPlatformDir(platformDir *string) {
 	flagSet.StringVar(platformDir, "platform", *platformDir, "path to platform directory")
 }
 
+// FlagParallelExport parses `parallel` flag
+func FlagParallelExport(parallelExport *bool) {
+	flagSet.BoolVar(parallelExport, "parallel", *parallelExport, "export app image and cache image in parallel")
+}
+
 func FlagPreviousImage(previousImage *string) {
 	flagSet.StringVar(previousImage, "previous-image", *previousImage, "reference to previous image")
 }

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -52,7 +52,6 @@ func (c *createCmd) DefineFlags() {
 	cli.FlagLauncherPath(&c.LauncherPath)
 	cli.FlagLayersDir(&c.LayersDir)
 	cli.FlagOrderPath(&c.OrderPath)
-	cli.FlagParallelExport(&c.ParallelExport)
 	cli.FlagPlatformDir(&c.PlatformDir)
 	cli.FlagPreviousImage(&c.PreviousImageRef)
 	cli.FlagProcessType(&c.DefaultProcessType)

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -52,6 +52,7 @@ func (c *createCmd) DefineFlags() {
 	cli.FlagLauncherPath(&c.LauncherPath)
 	cli.FlagLayersDir(&c.LayersDir)
 	cli.FlagOrderPath(&c.OrderPath)
+	cli.FlagParallelExport(&c.ParallelExport)
 	cli.FlagPlatformDir(&c.PlatformDir)
 	cli.FlagPreviousImage(&c.PreviousImageRef)
 	cli.FlagProcessType(&c.DefaultProcessType)

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/buildpacks/lifecycle/auth"
 	"github.com/buildpacks/lifecycle/buildpack"
@@ -72,6 +74,7 @@ func (e *exportCmd) DefineFlags() {
 	cli.FlagLaunchCacheDir(&e.LaunchCacheDir)
 	cli.FlagLauncherPath(&e.LauncherPath)
 	cli.FlagLayersDir(&e.LayersDir)
+	cli.FlagParallelExport(&e.ParallelExport)
 	cli.FlagProcessType(&e.DefaultProcessType)
 	cli.FlagProjectMetadataPath(&e.ProjectMetadataPath)
 	cli.FlagReportPath(&e.ReportPath)
@@ -170,6 +173,12 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 		return err
 	}
 
+	g := new(errgroup.Group)
+	var ctx context.Context
+
+	if e.ParallelExport {
+		g, ctx = errgroup.WithContext(context.Background())
+	}
 	exporter := &phase.Exporter{
 		Buildpacks: group.Group,
 		LayerFactory: &layers.Factory{
@@ -177,6 +186,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 			UID:          e.UID,
 			GID:          e.GID,
 			Logger:       cmd.DefaultLogger,
+			Ctx:          ctx,
 		},
 		Logger:      cmd.DefaultLogger,
 		PlatformAPI: e.PlatformAPI,
@@ -203,31 +213,48 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 		return err
 	}
 
-	report, err := exporter.Export(phase.ExportOptions{
-		AdditionalNames:    e.AdditionalTags,
-		AppDir:             e.AppDir,
-		DefaultProcessType: e.DefaultProcessType,
-		ExtendedDir:        e.ExtendedDir,
-		LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
-		LayersDir:          e.LayersDir,
-		OrigMetadata:       analyzedMD.LayersMetadata,
-		Project:            projectMD,
-		RunImageRef:        runImageID,
-		RunImageForExport:  runImageForExport,
-		WorkingImage:       appImage,
+	g.Go(func() error {
+		report, err := exporter.Export(phase.ExportOptions{
+			AdditionalNames:    e.AdditionalTags,
+			AppDir:             e.AppDir,
+			DefaultProcessType: e.DefaultProcessType,
+			ExtendedDir:        e.ExtendedDir,
+			LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
+			LayersDir:          e.LayersDir,
+			OrigMetadata:       analyzedMD.LayersMetadata,
+			Project:            projectMD,
+			RunImageRef:        runImageID,
+			RunImageForExport:  runImageForExport,
+			WorkingImage:       appImage,
+		})
+		if err != nil {
+			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
+		}
+		if err = files.Handler.WriteReport(e.ReportPath, &report); err != nil {
+			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "write export report")
+		}
+		return nil
 	})
-	if err != nil {
-		return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
-	}
-	if err = files.Handler.WriteReport(e.ReportPath, &report); err != nil {
-		return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "write export report")
-	}
 
-	if cacheStore != nil {
-		if cacheErr := exporter.Cache(e.LayersDir, cacheStore); cacheErr != nil {
-			cmd.DefaultLogger.Warnf("Failed to export cache: %v\n", cacheErr)
+	if !e.ParallelExport {
+		if err := g.Wait(); err != nil {
+			return err
 		}
 	}
+
+	g.Go(func() error {
+		if cacheStore != nil {
+			if cacheErr := exporter.Cache(e.LayersDir, cacheStore); cacheErr != nil {
+				cmd.DefaultLogger.Warnf("Failed to export cache: %v\n", cacheErr)
+			}
+		}
+		return nil
+	})
+
+	if err = g.Wait(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/buildpacks/lifecycle/auth"
 	"github.com/buildpacks/lifecycle/buildpack"
@@ -72,6 +74,7 @@ func (e *exportCmd) DefineFlags() {
 	cli.FlagLaunchCacheDir(&e.LaunchCacheDir)
 	cli.FlagLauncherPath(&e.LauncherPath)
 	cli.FlagLayersDir(&e.LayersDir)
+	cli.FlagParallelExport(&e.ParallelExport)
 	cli.FlagProcessType(&e.DefaultProcessType)
 	cli.FlagProjectMetadataPath(&e.ProjectMetadataPath)
 	cli.FlagReportPath(&e.ReportPath)
@@ -170,6 +173,11 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 		return err
 	}
 
+	var g *errgroup.Group
+	var ctx context.Context
+	if e.ParallelExport {
+		g, ctx = errgroup.WithContext(context.Background())
+	}
 	exporter := &phase.Exporter{
 		Buildpacks: group.Group,
 		LayerFactory: &layers.Factory{
@@ -177,6 +185,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 			UID:          e.UID,
 			GID:          e.GID,
 			Logger:       cmd.DefaultLogger,
+			Ctx:          ctx,
 		},
 		Logger:      cmd.DefaultLogger,
 		PlatformAPI: e.PlatformAPI,
@@ -203,31 +212,48 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 		return err
 	}
 
-	report, err := exporter.Export(phase.ExportOptions{
-		AdditionalNames:    e.AdditionalTags,
-		AppDir:             e.AppDir,
-		DefaultProcessType: e.DefaultProcessType,
-		ExtendedDir:        e.ExtendedDir,
-		LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
-		LayersDir:          e.LayersDir,
-		OrigMetadata:       analyzedMD.LayersMetadata,
-		Project:            projectMD,
-		RunImageRef:        runImageID,
-		RunImageForExport:  runImageForExport,
-		WorkingImage:       appImage,
+	g.Go(func() error {
+		report, err := exporter.Export(phase.ExportOptions{
+			AdditionalNames:    e.AdditionalTags,
+			AppDir:             e.AppDir,
+			DefaultProcessType: e.DefaultProcessType,
+			ExtendedDir:        e.ExtendedDir,
+			LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
+			LayersDir:          e.LayersDir,
+			OrigMetadata:       analyzedMD.LayersMetadata,
+			Project:            projectMD,
+			RunImageRef:        runImageID,
+			RunImageForExport:  runImageForExport,
+			WorkingImage:       appImage,
+		})
+		if err != nil {
+			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
+		}
+		if err = files.Handler.WriteReport(e.ReportPath, &report); err != nil {
+			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "write export report")
+		}
 	})
-	if err != nil {
-		return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
-	}
-	if err = files.Handler.WriteReport(e.ReportPath, &report); err != nil {
-		return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "write export report")
-	}
 
-	if cacheStore != nil {
-		if cacheErr := exporter.Cache(e.LayersDir, cacheStore); cacheErr != nil {
-			cmd.DefaultLogger.Warnf("Failed to export cache: %v\n", cacheErr)
+	if !e.ParallelExport {
+		ctx = nil
+		if err := g.Wait(); err != nil {
+			return err
 		}
 	}
+
+	g.Go(func() error {
+		if cacheStore != nil {
+			if cacheErr := exporter.Cache(e.LayersDir, cacheStore); cacheErr != nil {
+				cmd.DefaultLogger.Warnf("Failed to export cache: %v\n", cacheErr)
+			}
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/layers/factory.go
+++ b/layers/factory.go
@@ -1,11 +1,16 @@
 package layers
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"sync"
 
 	"github.com/buildpacks/lifecycle/archive"
 	"github.com/buildpacks/lifecycle/log"
@@ -27,7 +32,9 @@ type Factory struct {
 	UID, GID     int    // UID and GID are used to normalize layer entries
 	Logger       log.Logger
 
-	tarHashes map[string]string // tarHases Stores hashes of layer tarballs for reuse between the export and cache steps.
+	// tarHashes stores hashes of layer tarballs for reuse between the export and cache steps.
+	tarHashes sync.Map
+	ctx       context.Context
 }
 
 type Layer struct {
@@ -38,38 +45,62 @@ type Layer struct {
 }
 
 func (f *Factory) writeLayer(id, createdBy string, addEntries func(tw *archive.NormalizingTarWriter) error) (layer Layer, err error) {
-	tarPath := filepath.Join(f.ArtifactsDir, escape(id)+".tar")
-	if f.tarHashes == nil {
-		f.tarHashes = make(map[string]string)
-	}
-	if sha, ok := f.tarHashes[tarPath]; ok {
-		f.Logger.Debugf("Reusing tarball for layer %q with SHA: %s\n", id, sha)
-		return Layer{
-			ID:      id,
-			TarPath: tarPath,
-			Digest:  sha,
-			History: v1.History{CreatedBy: createdBy},
-		}, nil
-	}
-	lw, err := newFileLayerWriter(tarPath)
-	if err != nil {
-		return Layer{}, err
-	}
-	defer func() {
-		if closeErr := lw.Close(); err == nil {
-			err = closeErr
-		}
-	}()
-	tw := tarWriter(lw)
-	if err := addEntries(tw); err != nil {
-		return Layer{}, err
+	if f.ctx == nil {
+		f.ctx = context.TODO()
 	}
 
-	if err := tw.Close(); err != nil {
-		return Layer{}, err
+	tarPath := filepath.Join(f.ArtifactsDir, escape(id)+".tar")
+	const processing = "processing"
+	for {
+		sha, loaded := f.tarHashes.LoadOrStore(tarPath, processing)
+		if loaded {
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("layer factory context canceled")
+			default:
+				shaString := sha.(string)
+				if shaString == processing {
+					// another goroutine is processing this layer, wait and try again
+					time.Sleep(time.Duration(500 * time.Millisecond))
+					continue
+				}
+
+				f.Logger.Debugf("Reusing tarball for layer %q with SHA: %s\n", id, shaString)
+				return Layer{
+					ID:      id,
+					TarPath: tarPath,
+					Digest:  shaString,
+					History: v1.History{CreatedBy: createdBy},
+				}, nil
+			}
+		}
+		break
 	}
-	digest := lw.Digest()
-	f.tarHashes[tarPath] = digest
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("layer factory context canceled")
+	default:
+		lw, err := newFileLayerWriter(tarPath)
+		if err != nil {
+			return Layer{}, err
+		}
+		defer func() {
+			if closeErr := lw.Close(); err == nil {
+				err = closeErr
+			}
+		}()
+		tw := tarWriter(lw)
+		if err := addEntries(tw); err != nil {
+			return Layer{}, err
+		}
+
+		if err := tw.Close(); err != nil {
+			return Layer{}, err
+		}
+		digest := lw.Digest()
+		f.tarHashes[tarPath] = digest
+	}
 	return Layer{
 		ID:      id,
 		Digest:  digest,

--- a/layers/factory.go
+++ b/layers/factory.go
@@ -1,16 +1,11 @@
 package layers
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-
-	"sync"
 
 	"github.com/buildpacks/lifecycle/archive"
 	"github.com/buildpacks/lifecycle/log"
@@ -32,9 +27,7 @@ type Factory struct {
 	UID, GID     int    // UID and GID are used to normalize layer entries
 	Logger       log.Logger
 
-	// tarHashes stores hashes of layer tarballs for reuse between the export and cache steps.
-	tarHashes sync.Map
-	ctx       context.Context
+	tarHashes map[string]string // tarHases Stores hashes of layer tarballs for reuse between the export and cache steps.
 }
 
 type Layer struct {
@@ -45,62 +38,38 @@ type Layer struct {
 }
 
 func (f *Factory) writeLayer(id, createdBy string, addEntries func(tw *archive.NormalizingTarWriter) error) (layer Layer, err error) {
-	if f.ctx == nil {
-		f.ctx = context.TODO()
-	}
-
 	tarPath := filepath.Join(f.ArtifactsDir, escape(id)+".tar")
-	const processing = "processing"
-	for {
-		sha, loaded := f.tarHashes.LoadOrStore(tarPath, processing)
-		if loaded {
-			select {
-			case <-ctx.Done():
-				return nil, fmt.Errorf("layer factory context canceled")
-			default:
-				shaString := sha.(string)
-				if shaString == processing {
-					// another goroutine is processing this layer, wait and try again
-					time.Sleep(time.Duration(500 * time.Millisecond))
-					continue
-				}
-
-				f.Logger.Debugf("Reusing tarball for layer %q with SHA: %s\n", id, shaString)
-				return Layer{
-					ID:      id,
-					TarPath: tarPath,
-					Digest:  shaString,
-					History: v1.History{CreatedBy: createdBy},
-				}, nil
-			}
+	if f.tarHashes == nil {
+		f.tarHashes = make(map[string]string)
+	}
+	if sha, ok := f.tarHashes[tarPath]; ok {
+		f.Logger.Debugf("Reusing tarball for layer %q with SHA: %s\n", id, sha)
+		return Layer{
+			ID:      id,
+			TarPath: tarPath,
+			Digest:  sha,
+			History: v1.History{CreatedBy: createdBy},
+		}, nil
+	}
+	lw, err := newFileLayerWriter(tarPath)
+	if err != nil {
+		return Layer{}, err
+	}
+	defer func() {
+		if closeErr := lw.Close(); err == nil {
+			err = closeErr
 		}
-		break
+	}()
+	tw := tarWriter(lw)
+	if err := addEntries(tw); err != nil {
+		return Layer{}, err
 	}
 
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("layer factory context canceled")
-	default:
-		lw, err := newFileLayerWriter(tarPath)
-		if err != nil {
-			return Layer{}, err
-		}
-		defer func() {
-			if closeErr := lw.Close(); err == nil {
-				err = closeErr
-			}
-		}()
-		tw := tarWriter(lw)
-		if err := addEntries(tw); err != nil {
-			return Layer{}, err
-		}
-
-		if err := tw.Close(); err != nil {
-			return Layer{}, err
-		}
-		digest := lw.Digest()
-		f.tarHashes[tarPath] = digest
+	if err := tw.Close(); err != nil {
+		return Layer{}, err
 	}
+	digest := lw.Digest()
+	f.tarHashes[tarPath] = digest
 	return Layer{
 		ID:      id,
 		Digest:  digest,

--- a/layers/factory.go
+++ b/layers/factory.go
@@ -1,9 +1,12 @@
 package layers
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
@@ -20,14 +23,15 @@ const (
 	ProcessTypesLayerName   = "Buildpacks Process Types"
 	SBOMLayerName           = "Software Bill-of-Materials"
 	SliceLayerName          = "Application Slice: %d"
+	processing              = "processing"
 )
 
 type Factory struct {
 	ArtifactsDir string // ArtifactsDir is the directory where layer files are written
 	UID, GID     int    // UID and GID are used to normalize layer entries
 	Logger       log.Logger
-
-	tarHashes map[string]string // tarHases Stores hashes of layer tarballs for reuse between the export and cache steps.
+	Ctx          context.Context
+	tarHashes    sync.Map // tarHases Stores hashes of layer tarballs for reuse between the export and cache steps.
 }
 
 type Layer struct {
@@ -38,44 +42,66 @@ type Layer struct {
 }
 
 func (f *Factory) writeLayer(id, createdBy string, addEntries func(tw *archive.NormalizingTarWriter) error) (layer Layer, err error) {
+	if f.Ctx == nil {
+		f.Ctx = context.TODO()
+	}
 	tarPath := filepath.Join(f.ArtifactsDir, escape(id)+".tar")
-	if f.tarHashes == nil {
-		f.tarHashes = make(map[string]string)
-	}
-	if sha, ok := f.tarHashes[tarPath]; ok {
-		f.Logger.Debugf("Reusing tarball for layer %q with SHA: %s\n", id, sha)
-		return Layer{
-			ID:      id,
-			TarPath: tarPath,
-			Digest:  sha,
-			History: v1.History{CreatedBy: createdBy},
-		}, nil
-	}
-	lw, err := newFileLayerWriter(tarPath)
-	if err != nil {
-		return Layer{}, err
-	}
-	defer func() {
-		if closeErr := lw.Close(); err == nil {
-			err = closeErr
+	for {
+		sha, loaded := f.tarHashes.LoadOrStore(tarPath, processing)
+		if loaded {
+			select {
+			case <-f.Ctx.Done():
+				return Layer{}, f.Ctx.Err()
+			default:
+				shaString := sha.(string)
+				if shaString == processing {
+					// another goroutine is processing this layer, wait and try again
+					time.Sleep(500 * time.Millisecond)
+					continue
+				}
+
+				f.Logger.Debugf("Reusing tarball for layer %q with SHA: %s\n", id, shaString)
+				return Layer{
+					ID:      id,
+					TarPath: tarPath,
+					Digest:  shaString,
+					History: v1.History{CreatedBy: createdBy},
+				}, nil
+			}
 		}
-	}()
-	tw := tarWriter(lw)
-	if err := addEntries(tw); err != nil {
-		return Layer{}, err
+		break
 	}
 
-	if err := tw.Close(); err != nil {
-		return Layer{}, err
+	select {
+	case <-f.Ctx.Done():
+		return Layer{}, f.Ctx.Err()
+	default:
+		lw, err := newFileLayerWriter(tarPath)
+		if err != nil {
+			return Layer{}, err
+		}
+		defer func() {
+			if closeErr := lw.Close(); err == nil {
+				err = closeErr
+			}
+		}()
+		tw := tarWriter(lw)
+		if err := addEntries(tw); err != nil {
+			return Layer{}, err
+		}
+
+		if err := tw.Close(); err != nil {
+			return Layer{}, err
+		}
+		digest := lw.Digest()
+		f.tarHashes.Store(tarPath, digest)
+		return Layer{
+			ID:      id,
+			Digest:  digest,
+			TarPath: tarPath,
+			History: v1.History{CreatedBy: createdBy},
+		}, err
 	}
-	digest := lw.Digest()
-	f.tarHashes[tarPath] = digest
-	return Layer{
-		ID:      id,
-		Digest:  digest,
-		TarPath: tarPath,
-		History: v1.History{CreatedBy: createdBy},
-	}, err
 }
 
 func escape(id string) string {

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -189,9 +189,6 @@ const (
 
 	// EnvKanikoCacheTTL is the amount of time to persist layers cached by kaniko during the `extend` phase.
 	EnvKanikoCacheTTL = "CNB_KANIKO_CACHE_TTL"
-
-	// EnvParallelExport is a flag used to instruct the lifecycle to export of application image and cache image in parallel, if true.
-	EnvParallelExport = "CNB_PARALLEL_EXPORT"
 )
 
 // DefaultKanikoCacheTTL is the default kaniko cache TTL (2 weeks).

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -189,6 +189,9 @@ const (
 
 	// EnvKanikoCacheTTL is the amount of time to persist layers cached by kaniko during the `extend` phase.
 	EnvKanikoCacheTTL = "CNB_KANIKO_CACHE_TTL"
+
+	// EnvParallelExport is a flag used to instruct the lifecycle to export of application image and cache image in parallel, if true.
+	EnvParallelExport = "CNB_PARALLEL_EXPORT"
 )
 
 // DefaultKanikoCacheTTL is the default kaniko cache TTL (2 weeks).

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -55,7 +55,6 @@ type LifecycleInputs struct {
 	GID                   int
 	ForceRebase           bool
 	SkipLayers            bool
-	ParallelExport        bool
 	UseDaemon             bool
 	UseLayout             bool
 	AdditionalTags        str.Slice // str.Slice satisfies the `Value` interface required by the `flag` package
@@ -132,7 +131,6 @@ func NewLifecycleInputs(platformAPI *api.Version) *LifecycleInputs {
 		KanikoDir:      "/kaniko",
 		LaunchCacheDir: os.Getenv(EnvLaunchCacheDir),
 		SkipLayers:     skipLayers,
-		ParallelExport: boolEnv(EnvParallelExport),
 
 		// Images used by the lifecycle during the build
 

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -55,6 +55,7 @@ type LifecycleInputs struct {
 	GID                   int
 	ForceRebase           bool
 	SkipLayers            bool
+	ParallelExport        bool
 	UseDaemon             bool
 	UseLayout             bool
 	AdditionalTags        str.Slice // str.Slice satisfies the `Value` interface required by the `flag` package
@@ -131,6 +132,7 @@ func NewLifecycleInputs(platformAPI *api.Version) *LifecycleInputs {
 		KanikoDir:      "/kaniko",
 		LaunchCacheDir: os.Getenv(EnvLaunchCacheDir),
 		SkipLayers:     skipLayers,
+		ParallelExport: boolEnv(EnvParallelExport),
 
 		// Images used by the lifecycle during the build
 

--- a/platform/resolve_create_inputs_test.go
+++ b/platform/resolve_create_inputs_test.go
@@ -45,6 +45,17 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 				h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.12"), "")
 			})
 
+			when("parallel export is enabled and cache image ref is blank", func() {
+				it("warns", func() {
+					inputs.ParallelExport = true
+					inputs.CacheImageRef = ""
+					err := platform.ResolveInputs(platform.Create, inputs, logger)
+					h.AssertNil(t, err)
+					expected := "parallel export has been enabled, but it has not taken effect because cache image (-cache-image) has not been specified."
+					h.AssertLogEntry(t, logHandler, expected)
+				})
+			})
+
 			when("run image", func() {
 				when("not provided", func() {
 					it.Before(func() {

--- a/platform/resolve_create_inputs_test.go
+++ b/platform/resolve_create_inputs_test.go
@@ -45,17 +45,6 @@ func testResolveCreateInputs(platformAPI string) func(t *testing.T, when spec.G,
 				h.SkipIf(t, api.MustParse(platformAPI).LessThan("0.12"), "")
 			})
 
-			when("parallel export is enabled and cache image ref is blank", func() {
-				it("warns", func() {
-					inputs.ParallelExport = true
-					inputs.CacheImageRef = ""
-					err := platform.ResolveInputs(platform.Create, inputs, logger)
-					h.AssertNil(t, err)
-					expected := "parallel export has been enabled, but it has not taken effect because cache image (-cache-image) has not been specified."
-					h.AssertLogEntry(t, logHandler, expected)
-				})
-			})
-
 			when("run image", func() {
 				when("not provided", func() {
 					it.Before(func() {

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -36,6 +36,7 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
+			CheckParallelExport,
 		)
 	case Build:
 		// nop
@@ -47,6 +48,7 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
+			CheckParallelExport,
 		)
 	case Detect:
 		// nop
@@ -224,6 +226,14 @@ func ValidateRebaseRunImage(i *LifecycleInputs, _ log.Logger) error {
 	default:
 		return nil
 	}
+}
+
+// CheckParallelExport will validate cache image references when parallel export is enabled.
+func CheckParallelExport(i *LifecycleInputs, logger log.Logger) error {
+	if i.ParallelExport && i.CacheImageRef == "" {
+		logger.Warn("parallel export has been enabled, but it has not taken effect because cache image (-cache-image) has not been specified.")
+	}
+	return nil
 }
 
 // ValidateTargetsAreSameRegistry ensures all output images are on the same registry.

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -47,6 +47,7 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
+			CheckParallelExport,
 		)
 	case Detect:
 		// nop
@@ -58,6 +59,7 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
+			CheckParallelExport,
 		)
 	case Extend:
 		// nop
@@ -224,6 +226,14 @@ func ValidateRebaseRunImage(i *LifecycleInputs, _ log.Logger) error {
 	default:
 		return nil
 	}
+}
+
+// CheckParallelExport will validate cache image references when parallel export is enabled.
+func CheckParallelExport(i *LifecycleInputs, logger log.Logger) error {
+	if i.ParallelExport && i.CacheImageRef == "" {
+		logger.Warn("parallel export has been enabled, but it has not taken effect because cache image (-cache-image) has not been specified.")
+	}
+	return nil
 }
 
 // ValidateTargetsAreSameRegistry ensures all output images are on the same registry.

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -47,7 +47,6 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
-			CheckParallelExport,
 		)
 	case Detect:
 		// nop
@@ -59,7 +58,6 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
-			CheckParallelExport,
 		)
 	case Extend:
 		// nop
@@ -226,14 +224,6 @@ func ValidateRebaseRunImage(i *LifecycleInputs, _ log.Logger) error {
 	default:
 		return nil
 	}
-}
-
-// CheckParallelExport will validate cache image references when parallel export is enabled.
-func CheckParallelExport(i *LifecycleInputs, logger log.Logger) error {
-	if i.ParallelExport && i.CacheImageRef == "" {
-		logger.Warn("parallel export has been enabled, but it has not taken effect because cache image (-cache-image) has not been specified.")
-	}
-	return nil
 }
 
 // ValidateTargetsAreSameRegistry ensures all output images are on the same registry.


### PR DESCRIPTION
cc - credits Woa me@wuzy.cn for initiating this work

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
Export cache image and app image in parallel when parallel-export is enabled by platform.


#### Release notes
Export cache image and app image in parallel when parallel-export is enabled by platform.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1167 

---

### Context
Export app image and cache image in parallel when enabled by platform. 

