### PR TITLE
refactor `phase/extender_test.go`

### DIFF
--- a/phase/extender_test.go
+++ b/phase/extender_test.go
@@ -196,623 +196,327 @@ func testExtender(t *testing.T, when spec.G, it spec.S) {
 			mockCtrl.Finish()
 		})
 
-		when("using the platform API 0.12", func() {
-			it.Before(func() {
-				extender.PlatformAPI = api.MustParse("0.12")
-			})
+		prepareDockerfile := func(id, kind, contextDir string) extend.Dockerfile {
+			basePath := filepath.Join(generatedDir, kind, id)
+			dockerfilePath := filepath.Join(basePath, "Dockerfile")
 
-			when("build base image", func() {
-				it("applies the Dockerfile with the expected args and opts", func() {
-					expectedDockerfileA := extend.Dockerfile{
-						Path: filepath.Join(generatedDir, "build", "A", "Dockerfile"),
-						Args: []extend.Arg{{Name: "argA", Value: "valueA"}},
-					}
-					h.Mkdir(t, filepath.Join(generatedDir, "build", "A"))
-					h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "build", "A", "Dockerfile"))
-					buf := new(bytes.Buffer)
-					data := extend.Config{Build: extend.BuildConfig{Args: expectedDockerfileA.Args}}
-					h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-					h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "build", "A", "extend-config.toml"))
+			if extender.PlatformAPI.AtLeast("0.13") {
+				basePath = filepath.Join(generatedDir, id)
+				dockerfilePath = filepath.Join(basePath, fmt.Sprintf("%s.Dockerfile", kind))
+			} else {
+				h.AssertEq(t, contextDir, "app")
+			}
 
-					expectedDockerfileB := extend.Dockerfile{
-						Path: filepath.Join(generatedDir, "build", "B", "Dockerfile"),
-						Args: []extend.Arg{{Name: "argB", Value: "valueB"}},
-					}
-					h.Mkdir(t, filepath.Join(generatedDir, "build", "B"))
-					h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "build", "B", "Dockerfile"))
-					buf = new(bytes.Buffer)
-					data = extend.Config{Build: extend.BuildConfig{Args: expectedDockerfileB.Args}}
-					h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-					h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "build", "B", "extend-config.toml"))
+			expectedDockerfile := extend.Dockerfile{
+				Path: dockerfilePath,
+				Args: []extend.Arg{{Name: fmt.Sprintf("arg%s", id), Value: fmt.Sprintf("value%s", id)}},
+			}
+			h.Mkdir(t, basePath)
+			h.Mkfile(t, "some dockerfile content", dockerfilePath)
 
-					fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
-					someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
+			buf := new(bytes.Buffer)
+			var data extend.Config
+			switch kind {
+			case "run":
+				data = extend.Config{Run: extend.BuildConfig{Args: expectedDockerfile.Args}}
+			case "build":
+				data = extend.Config{Build: extend.BuildConfig{Args: expectedDockerfile.Args}}
+			default:
+				t.Fail()
+			}
+			switch contextDir {
+			case "specific":
+				h.Mkdir(t, filepath.Join(basePath, fmt.Sprintf("context.%s", kind)))
+			case "shared":
+				h.Mkdir(t, filepath.Join(basePath, "context"))
+			case "app":
+				// nothing to do
+			default:
+				t.Fail()
+			}
+			h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
+			h.Mkfile(t, buf.String(), filepath.Join(basePath, "extend-config.toml"))
+			return expectedDockerfile
+		}
 
