### PR TITLE
Restore cached launch layers not found in `appLayers`

### DIFF
--- a/api/apis.go
+++ b/api/apis.go
@@ -11,7 +11,7 @@ var (
 	// Platform is a pair of lists of Platform API versions:
 	// 1. All supported versions (including deprecated versions)
 	// 2. The versions that are deprecated
-	Platform = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13"}, []string{})
+	Platform = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14"}, []string{})
 	// Buildpack is a pair of lists of Buildpack API versions:
 	// 1. All supported versions (including deprecated versions)
 	// 2. The versions that are deprecated

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -276,7 +276,7 @@ func (r *restoreCmd) restore(layerMetadata files.LayersMetadata, group buildpack
 		Buildpacks:            group.Group,
 		Logger:                cmd.DefaultLogger,
 		PlatformAPI:           r.PlatformAPI,
-		LayerMetadataRestorer: layer.NewDefaultMetadataRestorer(r.LayersDir, r.SkipLayers, cmd.DefaultLogger),
+		LayerMetadataRestorer: layer.NewDefaultMetadataRestorer(r.LayersDir, r.SkipLayers, cmd.DefaultLogger, r.PlatformAPI),
 		LayersMetadata:        layerMetadata,
 		SBOMRestorer: layer.NewSBOMRestorer(layer.SBOMRestorerOpts{
 			LayersDir: r.LayersDir,

--- a/internal/layer/metadata_restorer.go
+++ b/internal/layer/metadata_restorer.go
@@ -113,8 +113,8 @@ func (r *DefaultMetadataRestorer) restoreLayerMetadata(layerSHAStore SHAStore, a
 				r.Logger.Debugf("Not restoring %q from cache, marked as cache=false", identifier)
 				continue
 			}
-			// If launch=true, the metadata was restored from the app image or the layer is stale.
-			if layer.Launch {
+			// If launch=true, the metadata was restored from the appLayers if present.
+			if _, ok := appLayers[layerName]; ok && layer.Launch {
 				r.Logger.Debugf("Not restoring %q from cache, marked as launch=true", identifier)
 				continue
 			}

--- a/internal/layer/metadata_restorer_test.go
+++ b/internal/layer/metadata_restorer_test.go
@@ -42,7 +42,7 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 		layerDir, err = os.MkdirTemp("", "lifecycle-layer-dir")
 		h.AssertNil(t, err)
 		logger = log.Logger{Handler: &discard.Handler{}}
-		layerMetadataRestorer = layer.NewDefaultMetadataRestorer(layerDir, skipLayers, &logger)
+		layerMetadataRestorer = layer.NewDefaultMetadataRestorer(layerDir, skipLayers, &logger, api.Platform.Latest())
 		layerSHAStore = layer.NewSHAStore()
 	})
 
@@ -143,6 +143,33 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 					h.AssertStringContains(t, string(got), data.want)
 					h.AssertStringDoesNotContain(t, string(got), unsetFlags) // The [types] table shouldn't exist. The build, cache and launch flags are set to false.
 				}
+			})
+
+			when("platformAPI is less than 0.14", func() {
+				it.Before(func() {
+					layerMetadataRestorer = layer.NewDefaultMetadataRestorer(layerDir, skipLayers, &logger, api.MustParse("0.13"))
+				})
+
+				it("ignores launch-cache-not-in-app", func() {
+					err := layerMetadataRestorer.Restore(buildpacks, layersMetadata, cacheMetadata, layerSHAStore)
+					h.AssertNil(t, err)
+
+					h.AssertPathDoesNotExist(t, filepath.Join(layerDir, "metadata.buildpack/launch-cache-not-in-app.toml"))
+					unsetFlags := "[types]"
+					for _, data := range []struct{ name, want string }{
+						// App layers.
+						{"metadata.buildpack/launch.toml", "[metadata]\n  launch-key = \"launch-value\""},
+						{"metadata.buildpack/launch-build-cache.toml", "[metadata]\n  launch-build-cache-key = \"launch-build-cache-value\""},
+						{"metadata.buildpack/launch-cache.toml", "[metadata]\n  launch-cache-key = \"launch-cache-value\""},
+						{"no.cache.buildpack/some-layer.toml", "[metadata]\n  some-layer-key = \"some-layer-value\""},
+						// Cache-image-only layers.
+						{"metadata.buildpack/cache.toml", "[metadata]\n  cache-key = \"cache-value\""},
+					} {
+						got := h.MustReadFile(t, filepath.Join(layerDir, data.name))
+						h.AssertStringContains(t, string(got), data.want)
+						h.AssertStringDoesNotContain(t, string(got), unsetFlags) // The [types] table shouldn't exist. The build, cache and launch flags are set to false.
+					}
+				})
 			})
 
 			it("restores layer metadata without the launch, build and cache flags", func() {
@@ -293,7 +320,7 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 			when("skip layers is true", func() {
 				it.Before(func() {
 					skipLayers = true
-					layerMetadataRestorer = layer.NewDefaultMetadataRestorer(layerDir, skipLayers, &logger)
+					layerMetadataRestorer = layer.NewDefaultMetadataRestorer(layerDir, skipLayers, &logger, api.Platform.Latest())
 				})
 
 				it("does not write buildpack layer metadata", func() {

--- a/internal/layer/metadata_restorer_test.go
+++ b/internal/layer/metadata_restorer_test.go
@@ -136,6 +136,8 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 					{"no.cache.buildpack/some-layer.toml", "[metadata]\n  some-layer-key = \"some-layer-value\""},
 					// Cache-image-only layers.
 					{"metadata.buildpack/cache.toml", "[metadata]\n  cache-key = \"cache-value\""},
+					// Cached launch layers not in app
+					{"metadata.buildpack/launch-cache-not-in-app.toml", "[metadata]\n  cache-only-key = \"cache-only-value\"\n  launch-cache-key = \"cache-specific-value\""},
 				} {
 					got := h.MustReadFile(t, filepath.Join(layerDir, data.name))
 					h.AssertStringContains(t, string(got), data.want)
@@ -184,14 +186,6 @@ func testLayerMetadataRestorer(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 
 				h.AssertPathDoesNotExist(t, filepath.Join(layerDir, "no.group.buildpack"))
-			})
-
-			it("does not restore launch=true layer metadata", func() {
-				err := layerMetadataRestorer.Restore(buildpacks, layersMetadata, cacheMetadata, layerSHAStore)
-				h.AssertNil(t, err)
-
-				h.AssertPathDoesNotExist(t, filepath.Join(layerDir, "metadata.buildpack", "launch-cache-not-in-app.toml"))
-				h.AssertPathDoesNotExist(t, filepath.Join(layerDir, "metadata.buildpack", "launch-cache-not-in-app.sha"))
 			})
 
 			it("does not restore cache=false layer metadata", func() {

--- a/internal/layer/testdata/cache_metadata.json
+++ b/internal/layer/testdata/cache_metadata.json
@@ -36,7 +36,7 @@
                     "launch": true,
                     "sha": "launch-cache-old-sha"
                 },
-		"launch-cache-not-in-app": {
+		        "launch-cache-not-in-app": {
                     "cache": true,
                     "data": {
                         "launch-cache-key": "cache-specific-value",

--- a/phase/restorer.go
+++ b/phase/restorer.go
@@ -36,7 +36,7 @@ func (r *Restorer) Restore(cache Cache) error {
 	}
 
 	if r.LayerMetadataRestorer == nil {
-		r.LayerMetadataRestorer = layer.NewDefaultMetadataRestorer(r.LayersDir, false, r.Logger)
+		r.LayerMetadataRestorer = layer.NewDefaultMetadataRestorer(r.LayersDir, false, r.Logger, r.PlatformAPI)
 	}
 
 	if r.SBOMRestorer == nil {

--- a/phase/restorer_test.go
+++ b/phase/restorer_test.go
@@ -81,7 +81,7 @@ func testRestorer(buildpackAPI, platformAPI string) func(t *testing.T, when spec
 						{ID: "buildpack.id", API: buildpackAPI},
 						{ID: "escaped/buildpack/id", API: buildpackAPI},
 					},
-					LayerMetadataRestorer: layer.NewDefaultMetadataRestorer(layersDir, skipLayers, &logger),
+					LayerMetadataRestorer: layer.NewDefaultMetadataRestorer(layersDir, skipLayers, &logger, api.Platform.Latest()),
 					SBOMRestorer:          sbomRestorer,
 					PlatformAPI:           api.MustParse(platformAPI),
 				}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

In case if a layer is found in cache and marked as `launch = true` and `cache = true`, it will be restored if not found in the `appLayers`.

This case is possible if `-previous-image` is not set/found, however a `-cache-dir` is provided (backed by persistent volumes etc.)

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->



---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

