### PR TITLE
Document deprecatedRunImage as deprecated

### DIFF
--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -181,7 +181,7 @@ func FlagInsecureRegistries(insecureRegistries *str.Slice) {
 // deprecated
 
 func DeprecatedFlagRunImage(deprecatedRunImage *string) {
-	flagSet.StringVar(deprecatedRunImage, "image", "", "reference to run image")
+	flagSet.StringVar(deprecatedRunImage, "image", "", "[deprecated] reference to run image")
 }
 
 // helpers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
When looking at the flags for `rebase`, it is confusing because both `-image` and `-run-image` are documented as `reference to run image`. It's not until inspection of the source code that you realize `-image` is deprecated. This adds a `[deprecated]` marker to `-image` so it can be seen in the help output.

Looking at uses of `DeprecatedFlagRunImage`, this impacts both `rebase` and `export`.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
Document `-image` flag as deprecated in help output for `rebase` and `export`.