### PR TITLE
FIXME: Used logger instead of returning the message

### DIFF
--- a/buildpack/layermetadata.go
+++ b/buildpack/layermetadata.go
@@ -49,7 +49,8 @@ func DecodeLayerMetadataFile(path string, buildpackAPI string, logger log.Logger
 		if decoder.IsSupported(buildpackAPI) {
 			lmf, str, err := decoder.Decode(path)
 			if str != "" {
-				return LayerMetadataFile{}, errors.New(str)
+				//instead of returning an error string , used the logger to print a warning
+				logger.Warnf("Warning while decoding layer metadata file at %s: %s", path, str)
 			}
 			return lmf, err
 		}

--- a/buildpack/layermetadata.go
+++ b/buildpack/layermetadata.go
@@ -51,6 +51,7 @@ func DecodeLayerMetadataFile(path string, buildpackAPI string, logger log.Logger
 			if str != "" {
 				// instead of returning an error string , used the logger to print a warning
 				logger.Warnf("Warning while decoding layer metadata file at %s: %s", path, str)
+
 			}
 			return lmf, err
 		}

--- a/buildpack/layermetadata.go
+++ b/buildpack/layermetadata.go
@@ -49,7 +49,7 @@ func DecodeLayerMetadataFile(path string, buildpackAPI string, logger log.Logger
 		if decoder.IsSupported(buildpackAPI) {
 			lmf, str, err := decoder.Decode(path)
 			if str != "" {
-				//instead of returning an error string , used the logger to print a warning
+				// instead of returning an error string , used the logger to print a warning
 				logger.Warnf("Warning while decoding layer metadata file at %s: %s", path, str)
 			}
 			return lmf, err

--- a/buildpack/layermetadata.go
+++ b/buildpack/layermetadata.go
@@ -51,7 +51,6 @@ func DecodeLayerMetadataFile(path string, buildpackAPI string, logger log.Logger
 			if str != "" {
 				// instead of returning an error string , used the logger to print a warning
 				logger.Warnf("Warning while decoding layer metadata file at %s: %s", path, str)
-
 			}
 			return lmf, err
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
pass the logger and print the warning inside ,instead of returning a message



#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->



---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #914 

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

