### PR TITLE
Creator errors if detected order contains extensions

### DIFF
--- a/acceptance/testdata/creator/container/cnb/extensions/samples_hello-world/0.0.1/extension.toml
+++ b/acceptance/testdata/creator/container/cnb/extensions/samples_hello-world/0.0.1/extension.toml
@@ -1,0 +1,8 @@
+# Buildpack API version
+api = "0.9"
+
+# Extension ID and metadata
+[extension]
+id = "samples/hello-world"
+version = "0.0.1"
+name = "Hello World Extension"

--- a/acceptance/testdata/creator/container/cnb/order-with-extensions.toml
+++ b/acceptance/testdata/creator/container/cnb/order-with-extensions.toml
@@ -1,0 +1,9 @@
+[[order]]
+[[order.group]]
+id = "samples/hello-world"
+version = "0.0.1"
+
+[[order-extensions]]
+[[order-extensions.group]]
+id = "samples/hello-world"
+version = "0.0.1"

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -111,7 +111,7 @@ func (c *createCmd) Exec() error {
 	if err != nil {
 		return err
 	}
-	dirStore := platform.NewDirStore(c.BuildpacksDir, "")
+	dirStore := platform.NewDirStore(c.BuildpacksDir, c.ExtensionsDir)
 	if err != nil {
 		return err
 	}
@@ -158,6 +158,13 @@ func (c *createCmd) Exec() error {
 	group, plan, err = doDetect(detector, c.Platform)
 	if err != nil {
 		return err // pass through error
+	}
+	if group.HasExtensions() {
+		return cmd.FailErrCode(
+			errors.New("detected order contains extensions which is not supported by the creator"),
+			c.CodeFor(platform.DetectError),
+			"detect",
+		)
 	}
 
 	// Restore


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Previously, if a platform provided an order.toml containing extensions, the creator would error due to "missing extensions directory". Now, the creator will actually run detect on the order and error with a "not supported" message if the detected group contains extensions, proceeding otherwise. 

This will allow builders to contain extensions and builds to succeed if the contained extensions do not detect by default (see https://github.com/buildpacks/community/discussions/244).

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Creator errors if detected order contains extensions

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves https://github.com/buildpacks/lifecycle/issues/1241
