### PR TITLE
Read `/etc/os-release` file when distro information is not present in labels

### DIFF
--- a/phase/builder.go
+++ b/phase/builder.go
@@ -149,7 +149,7 @@ func (b *Builder) getBuildInputs() buildpack.BuildInputs {
 		LayersDir:      b.LayersDir,
 		PlatformDir:    b.PlatformDir,
 		Env:            env.NewBuildEnv(os.Environ()),
-		TargetEnv:      platform.EnvVarsFor(b.AnalyzeMD.RunImageTarget(), b.Logger),
+		TargetEnv:      platform.EnvVarsFor(&fsutil.Detect{}, b.AnalyzeMD.RunImageTarget(), b.Logger),
 		Out:            b.Out,
 		Err:            b.Err,
 	}

--- a/phase/builder_test.go
+++ b/phase/builder_test.go
@@ -191,8 +191,6 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH=amd64")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH_VARIANT=")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_OS=linux")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_DISTRO_NAME=")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_DISTRO_VERSION=")
 					return buildpack.BuildOutputs{}, nil
 				},
 			)
@@ -205,8 +203,6 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH=amd64")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH_VARIANT=")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_OS=linux")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_DISTRO_NAME=")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_DISTRO_VERSION=")
 					return buildpack.BuildOutputs{}, nil
 				})
 

--- a/phase/detector.go
+++ b/phase/detector.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/env"
 	"github.com/buildpacks/lifecycle/internal/encoding"
+	"github.com/buildpacks/lifecycle/internal/fsutil"
 	"github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/buildpacks/lifecycle/platform/files"
@@ -239,7 +240,7 @@ func (d *Detector) detectGroup(group buildpack.Group, done []buildpack.GroupElem
 					BuildConfigDir: d.BuildConfigDir,
 					PlatformDir:    d.PlatformDir,
 					Env:            env.NewBuildEnv(os.Environ()),
-					TargetEnv:      platform.EnvVarsFor(d.AnalyzeMD.RunImageTarget(), d.Logger),
+					TargetEnv:      platform.EnvVarsFor(&fsutil.Detect{}, d.AnalyzeMD.RunImageTarget(), d.Logger),
 				}
 				d.Runs.Store(key, d.Executor.Detect(descriptor, inputs, d.Logger)) // this is where we finally invoke bin/detect
 			}

--- a/phase/detector_test.go
+++ b/phase/detector_test.go
@@ -223,8 +223,6 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH=amd64")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH_VARIANT=")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_OS=linux")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_DISTRO_NAME=")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_DISTRO_VERSION=")
 					return buildpack.DetectOutputs{}
 				})
 

--- a/phase/generator.go
+++ b/phase/generator.go
@@ -151,7 +151,7 @@ func (g *Generator) getGenerateInputs() buildpack.GenerateInputs {
 		BuildConfigDir: g.BuildConfigDir,
 		PlatformDir:    g.PlatformDir,
 		Env:            env.NewBuildEnv(os.Environ()),
-		TargetEnv:      platform.EnvVarsFor(g.AnalyzedMD.RunImageTarget(), g.Logger),
+		TargetEnv:      platform.EnvVarsFor(&fsutil.Detect{}, g.AnalyzedMD.RunImageTarget(), g.Logger),
 		Out:            g.Out,
 		Err:            g.Err,
 	}

