### PR TITLE
Buildpack API 0.11 is supported as of lifecycle 0.19

### DIFF
--- a/api/apis.go
+++ b/api/apis.go
@@ -15,7 +15,7 @@ var (
 	// Buildpack is a pair of lists of Buildpack API versions:
 	// 1. All supported versions (including deprecated versions)
 	// 2. The versions that are deprecated
-	Buildpack = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10"}, []string{})
+	Buildpack = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11"}, []string{})
 )
 
 type APIs struct {


### PR DESCRIPTION
Fixes https://github.com/buildpacks/lifecycle/issues/1322

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

lifecycle 0.19.0 "supports" Buildpack API 0.11 in that it is possible to use Buildpack API 0.11 features with this lifecycle, but it doesn't declare support for this API version in `api.Buildpack` nor in lifecycle.toml and the associated label. This fix adds Buildpack API 0.11 as a supported API version.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Adds Buildpack API 0.11 as a supported API version

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1322