-					// first dockerfile
+		for _, platformAPI := range []*api.Version{
+			api.MustParse("0.12"),
+			api.MustParse("0.13"),
+		} {
+			platformAPI := platformAPI
 
-					firstConfig := &v1.ConfigFile{Config: v1.Config{
-						User: "0:5678",
-					}}
-					someFakeImage.ConfigFileReturnsOnCall(0, firstConfig, nil)
-					fakeDockerfileApplier.EXPECT().Apply(
-						gomock.Any(),
-						gomock.Any(), // we mutate the provided image so we can't expect the fake image
-						extend.Options{
-							BuildContext: "some-app-dir",
-							IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-							CacheTTL:     7 * (24 * time.Hour),
-						},
-						logger,
-					).DoAndReturn(
-						func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-							h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
-							h.AssertEq(t, len(dockerfile.Args), 4)
-							h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-							_, err := uuid.Parse(dockerfile.Args[0].Value)
-							h.AssertNil(t, err)
-							h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-							h.AssertEq(t, dockerfile.Args[1].Value, "0")
-							h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-							h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-							h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
-
-							return someFakeImage, nil
-						})
-					secondConfig := &v1.ConfigFile{Config: v1.Config{
-						User: "2345:6789",
-						Env:  []string{"SOME_VAR=some-val"},
-					}}
-					someFakeImage.ConfigFileReturnsOnCall(1, secondConfig, nil)
-
-					// second dockerfile
-
-					someFakeImage.ConfigFileReturnsOnCall(2, secondConfig, nil)
-					fakeDockerfileApplier.EXPECT().Apply(
-						gomock.Any(),
-						someFakeImage,
-						extend.Options{
-							BuildContext: "some-app-dir",
-							IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-							CacheTTL:     7 * (24 * time.Hour),
-						},
-						logger,
-					).DoAndReturn(
-						func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-							h.AssertEq(t, dockerfile.Path, expectedDockerfileB.Path)
-							h.AssertEq(t, len(dockerfile.Args), 4)
-							h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-							_, err := uuid.Parse(dockerfile.Args[0].Value)
-							h.AssertNil(t, err)
-							h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-							h.AssertEq(t, dockerfile.Args[1].Value, "2345")
-							h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-							h.AssertEq(t, dockerfile.Args[2].Value, "6789")
-							h.AssertEq(t, dockerfile.Args[3], expectedDockerfileB.Args[0])
-
-							return someFakeImage, nil
-						})
-					someFakeImage.ConfigFileReturnsOnCall(3, secondConfig, nil)
-
-					fakeDockerfileApplier.EXPECT().Cleanup().Return(nil)
-
-					h.AssertNil(t, extender.Extend("build", logger))
-					h.AssertEq(t, os.Getenv("SOME_VAR"), "some-val")
-					h.AssertNil(t, os.Unsetenv("SOME_VAR"))
+			when(fmt.Sprintf("using the platform API %s", platformAPI), func() {
+				it.Before(func() {
+					extender.PlatformAPI = platformAPI
 				})
-			})
 
