### PR TITLE
Add go-version-file to draft-release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -131,6 +131,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
+          go-version-file: 'go.mod'
       - name: Get go version
         id: get-go-version
         run: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

We are getting warnings about go-version not being specified. This should fix that.

https://github.com/buildpacks/lifecycle/actions/runs/8573689482/job/23499317720#step:11:12

I'll cherry pick this to release/0.19.2 to fix the workflow there as well.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
N/A


---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

N/A

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

N/A