### PR TITLE
When a buildpack declares distro information, but a base image does not, consider it not a match

### DIFF
--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -91,8 +91,11 @@ func TargetSatisfiedForBuild(base files.TargetMetadata, module buildpack.TargetM
 	if !matches(base.ArchVariant, module.ArchVariant) {
 		return false
 	}
-	if base.Distro == nil || len(module.Distros) == 0 {
+	if len(module.Distros) == 0 {
 		return true
+	}
+	if base.Distro == nil {
+		return false
 	}
 	foundMatchingDist := false
 	for _, modDist := range module.Distros {

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -41,14 +41,14 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 
-					when("has extra information", func() {
-						it("matches", func() {
+					when("has distro information", func() {
+						it("does not match", func() {
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, ArchVariant: "MMX"}), true)
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(baseTarget, buildpack.TargetMetadata{
 								OS:      baseTarget.OS,
 								Arch:    baseTarget.Arch,
 								Distros: []buildpack.OSDistro{{Name: "a", Version: "2"}},
-							}), true)
+							}), false)
 						})
 					})
 				})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Fixes https://github.com/buildpacks/lifecycle/issues/1337

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

The lifecycle, when determining if a base image satisfies target constraints declared by a buildpack, fails if the buildpack declares distro information but the base image does not (fixes spec compliance)

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1337

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