-			when("run base image", func() {
-				type testCase struct {
-					firstDockerfileRebasable  bool
-					secondDockerfileRebasable bool
-					expectedImageSHA          string
-				}
-				var (
-					rebasableSHA    = "sha256:2407b98f3bcee33d24f47fc3d7beaf0928b3fa799a8a84aa9f9f239fcded6e62"
-					notRebasableSHA = "sha256:cc3b90b798b76e7d41de01d4f02f2917694ef0b09d0d923314c8d6c31c4ae8e9"
-				)
-				for _, tc := range []testCase{
-					{
-						firstDockerfileRebasable:  true,
-						secondDockerfileRebasable: true,
-						expectedImageSHA:          rebasableSHA,
-					},
-					{
-						firstDockerfileRebasable:  true,
-						secondDockerfileRebasable: false,
-						expectedImageSHA:          notRebasableSHA,
-					},
-					{
-						firstDockerfileRebasable:  false,
-						secondDockerfileRebasable: true,
-						expectedImageSHA:          notRebasableSHA,
-					},
-					{
-						firstDockerfileRebasable:  false,
-						secondDockerfileRebasable: false,
-						expectedImageSHA:          notRebasableSHA,
-					},
-				} {
-					tc := tc
-					when := when
-					desc := func(b bool) string {
-						if b {
-							return "rebasable"
+				when("build base image", func() {
+					it("applies the Dockerfile with the expected args and opts", func() {
+						var expectedDockerfileA, expectedDockerfileB extend.Dockerfile
+						var expectedBuildContextA, expectedBuildContextB string
+
+						if platformAPI.AtLeast("0.13") {
+							expectedDockerfileA = prepareDockerfile("A", "build", "specific")
+							expectedBuildContextA = filepath.Join(generatedDir, "A", "context.build")
+							expectedDockerfileB = prepareDockerfile("B", "build", "shared")
+							expectedBuildContextB = filepath.Join(generatedDir, "B", "context")
+						} else {
+							expectedDockerfileA = prepareDockerfile("A", "build", "app")
+							expectedBuildContextA = "some-app-dir"
+							expectedDockerfileB = prepareDockerfile("B", "build", "app")
+							expectedBuildContextB = "some-app-dir"
 						}
-						return "not rebasable"
-					}
-					when(fmt.Sprintf("first Dockerfile is %s, second Dockerfile is %s", desc(tc.firstDockerfileRebasable), desc(tc.secondDockerfileRebasable)), func() {
-						it("applies the Dockerfile with the expected args and opts", func() {
-							expectedDockerfileA := extend.Dockerfile{
-								Path: filepath.Join(generatedDir, "run", "A", "Dockerfile"),
-								Args: []extend.Arg{{Name: "argA", Value: "valueA"}},
-							}
-							h.Mkdir(t, filepath.Join(generatedDir, "run", "A"))
-							h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "run", "A", "Dockerfile"))
-							buf := new(bytes.Buffer)
-							data := extend.Config{Run: extend.BuildConfig{Args: expectedDockerfileA.Args}}
-							h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-							h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "run", "A", "extend-config.toml"))
 
-							expectedDockerfileB := extend.Dockerfile{
-								Path: filepath.Join(generatedDir, "run", "B", "Dockerfile"),
-								Args: []extend.Arg{{Name: "argB", Value: "valueB"}},
-							}
-							h.Mkdir(t, filepath.Join(generatedDir, "run", "B"))
-							h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "run", "B", "Dockerfile"))
-							buf = new(bytes.Buffer)
-							data = extend.Config{Run: extend.BuildConfig{Args: expectedDockerfileB.Args}}
-							h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-							h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "run", "B", "extend-config.toml"))
+						fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
+						someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
 
-							fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
-							someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
-							someFakeImage.ConfigFileReturnsOnCall(0, &v1.ConfigFile{Config: v1.Config{
-								User: "1234:5678",
-							}}, nil)
+						// first dockerfile
 
-							// first dockerfile
+						firstConfig := &v1.ConfigFile{Config: v1.Config{
+							User: "0:5678",
+						}}
+						someFakeImage.ConfigFileReturnsOnCall(0, firstConfig, nil)
+						fakeDockerfileApplier.EXPECT().Apply(
+							gomock.Any(),
+							gomock.Any(), // we mutate the provided image so we can't expect the fake image
+							extend.Options{
+								BuildContext: expectedBuildContextA,
+								IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
+								CacheTTL:     7 * (24 * time.Hour),
+							},
+							logger,
+						).DoAndReturn(
+							func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
+								h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
+								h.AssertEq(t, len(dockerfile.Args), 4)
+								h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
+								_, err := uuid.Parse(dockerfile.Args[0].Value)
+								h.AssertNil(t, err)
+								h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
+								h.AssertEq(t, dockerfile.Args[1].Value, "0")
+								h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
+								h.AssertEq(t, dockerfile.Args[2].Value, "5678")
+								h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
 
-							fakeDockerfileApplier.EXPECT().Apply(
-								gomock.Any(),
-								gomock.Any(), // we mutate the provided image so we can't expect the fake image
-								extend.Options{
-									BuildContext: "some-app-dir",
-									IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-									CacheTTL:     7 * (24 * time.Hour),
-								},
-								logger,
-							).DoAndReturn(
-								func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-									h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
-									h.AssertEq(t, len(dockerfile.Args), 4) // build_id, user_id, group_id
-									h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-									_, err := uuid.Parse(dockerfile.Args[0].Value)
-									h.AssertNil(t, err)
-									h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-									h.AssertEq(t, dockerfile.Args[1].Value, "1234")
-									h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-									h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-									h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
+								return someFakeImage, nil
+							})
+						secondConfig := &v1.ConfigFile{Config: v1.Config{
+							User: "2345:6789",
+							Env:  []string{"SOME_VAR=some-val"},
+						}}
+						someFakeImage.ConfigFileReturnsOnCall(1, secondConfig, nil)
 
-									return someFakeImage, nil
-								})
-							firstConfig := &v1.ConfigFile{Config: v1.Config{
-								User:   "1234:5678",
-								Labels: map[string]string{phase.RebasableLabel: fmt.Sprintf("%t", tc.firstDockerfileRebasable)},
-							}}
-							someFakeImage.ConfigFileReturnsOnCall(1, firstConfig, nil)
+						// second dockerfile
 
-							// second dockerfile
+						someFakeImage.ConfigFileReturnsOnCall(2, secondConfig, nil)
+						fakeDockerfileApplier.EXPECT().Apply(
+							gomock.Any(),
+							someFakeImage,
+							extend.Options{
+								BuildContext: expectedBuildContextB,
+								IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
+								CacheTTL:     7 * (24 * time.Hour),
+							},
+							logger,
+						).DoAndReturn(
+							func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
+								h.AssertEq(t, dockerfile.Path, expectedDockerfileB.Path)
+								h.AssertEq(t, len(dockerfile.Args), 4)
+								h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
+								_, err := uuid.Parse(dockerfile.Args[0].Value)
+								h.AssertNil(t, err)
+								h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
+								h.AssertEq(t, dockerfile.Args[1].Value, "2345")
+								h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
+								h.AssertEq(t, dockerfile.Args[2].Value, "6789")
+								h.AssertEq(t, dockerfile.Args[3], expectedDockerfileB.Args[0])
 
-							fakeDockerfileApplier.EXPECT().Apply(
-								gomock.Any(),
-								someFakeImage,
-								extend.Options{
-									BuildContext: "some-app-dir",
-									IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-									CacheTTL:     7 * (24 * time.Hour),
-								},
-								logger,
-							).DoAndReturn(
-								func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-									h.AssertEq(t, dockerfile.Path, expectedDockerfileB.Path)
-									h.AssertEq(t, len(dockerfile.Args), 4) // build_id, user_id, group_id
-									h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-									_, err := uuid.Parse(dockerfile.Args[0].Value)
-									h.AssertNil(t, err)
-									h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-									h.AssertEq(t, dockerfile.Args[1].Value, "1234")
-									h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-									h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-									h.AssertEq(t, dockerfile.Args[3], expectedDockerfileB.Args[0])
+								return someFakeImage, nil
+							})
+						someFakeImage.ConfigFileReturnsOnCall(3, secondConfig, nil)
 
-									return someFakeImage, nil
-								})
-							secondConfig := &v1.ConfigFile{Config: v1.Config{
-								User:   "1234:5678",
-								Labels: map[string]string{phase.RebasableLabel: fmt.Sprintf("%t", tc.secondDockerfileRebasable)},
-							}}
-							someFakeImage.ConfigFileReturnsOnCall(2, secondConfig, nil)
+						fakeDockerfileApplier.EXPECT().Cleanup().Return(nil)
 
