### PR TITLE
Allow env vars to skip vendor specific keychain

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,10 @@
+# auth
+
+## Skipping Vendor Specific Keychains
+
+The auth package has configuration available to skip vendor specific keychain implementations. If you are a platform handling credentials yourself, you may want to skip loading these keychains. This can improve performance as the helpers automatically get invoked based on the hosting environment and the registries being interacted with.
+
+Set any of the following to `true` to skip loading the vendor keychain.
+
+`CNB_REGISTRY_AUTH_KEYCHAIN_SKIP_AMAZON` - set to skip Amazon/AWS's ECR credhelper.
+`CNB_REGISTRY_AUTH_KEYCHAIN_SKIP_AZURE` - set to skip Microsoft/Azure's ACR credhelper


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
Vendor keychains can be slow or fail. This allows platform operators to skip them entirely.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Allow platform operators the ability to skip vendor specific keychain implementations by setting `CNB_REGISTRY_AUTH_KEYCHAIN_SKIP_AMAZON` or `CNB_REGISTRY_AUTH_KEYCHAIN_SKIP_AZURE`.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves https://github.com/buildpacks/lifecycle/issues/1007#issuecomment-1561349524

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

The Amazon/ECR one is _terribly_ inefficient. It tries to query the metadata service and eventually fails after a few tries. This is not needed if the platform is providing the credentials via Default/Env. Selectively disabling seemed liked a decent enough idea.

