### PR TITLE
Ignore non-impactful CVEs in .grype.yaml

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,4 +1,7 @@
 ignore:
   - vulnerability: CVE-2015-5237 # false positive, see https://github.com/anchore/grype/issues/558
   - vulnerability: CVE-2021-22570 # false positive, see https://github.com/anchore/grype/issues/558
-  - vulnerability: GHSA-jq35-85cj-fj4p # non-impactful as the lifecycle doesn't create containers
+  - vulnerability: GHSA-4v98-7qmw-rqr8 # non-impactful as the lifecycle doesn't invoke BuildKit frontends
+  - vulnerability: GHSA-9p26-698r-w4hx # non-impactful as the lifecycle doesn't invoke BuildKit frontends
+  - vulnerability: GHSA-m3r6-h7wv-7xxv # non-impactful as the lifecycle doesn't invoke BuildKit frontends
+  - vulnerability: GHSA-wr6v-9f75-vh2g # non-impactful as the lifecycle doesn't invoke BuildKit frontends


### PR DESCRIPTION
These are patched in BuildKit 0.12.5 but we are pinned to BuildKit 0.11.x because of Docker v24.0.x and we are pinned there because of GGCR & kaniko.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Ignore non-impactful CVEs in .grype.yaml