### PR TITLE
Fix post release workflow by calculating sha for linux-ppc64le

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -40,6 +40,10 @@ jobs:
           echo "LINUX_ARM64_SHA: $LINUX_ARM64_SHA"
           echo "LINUX_ARM64_SHA=$LINUX_ARM64_SHA" >> $GITHUB_ENV
 
+          LINUX_PPC64LE_SHA=$(cosign verify --certificate-identity-regexp "https://github.com/${{ github.repository_owner }}/lifecycle/.github/workflows/build.yml" --certificate-oidc-issuer https://token.actions.githubusercontent.com buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux-ppc64le | jq -r .[0].critical.image.\"docker-manifest-digest\")
+          echo "LINUX_PPC64LE_SHA: $LINUX_PPC64LE_SHA"
+          echo "LINUX_PPC64LE_SHA=$LINUX_PPC64LE_SHA" >> $GITHUB_ENV
+
           LINUX_S390X_SHA=$(cosign verify --certificate-identity-regexp "https://github.com/${{ github.repository_owner }}/lifecycle/.github/workflows/build.yml" --certificate-oidc-issuer https://token.actions.githubusercontent.com buildpacksio/lifecycle:${{ env.LIFECYCLE_IMAGE_TAG }}-linux-s390x | jq -r .[0].critical.image.\"docker-manifest-digest\")
           echo "LINUX_S390X_SHA: $LINUX_S390X_SHA"
           echo "LINUX_S390X_SHA=$LINUX_S390X_SHA" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Our post release workflow failed for 0.19.0-rc.2: https://github.com/buildpacks/lifecycle/actions/runs/8160849428

Someday, I'd like to modularize our setup to make it easier to just add os/arch combinations that we want to support as some kind of string array. But, that day is not today.

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

Tested on fork: https://github.com/natalieparellano/lifecycle/actions/runs/8175675694