-							// set label
-
-							someFakeImage.ConfigFileReturnsOnCall(3, secondConfig, nil)
-							someFakeImage.ConfigFileReturnsOnCall(4, secondConfig, nil)
-
-							// save selective
-
-							imageHash := v1.Hash{Algorithm: "sha256", Hex: "some-image-hex"}
-							someFakeImage.DigestReturns(imageHash, nil)
-							someFakeImage.ConfigNameReturns(v1.Hash{Algorithm: "sha256", Hex: "some-config-hex"}, nil)
-
-							fakeDockerfileApplier.EXPECT().Cleanup().Return(nil)
-
-							h.AssertNil(t, extender.Extend("run", logger))
-							outputImagePath := filepath.Join(extendedDir, "run", tc.expectedImageSHA)
-							h.AssertPathExists(t, outputImagePath)
-							fis, err := os.ReadDir(outputImagePath)
-							h.AssertNil(t, err)
-							h.AssertEq(t, len(fis), 3)
-						})
+						h.AssertNil(t, extender.Extend("build", logger))
+						h.AssertEq(t, os.Getenv("SOME_VAR"), "some-val")
+						h.AssertNil(t, os.Unsetenv("SOME_VAR"))
 					})
-				}
-
-				it("errors if the last extension leaves the user as root", func() {
-					expectedDockerfileA := extend.Dockerfile{
-						Path: filepath.Join(generatedDir, "run", "A", "Dockerfile"),
-						Args: []extend.Arg{{Name: "argA", Value: "valueA"}},
-					}
-					h.Mkdir(t, filepath.Join(generatedDir, "run", "A"))
-					h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "run", "A", "Dockerfile"))
-					buf := new(bytes.Buffer)
-					data := extend.Config{Run: extend.BuildConfig{Args: expectedDockerfileA.Args}}
-					h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-					h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "run", "A", "extend-config.toml"))
-
-					fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
-					firstConfig := &v1.ConfigFile{Config: v1.Config{
-						User: "0:5678",
-					}}
-					someFakeImage.ConfigFileReturns(firstConfig, nil)
-					someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
-
-					fakeDockerfileApplier.EXPECT().Apply(
-						gomock.Any(),
-						gomock.Any(),
-						gomock.Any(),
-						logger,
-					).DoAndReturn(
-						func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-							h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
-							h.AssertEq(t, len(dockerfile.Args), 4)
-							h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-							_, err := uuid.Parse(dockerfile.Args[0].Value)
-							h.AssertNil(t, err)
-							h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-							h.AssertEq(t, dockerfile.Args[1].Value, "0")
-							h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-							h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-							h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
-
-							return someFakeImage, nil
-						})
-
-					err := extender.Extend("run", logger)
-					h.AssertError(t, err, "extending run image: the final user ID is 0 (root); please add another extension that resets the user to non-root")
 				})
-			})
-		})
 