--- a/phase/generator_test.go
+++ b/phase/generator_test.go
@@ -284,8 +284,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							h.AssertContains(t, inputs.TargetEnv,
 								"CNB_TARGET_ARCH=amd64",
 								"CNB_TARGET_ARCH_VARIANT=",
-								"CNB_TARGET_DISTRO_NAME=ubuntu",
-								"CNB_TARGET_DISTRO_VERSION=22.04",
 								"CNB_TARGET_OS=linux",
 							)
 							return buildpack.GenerateOutputs{Dockerfiles: []buildpack.DockerfileInfo{{ExtensionID: d.Extension.ID,

--- a/phase/generator_test.go
+++ b/phase/generator_test.go
@@ -284,8 +284,8 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							h.AssertContains(t, inputs.TargetEnv,
 								"CNB_TARGET_ARCH=amd64",
 								"CNB_TARGET_ARCH_VARIANT=",
-								"CNB_TARGET_DISTRO_NAME=",
-								"CNB_TARGET_DISTRO_VERSION=",
+								"CNB_TARGET_DISTRO_NAME=ubuntu",
+								"CNB_TARGET_DISTRO_VERSION=22.04",
 								"CNB_TARGET_OS=linux",
 							)
 							return buildpack.GenerateOutputs{Dockerfiles: []buildpack.DockerfileInfo{{ExtensionID: d.Extension.ID,
@@ -296,8 +296,8 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							h.AssertContains(t, inputs.TargetEnv,
 								"CNB_TARGET_ARCH=amd64",
 								"CNB_TARGET_ARCH_VARIANT=",
-								"CNB_TARGET_DISTRO_NAME=",
-								"CNB_TARGET_DISTRO_VERSION=",
+								"CNB_TARGET_DISTRO_NAME=ubuntu",
+								"CNB_TARGET_DISTRO_VERSION=22.04",
 								"CNB_TARGET_OS=linux",
 							)
 							return buildpack.GenerateOutputs{Dockerfiles: []buildpack.DockerfileInfo{{ExtensionID: d.Extension.ID,

--- a/phase/generator_test.go
+++ b/phase/generator_test.go
@@ -294,8 +294,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							h.AssertContains(t, inputs.TargetEnv,
 								"CNB_TARGET_ARCH=amd64",
 								"CNB_TARGET_ARCH_VARIANT=",
-								"CNB_TARGET_DISTRO_NAME=ubuntu",
-								"CNB_TARGET_DISTRO_VERSION=22.04",
 								"CNB_TARGET_OS=linux",
 							)
 							return buildpack.GenerateOutputs{Dockerfiles: []buildpack.DockerfileInfo{{ExtensionID: d.Extension.ID,

--- a/platform/run_image_test.go
+++ b/platform/run_image_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/memory"
 	"github.com/google/go-containerregistry/pkg/authn"
 
 	"github.com/buildpacks/lifecycle/platform"
@@ -204,7 +206,12 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 	when(".EnvVarsFor", func() {
 		it("returns the right thing", func() {
 			tm := files.TargetMetadata{Arch: "pentium", ArchVariant: "mmx", ID: "my-id", OS: "linux", Distro: &files.OSDistro{Name: "nix", Version: "22.11"}}
-			observed := platform.EnvVarsFor(tm, nil)
+			d := &mockDetector{
+				contents: "this is just test contents really",
+				t:        t,
+				HasFile:  false,
+			}
+			observed := platform.EnvVarsFor(d, tm, nil)
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT="+tm.ArchVariant)
 			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME="+tm.Distro.Name)
@@ -213,9 +220,31 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, len(observed), 5)
 		})
 
+		it("returns the right thing from /etc/os-release", func() {
+			logr := &log.Logger{Handler: memory.New()}
+			d := &mockDetector{
+				contents: "this is just test contents really",
+				t:        t,
+				HasFile:  true,
+			}
+			tm := files.TargetMetadata{Arch: "pentium", ArchVariant: "mmx", ID: "my-id", OS: "linux", Distro: nil}
+			observed := platform.EnvVarsFor(d, tm, logr)
+			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
+			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT="+tm.ArchVariant)
+			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME=opensesame")
+			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_VERSION=3.14")
+			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
+			h.AssertEq(t, len(observed), 5)
+		})
+
 		it("does not return the wrong thing", func() {
 			tm := files.TargetMetadata{Arch: "pentium", OS: "linux"}
-			observed := platform.EnvVarsFor(tm, nil)
+			d := &mockDetector{
+				contents: "this is just test contents really",
+				t:        t,
+				HasFile:  false,
+			}
+			observed := platform.EnvVarsFor(d, tm, nil)
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
 			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
 			// note: per the spec only the ID field is optional, so I guess the others should always be set: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md#runtime-metadata

--- a/platform/run_image_test.go
+++ b/platform/run_image_test.go
@@ -211,7 +211,7 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 				t:        t,
 				HasFile:  false,
 			}
-			observed := platform.EnvVarsFor(d, tm, nil)
+			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT="+tm.ArchVariant)
 			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME="+tm.Distro.Name)
@@ -221,14 +221,13 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("returns the right thing from /etc/os-release", func() {
-			logr := &log.Logger{Handler: memory.New()}
 			d := &mockDetector{
 				contents: "this is just test contents really",
 				t:        t,
 				HasFile:  true,
 			}
 			tm := files.TargetMetadata{Arch: "pentium", ArchVariant: "mmx", ID: "my-id", OS: "linux", Distro: nil}
-			observed := platform.EnvVarsFor(d, tm, logr)
+			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT="+tm.ArchVariant)
 			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME=opensesame")
@@ -244,7 +243,7 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 				t:        t,
 				HasFile:  false,
 			}
-			observed := platform.EnvVarsFor(d, tm, nil)
+			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
 			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
 			// note: per the spec only the ID field is optional, so I guess the others should always be set: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md#runtime-metadata

--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -11,11 +11,12 @@ import (
 
 // EnvVarsFor fulfills the prophecy set forth in https://github.com/buildpacks/rfcs/blob/b8abe33f2bdc58792acf0bd094dc4ce3c8a54dbb/text/0096-remove-stacks-mixins.md?plain=1#L97
 // by returning an array of "VARIABLE=value" strings suitable for inclusion in your environment or complete breakfast.
-func EnvVarsFor(tm files.TargetMetadata, logger log.Logger) []string {
+func EnvVarsFor(d fsutil.Detector, tm files.TargetMetadata, logger log.Logger) []string {
 	// we should always have os & arch,
 	// if they are not populated try to get target information from the build-time base image
-	if tm.OS == "" {
-		GetTargetOSFromFileSystem(&fsutil.Detect{}, &tm, logger)
+	if tm.OS == "" || tm.Distro == nil {
+		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
+		GetTargetOSFromFileSystem(d, &tm, logger)
 	}
 	ret := []string{
 		"CNB_TARGET_OS=" + tm.OS,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Related issue: https://github.com/buildpacks/lifecycle/issues/1336

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->



---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1336

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

