### PR TITLE
Initialize default `LayerMetadataRestorer` and `SBOMRestorer` if none provided

### DIFF
--- a/phase/restorer.go
+++ b/phase/restorer.go
@@ -35,6 +35,18 @@ func (r *Restorer) Restore(cache Cache) error {
 		return err
 	}
 
+	if r.LayerMetadataRestorer == nil {
+		r.LayerMetadataRestorer = layer.NewDefaultMetadataRestorer(r.LayersDir, false, r.Logger)
+	}
+
+	if r.SBOMRestorer == nil {
+		r.SBOMRestorer = layer.NewSBOMRestorer(layer.SBOMRestorerOpts{
+			LayersDir: r.LayersDir,
+			Logger:    r.Logger,
+			Nop:       false,
+		}, r.PlatformAPI)
+	}
+
 	layerSHAStore := layer.NewSHAStore()
 	r.Logger.Debug("Restoring Layer Metadata")
 	if err := r.LayerMetadataRestorer.Restore(r.Buildpacks, r.LayersMetadata, cacheMeta, layerSHAStore); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Initialize default `layer.LayerMetadataRestorer` and `layer.SBOMRestorer` structs if none provided.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->



---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

At the moment, it is impossible to reuse `phase.Restorer` structure due to the usage of two internal structs: `layer.LayerMetadataRestorer` and `layer.SBOMRestorer`. Defaulting them with the default constructors would allow re-use of the `phase.Restorer` without opening up the internal package.

This change would greatly improve future work on https://github.com/cloudfoundry/community/pull/796