-		when("using platform API 0.13", func() {
-			it.Before(func() {
-				extender.PlatformAPI = api.MustParse("0.13")
-			})
-
-			when("build base image", func() {
-				it("applies the Dockerfile with the expected args and opts", func() {
-					expectedDockerfileA := extend.Dockerfile{
-						Path: filepath.Join(generatedDir, "A", "build.Dockerfile"),
-						Args: []extend.Arg{{Name: "argA", Value: "valueA"}},
+				when("run base image", func() {
+					type testCase struct {
+						firstDockerfileRebasable  bool
+						secondDockerfileRebasable bool
+						expectedImageSHA          string
 					}
-					h.Mkdir(t, filepath.Join(generatedDir, "A"))
-					h.Mkdir(t, filepath.Join(generatedDir, "A", "context.build"))
-					h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "A", "build.Dockerfile"))
-					buf := new(bytes.Buffer)
-					data := extend.Config{Build: extend.BuildConfig{Args: expectedDockerfileA.Args}}
-					h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-					h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "A", "extend-config.toml"))
-
-					expectedDockerfileB := extend.Dockerfile{
-						Path:       filepath.Join(generatedDir, "B", "build.Dockerfile"),
-						Args:       []extend.Arg{{Name: "argB", Value: "valueB"}},
-						ContextDir: "dirB",
-					}
-					h.Mkdir(t, filepath.Join(generatedDir, "B"))
-					h.Mkdir(t, filepath.Join(generatedDir, "B", "context"))
-					h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "B", "build.Dockerfile"))
-					buf = new(bytes.Buffer)
-					data = extend.Config{Build: extend.BuildConfig{Args: expectedDockerfileB.Args}}
-					h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-					h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "B", "extend-config.toml"))
-
-					fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
-					someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
-
-					// first dockerfile
-
-					firstConfig := &v1.ConfigFile{Config: v1.Config{
-						User: "0:5678",
-					}}
-					someFakeImage.ConfigFileReturnsOnCall(0, firstConfig, nil)
-					fakeDockerfileApplier.EXPECT().Apply(
-						gomock.Any(),
-						gomock.Any(), // we mutate the provided image so we can't expect the fake image
-						extend.Options{
-							BuildContext: filepath.Join(generatedDir, "A", "context.build"),
-							IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-							CacheTTL:     7 * (24 * time.Hour),
+					var (
+						rebasableSHA    = "sha256:2407b98f3bcee33d24f47fc3d7beaf0928b3fa799a8a84aa9f9f239fcded6e62"
+						notRebasableSHA = "sha256:cc3b90b798b76e7d41de01d4f02f2917694ef0b09d0d923314c8d6c31c4ae8e9"
+					)
+					for _, tc := range []testCase{
+						{
+							firstDockerfileRebasable:  true,
+							secondDockerfileRebasable: true,
+							expectedImageSHA:          rebasableSHA,
 						},
-						logger,
-					).DoAndReturn(
-						func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-							h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
-							h.AssertEq(t, len(dockerfile.Args), 4)
-							h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-							_, err := uuid.Parse(dockerfile.Args[0].Value)
-							h.AssertNil(t, err)
-							h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-							h.AssertEq(t, dockerfile.Args[1].Value, "0")
-							h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-							h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-							h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
-
-							return someFakeImage, nil
-						})
-					secondConfig := &v1.ConfigFile{Config: v1.Config{
-						User: "2345:6789",
-						Env:  []string{"SOME_VAR=some-val"},
-					}}
-					someFakeImage.ConfigFileReturnsOnCall(1, secondConfig, nil)
-
-					// second dockerfile
-
-					someFakeImage.ConfigFileReturnsOnCall(2, secondConfig, nil)
-					fakeDockerfileApplier.EXPECT().Apply(
-						gomock.Any(),
-						someFakeImage,
-						extend.Options{
-							BuildContext: filepath.Join(generatedDir, "B", "context"),
-							IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-							CacheTTL:     7 * (24 * time.Hour),
+						{
+							firstDockerfileRebasable:  true,
+							secondDockerfileRebasable: false,
+							expectedImageSHA:          notRebasableSHA,
 						},
-						logger,
-					).DoAndReturn(
-						func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-							h.AssertEq(t, dockerfile.Path, expectedDockerfileB.Path)
-							h.AssertEq(t, len(dockerfile.Args), 4)
-							h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-							_, err := uuid.Parse(dockerfile.Args[0].Value)
-							h.AssertNil(t, err)
-							h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-							h.AssertEq(t, dockerfile.Args[1].Value, "2345")
-							h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-							h.AssertEq(t, dockerfile.Args[2].Value, "6789")
-							h.AssertEq(t, dockerfile.Args[3], expectedDockerfileB.Args[0])
-
-							return someFakeImage, nil
-						})
-					someFakeImage.ConfigFileReturnsOnCall(3, secondConfig, nil)
-
-					fakeDockerfileApplier.EXPECT().Cleanup().Return(nil)
-
-					h.AssertNil(t, extender.Extend("build", logger))
-					h.AssertEq(t, os.Getenv("SOME_VAR"), "some-val")
-					h.AssertNil(t, os.Unsetenv("SOME_VAR"))
-				})
-			})
-
-			when("run base image", func() {
-				type testCase struct {
-					firstDockerfileRebasable  bool
-					secondDockerfileRebasable bool
-					expectedImageSHA          string
-				}
-				var (
-					rebasableSHA    = "sha256:2407b98f3bcee33d24f47fc3d7beaf0928b3fa799a8a84aa9f9f239fcded6e62"
-					notRebasableSHA = "sha256:cc3b90b798b76e7d41de01d4f02f2917694ef0b09d0d923314c8d6c31c4ae8e9"
-				)
-				for _, tc := range []testCase{
-					{
-						firstDockerfileRebasable:  true,
-						secondDockerfileRebasable: true,
-						expectedImageSHA:          rebasableSHA,
-					},
-					{
-						firstDockerfileRebasable:  true,
-						secondDockerfileRebasable: false,
-						expectedImageSHA:          notRebasableSHA,
-					},
-					{
-						firstDockerfileRebasable:  false,
-						secondDockerfileRebasable: true,
-						expectedImageSHA:          notRebasableSHA,
-					},
-					{
-						firstDockerfileRebasable:  false,
-						secondDockerfileRebasable: false,
-						expectedImageSHA:          notRebasableSHA,
-					},
-				} {
-					tc := tc
-					when := when
-					desc := func(b bool) string {
-						if b {
-							return "rebasable"
+						{
+							firstDockerfileRebasable:  false,
+							secondDockerfileRebasable: true,
+							expectedImageSHA:          notRebasableSHA,
+						},
+						{
+							firstDockerfileRebasable:  false,
+							secondDockerfileRebasable: false,
+							expectedImageSHA:          notRebasableSHA,
+						},
+					} {
+						tc := tc
+						when := when
+						desc := func(b bool) string {
+							if b {
+								return "rebasable"
+							}
+							return "not rebasable"
 						}
-						return "not rebasable"
-					}
-					when(fmt.Sprintf("first Dockerfile is %s, second Dockerfile is %s", desc(tc.firstDockerfileRebasable), desc(tc.secondDockerfileRebasable)), func() {
-						it("applies the Dockerfile with the expected args and opts", func() {
-							expectedDockerfileA := extend.Dockerfile{
-								Path: filepath.Join(generatedDir, "A", "run.Dockerfile"),
-								Args: []extend.Arg{{Name: "argA", Value: "valueA"}},
-							}
-							h.Mkdir(t, filepath.Join(generatedDir, "A"))
-							h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "A", "run.Dockerfile"))
-							buf := new(bytes.Buffer)
-							data := extend.Config{Run: extend.BuildConfig{Args: expectedDockerfileA.Args}}
-							h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-							h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "A", "extend-config.toml"))
+						when(fmt.Sprintf("first Dockerfile is %s, second Dockerfile is %s", desc(tc.firstDockerfileRebasable), desc(tc.secondDockerfileRebasable)), func() {
+							it("applies the Dockerfile with the expected args and opts", func() {
+								expectedDockerfileA := prepareDockerfile("A", "run", "app")
+								expectedDockerfileB := prepareDockerfile("B", "run", "app")
 
-							expectedDockerfileB := extend.Dockerfile{
-								Path: filepath.Join(generatedDir, "B", "run.Dockerfile"),
-								Args: []extend.Arg{{Name: "argB", Value: "valueB"}},
-							}
-							h.Mkdir(t, filepath.Join(generatedDir, "B"))
-							h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "B", "run.Dockerfile"))
-							buf = new(bytes.Buffer)
-							data = extend.Config{Run: extend.BuildConfig{Args: expectedDockerfileB.Args}}
-							h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-							h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "B", "extend-config.toml"))
+								fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
+								someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
+								someFakeImage.ConfigFileReturnsOnCall(0, &v1.ConfigFile{Config: v1.Config{
+									User: "1234:5678",
+								}}, nil)
 
-							fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
-							someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
-							someFakeImage.ConfigFileReturnsOnCall(0, &v1.ConfigFile{Config: v1.Config{
-								User: "1234:5678",
-							}}, nil)
+								// first dockerfile
 
-							// first dockerfile
+								fakeDockerfileApplier.EXPECT().Apply(
+									gomock.Any(),
+									gomock.Any(), // we mutate the provided image so we can't expect the fake image
+									extend.Options{
+										BuildContext: "some-app-dir",
+										IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
+										CacheTTL:     7 * (24 * time.Hour),
+									},
+									logger,
+								).DoAndReturn(
+									func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
+										h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
+										h.AssertEq(t, len(dockerfile.Args), 4) // build_id, user_id, group_id
+										h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
+										_, err := uuid.Parse(dockerfile.Args[0].Value)
+										h.AssertNil(t, err)
+										h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
+										h.AssertEq(t, dockerfile.Args[1].Value, "1234")
+										h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
+										h.AssertEq(t, dockerfile.Args[2].Value, "5678")
+										h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
 
-							fakeDockerfileApplier.EXPECT().Apply(
-								gomock.Any(),
-								gomock.Any(), // we mutate the provided image so we can't expect the fake image
-								extend.Options{
-									BuildContext: "some-app-dir",
-									IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-									CacheTTL:     7 * (24 * time.Hour),
-								},
-								logger,
-							).DoAndReturn(
-								func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-									h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
-									h.AssertEq(t, len(dockerfile.Args), 4) // build_id, user_id, group_id
-									h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-									_, err := uuid.Parse(dockerfile.Args[0].Value)
-									h.AssertNil(t, err)
-									h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-									h.AssertEq(t, dockerfile.Args[1].Value, "1234")
-									h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-									h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-									h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
+										return someFakeImage, nil
+									})
+								firstConfig := &v1.ConfigFile{Config: v1.Config{
+									User:   "1234:5678",
+									Labels: map[string]string{phase.RebasableLabel: fmt.Sprintf("%t", tc.firstDockerfileRebasable)},
+								}}
+								someFakeImage.ConfigFileReturnsOnCall(1, firstConfig, nil)
 
-									return someFakeImage, nil
-								})
-							firstConfig := &v1.ConfigFile{Config: v1.Config{
-								User:   "1234:5678",
-								Labels: map[string]string{phase.RebasableLabel: fmt.Sprintf("%t", tc.firstDockerfileRebasable)},
-							}}
-							someFakeImage.ConfigFileReturnsOnCall(1, firstConfig, nil)
+								// second dockerfile
 
-							// second dockerfile
+								fakeDockerfileApplier.EXPECT().Apply(
+									gomock.Any(),
+									someFakeImage,
+									extend.Options{
+										BuildContext: "some-app-dir",
+										IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
+										CacheTTL:     7 * (24 * time.Hour),
+									},
+									logger,
+								).DoAndReturn(
+									func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
+										h.AssertEq(t, dockerfile.Path, expectedDockerfileB.Path)
+										h.AssertEq(t, len(dockerfile.Args), 4) // build_id, user_id, group_id
+										h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
+										_, err := uuid.Parse(dockerfile.Args[0].Value)
+										h.AssertNil(t, err)
+										h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
+										h.AssertEq(t, dockerfile.Args[1].Value, "1234")
+										h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
+										h.AssertEq(t, dockerfile.Args[2].Value, "5678")
+										h.AssertEq(t, dockerfile.Args[3], expectedDockerfileB.Args[0])
 
-							fakeDockerfileApplier.EXPECT().Apply(
-								gomock.Any(),
-								someFakeImage,
-								extend.Options{
-									BuildContext: "some-app-dir",
-									IgnorePaths:  []string{"some-app-dir", "some-layers-dir", "some-platform-dir"},
-									CacheTTL:     7 * (24 * time.Hour),
-								},
-								logger,
-							).DoAndReturn(
-								func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-									h.AssertEq(t, dockerfile.Path, expectedDockerfileB.Path)
-									h.AssertEq(t, len(dockerfile.Args), 4) // build_id, user_id, group_id
-									h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-									_, err := uuid.Parse(dockerfile.Args[0].Value)
-									h.AssertNil(t, err)
-									h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-									h.AssertEq(t, dockerfile.Args[1].Value, "1234")
-									h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-									h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-									h.AssertEq(t, dockerfile.Args[3], expectedDockerfileB.Args[0])
+										return someFakeImage, nil
+									})
+								secondConfig := &v1.ConfigFile{Config: v1.Config{
+									User:   "1234:5678",
+									Labels: map[string]string{phase.RebasableLabel: fmt.Sprintf("%t", tc.secondDockerfileRebasable)},
+								}}
+								someFakeImage.ConfigFileReturnsOnCall(2, secondConfig, nil)
 
-									return someFakeImage, nil
-								})
-							secondConfig := &v1.ConfigFile{Config: v1.Config{
-								User:   "1234:5678",
-								Labels: map[string]string{phase.RebasableLabel: fmt.Sprintf("%t", tc.secondDockerfileRebasable)},
-							}}
-							someFakeImage.ConfigFileReturnsOnCall(2, secondConfig, nil)
+								// set label
 
