### PR TITLE
Fix rebase run-image resolution

### DIFF
--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -192,13 +192,14 @@ func (r *rebaseCmd) setAppImage() error {
 
 	if r.RunImageRef == "" {
 		var runImage files.RunImageForExport
-		if r.PlatformAPI.AtLeast("0.12") && md.RunImage.RunImageForExport.Image != "" {
+		switch {
+		case r.PlatformAPI.AtLeast("0.12") && md.RunImage.RunImageForExport.Image != "":
 			runImage = md.RunImage.RunImageForExport
-		} else if md.Stack != nil && md.Stack.RunImage.Image != "" {
+		case md.Stack != nil && md.Stack.RunImage.Image != "":
 			// for backwards compatibility, we need to fallback to the stack metadata
 			// fail if there is no run image metadata available from either location
 			runImage = md.Stack.RunImage
-		} else {
+		default:
 			return cmd.FailErrCode(errors.New("-run-image is required when there is no run image metadata available"), cmd.CodeForInvalidArgs, "parse arguments")
 		}
 

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -191,15 +191,8 @@ func (r *rebaseCmd) setAppImage() error {
 	}
 
 	if r.RunImageRef == "" {
-		var runImage files.RunImageForExport
-		switch {
-		case r.PlatformAPI.AtLeast("0.12") && md.RunImage.RunImageForExport.Image != "":
-			runImage = md.RunImage.RunImageForExport
-		case md.Stack != nil && md.Stack.RunImage.Image != "":
-			// for backwards compatibility, we need to fallback to the stack metadata
-			// fail if there is no run image metadata available from either location
-			runImage = md.Stack.RunImage
-		default:
+		runImage, err := platform.GetRunImageFromMetadata(*r.LifecycleInputs, md)
+		if err != nil {
 			return cmd.FailErrCode(errors.New("-run-image is required when there is no run image metadata available"), cmd.CodeForInvalidArgs, "parse arguments")
 		}
 

--- a/platform/run_image.go
+++ b/platform/run_image.go
@@ -112,3 +112,17 @@ func GetRunImageForExport(inputs LifecycleInputs) (files.RunImageForExport, erro
 	}
 	return runMD.Images[0], nil
 }
+
+// GetRunImageFromMetadata extracts the run image from the image metadata
+func GetRunImageFromMetadata(inputs LifecycleInputs, md files.LayersMetadata) (files.RunImageForExport, error) {
+	switch {
+	case inputs.PlatformAPI.AtLeast("0.12") && md.RunImage.RunImageForExport.Image != "":
+		return md.RunImage.RunImageForExport, nil
+	case md.Stack != nil && md.Stack.RunImage.Image != "":
+		// for backwards compatibility, we need to fallback to the stack metadata
+		// fail if there is no run image metadata available from either location
+		return md.Stack.RunImage, nil
+	default:
+		return files.RunImageForExport{}, errors.New("no run image metadata available")
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Currently, if `-run-image` is not set, `io.buildpacks.lifecycle.metdata[runImage.reference]` is used. This does not follow the [Run Image Resolution spec](https://github.com/buildpacks/spec/blob/main/platform.md#run-image-resolution), which specifies using `io.buildpacks.lifecycle.metdata[runImage.image]` and optionally `io.buildpacks.lifecycle.metdata[runImage.mirrors]`. Because of this, it ends up making `lifecycle rebase` without the `-run-image` flag a no-op because the run image is pinned to the same version instead of getting the latest.

This change simplifies and unifies the behavior for before and after Platform Version 0.12 so that they both read the same run-image data type (just from different locations), and then validate and resolve mirrors the same.

Note, this is also consistent with [the way `pack rebase` resolves run-images](https://github.com/buildpacks/pack/blob/8b58c6eb9d1e7b40644b8d64017355d58253dc82/pkg/client/rebase.go#L80-L91); however, it does not switch on the Platform Version (I didn't want to change that here).

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
Fix `lifecycle rebase` automatic run image resolution from `io.buildpacks.lifecycle.metdata` to read keys `runImage.image` (and optionally `runImage.mirrors`) instead of `runImage.reference`.

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->
I did not see any relevant tests for this code, but please let me know if there's a test I should change or add. I did do various permutations of manual testing and it is working as expected.