### PR TITLE
Fix draft release workflow by giving GITHUB_TOKEN additional permissions

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   draft-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Install jq


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

In https://github.com/buildpacks/lifecycle/pull/1201 we explicitly granted
the needed permissions to the token, and we updated the repo settings to be the most restrictive.
Now that the repo has been updated, the draft-release workflow is broken
for minor versions less than 0.18.x.
    
This change will allow us to continue to patch 0.17.x.