-							// set label
+								someFakeImage.ConfigFileReturnsOnCall(3, secondConfig, nil)
+								someFakeImage.ConfigFileReturnsOnCall(4, secondConfig, nil)
 
-							someFakeImage.ConfigFileReturnsOnCall(3, secondConfig, nil)
-							someFakeImage.ConfigFileReturnsOnCall(4, secondConfig, nil)
+								// save without base layers
 
-							// save without base layers
+								imageHash := v1.Hash{Algorithm: "sha256", Hex: "some-image-hex"}
+								someFakeImage.DigestReturns(imageHash, nil)
+								someFakeImage.ConfigNameReturns(v1.Hash{Algorithm: "sha256", Hex: "some-config-hex"}, nil)
 
-							imageHash := v1.Hash{Algorithm: "sha256", Hex: "some-image-hex"}
-							someFakeImage.DigestReturns(imageHash, nil)
-							someFakeImage.ConfigNameReturns(v1.Hash{Algorithm: "sha256", Hex: "some-config-hex"}, nil)
+								fakeDockerfileApplier.EXPECT().Cleanup().Return(nil)
 
-							fakeDockerfileApplier.EXPECT().Cleanup().Return(nil)
-
-							h.AssertNil(t, extender.Extend("run", logger))
-							outputImagePath := filepath.Join(extendedDir, "run", tc.expectedImageSHA)
-							h.AssertPathExists(t, outputImagePath)
-							fis, err := os.ReadDir(outputImagePath)
-							h.AssertNil(t, err)
-							h.AssertEq(t, len(fis), 3)
+								h.AssertNil(t, extender.Extend("run", logger))
+								outputImagePath := filepath.Join(extendedDir, "run", tc.expectedImageSHA)
+								h.AssertPathExists(t, outputImagePath)
+								fis, err := os.ReadDir(outputImagePath)
+								h.AssertNil(t, err)
+								h.AssertEq(t, len(fis), 3)
+							})
 						})
+					}
+
+					it("errors if the last extension leaves the user as root", func() {
+						expectedDockerfileA := prepareDockerfile("A", "run", "app")
+
+						fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
+						firstConfig := &v1.ConfigFile{Config: v1.Config{
+							User: "0:5678",
+						}}
+						someFakeImage.ConfigFileReturns(firstConfig, nil)
+						someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
+
+						fakeDockerfileApplier.EXPECT().Apply(
+							gomock.Any(),
+							gomock.Any(),
+							gomock.Any(),
+							logger,
+						).DoAndReturn(
+							func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
+								h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
+								h.AssertEq(t, len(dockerfile.Args), 4)
+								h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
+								_, err := uuid.Parse(dockerfile.Args[0].Value)
+								h.AssertNil(t, err)
+								h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
+								h.AssertEq(t, dockerfile.Args[1].Value, "0")
+								h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
+								h.AssertEq(t, dockerfile.Args[2].Value, "5678")
+								h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
+
+								return someFakeImage, nil
+							})
+
+						err := extender.Extend("run", logger)
+						h.AssertError(t, err, "extending run image: the final user ID is 0 (root); please add another extension that resets the user to non-root")
 					})
-				}
-
-				it("errors if the last extension leaves the user as root", func() {
-					expectedDockerfileA := extend.Dockerfile{
-						Path: filepath.Join(generatedDir, "A", "run.Dockerfile"),
-						Args: []extend.Arg{{Name: "argA", Value: "valueA"}},
-					}
-					h.Mkdir(t, filepath.Join(generatedDir, "A"))
-					h.Mkfile(t, "some dockerfile content", filepath.Join(generatedDir, "A", "run.Dockerfile"))
-					buf := new(bytes.Buffer)
-					data := extend.Config{Run: extend.BuildConfig{Args: expectedDockerfileA.Args}}
-					h.AssertNil(t, toml.NewEncoder(buf).Encode(data))
-					h.Mkfile(t, buf.String(), filepath.Join(generatedDir, "A", "extend-config.toml"))
-
-					fakeDockerfileApplier.EXPECT().ImageFor(extender.ImageRef).Return(someFakeImage, nil)
-					firstConfig := &v1.ConfigFile{Config: v1.Config{
-						User: "0:5678",
-					}}
-					someFakeImage.ConfigFileReturns(firstConfig, nil)
-					someFakeImage.ManifestReturns(&v1.Manifest{Layers: []v1.Descriptor{}}, nil)
-
-					fakeDockerfileApplier.EXPECT().Apply(
-						gomock.Any(),
-						gomock.Any(),
-						gomock.Any(),
-						logger,
-					).DoAndReturn(
-						func(dockerfile extend.Dockerfile, _ v1.Image, _ extend.Options, _ llog.Logger) (v1.Image, error) {
-							h.AssertEq(t, dockerfile.Path, expectedDockerfileA.Path)
-							h.AssertEq(t, len(dockerfile.Args), 4)
-							h.AssertEq(t, dockerfile.Args[0].Name, "build_id")
-							_, err := uuid.Parse(dockerfile.Args[0].Value)
-							h.AssertNil(t, err)
-							h.AssertEq(t, dockerfile.Args[1].Name, "user_id")
-							h.AssertEq(t, dockerfile.Args[1].Value, "0")
-							h.AssertEq(t, dockerfile.Args[2].Name, "group_id")
-							h.AssertEq(t, dockerfile.Args[2].Value, "5678")
-							h.AssertEq(t, dockerfile.Args[3], expectedDockerfileA.Args[0])
-
-							return someFakeImage, nil
-						})
-
-					err := extender.Extend("run", logger)
-					h.AssertError(t, err, "extending run image: the final user ID is 0 (root); please add another extension that resets the user to non-root")
 				})
 			})
-		})
+		}
 	})
 }


### PR DESCRIPTION
### Summary

Refactor `phase/extender_test.go` as suggested in https://github.com/buildpacks/lifecycle/pull/1276#discussion_r1489675972

### Context

In #1276 we duplicated most of the test code in `phase/extender_test.go`, basically doing the same tests twice, once for Platform API `0.12` and once for `0.13`. The API versions expect a different folder layout, which requires changes to the test setup. The reduce the size of `phase/extender_test.go`, I:
- moved the code to create the folder layout into a helper function (it will check for the Platform API version and behave differently based on that)
- added a loop around the test cases looping over API versions.

Now we have every tests only once in code, while still being executed twice.

The drawback: The helper function is quite complex (especially for test code). 


A middle ground could be to keep the loop, but to the Platform API version switch in every test case.

@natalieparellano WDYT?