### PR TITLE
Also read distro information from /etc/os-release when checking target compat

### DIFF
--- a/phase/analyzer.go
+++ b/phase/analyzer.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/image"
-	"github.com/buildpacks/lifecycle/internal/fsutil"
 	"github.com/buildpacks/lifecycle/internal/layer"
 	"github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
@@ -86,9 +85,6 @@ func (a *Analyzer) Analyze() (files.Analyzed, error) {
 			atm, err = platform.GetTargetMetadata(a.RunImage)
 			if err != nil {
 				return files.Analyzed{}, errors.Wrap(err, "unpacking metadata from image")
-			}
-			if atm.OS == "" {
-				platform.GetTargetOSFromFileSystem(&fsutil.Detect{}, atm, a.Logger)
 			}
 		}
 	}

--- a/phase/analyzer.go
+++ b/phase/analyzer.go
@@ -86,6 +86,9 @@ func (a *Analyzer) Analyze() (files.Analyzed, error) {
 			if err != nil {
 				return files.Analyzed{}, errors.Wrap(err, "unpacking metadata from image")
 			}
+			if atm.OS == "" {
+				return files.Analyzed{}, errors.New("failed to find OS in run image config")
+			}
 		}
 	}
 

--- a/phase/analyzer_test.go
+++ b/phase/analyzer_test.go
@@ -484,6 +484,7 @@ func testAnalyzer(platformAPI string) func(t *testing.T, when spec.G, it spec.S)
 
 					h.AssertEq(t, md.RunImage.Reference, "s0m3D1g3sT")
 				})
+
 				it("populates target metadata from the run image", func() {
 					h.AssertNil(t, previousImage.SetLabel("io.buildpacks.base.id", "id software"))
 					h.AssertNil(t, previousImage.SetOS("windows"))
@@ -507,6 +508,18 @@ func testAnalyzer(platformAPI string) func(t *testing.T, when spec.G, it spec.S)
 						h.AssertEq(t, md.RunImage.TargetMetadata.Distro.Name, "moobuntu")
 						h.AssertEq(t, md.RunImage.TargetMetadata.Distro.Version, "Helpful Holstein")
 					}
+				})
+
+				when("run image is missing OS", func() {
+					it("errors", func() {
+						h.AssertNil(t, previousImage.SetOS(""))
+						_, err := analyzer.Analyze()
+						if api.MustParse(platformAPI).LessThan("0.12") {
+							h.AssertNil(t, err)
+						} else {
+							h.AssertError(t, err, "failed to find OS")
+						}
+					})
 				})
 			})
 		})

--- a/phase/detector.go
+++ b/phase/detector.go
@@ -206,7 +206,7 @@ func (d *Detector) detectGroup(group buildpack.Group, done []buildpack.GroupElem
 			} else {
 				for i := range descriptor.TargetsList() {
 					d.Logger.Debugf("Checking for match against descriptor: %s", descriptor.TargetsList()[i])
-					if platform.TargetSatisfiedForBuild(*d.AnalyzeMD.RunImage.TargetMetadata, descriptor.TargetsList()[i]) {
+					if platform.TargetSatisfiedForBuild(&fsutil.Detect{}, *d.AnalyzeMD.RunImage.TargetMetadata, descriptor.TargetsList()[i], d.Logger) {
 						targetMatch = true
 						break
 					}

--- a/platform/run_image_test.go
+++ b/platform/run_image_test.go
@@ -4,8 +4,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/apex/log"
-	"github.com/apex/log/handlers/memory"
 	"github.com/google/go-containerregistry/pkg/authn"
 
 	"github.com/buildpacks/lifecycle/platform"
@@ -200,58 +198,6 @@ func testRunImage(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, result.Image, "")
 				})
 			})
-		})
-	})
-
-	when(".EnvVarsFor", func() {
-		it("returns the right thing", func() {
-			tm := files.TargetMetadata{Arch: "pentium", ArchVariant: "mmx", ID: "my-id", OS: "linux", Distro: &files.OSDistro{Name: "nix", Version: "22.11"}}
-			d := &mockDetector{
-				contents: "this is just test contents really",
-				t:        t,
-				HasFile:  false,
-			}
-			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT="+tm.ArchVariant)
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME="+tm.Distro.Name)
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_VERSION="+tm.Distro.Version)
-			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
-			h.AssertEq(t, len(observed), 5)
-		})
-
-		it("returns the right thing from /etc/os-release", func() {
-			d := &mockDetector{
-				contents: "this is just test contents really",
-				t:        t,
-				HasFile:  true,
-			}
-			tm := files.TargetMetadata{Arch: "pentium", ArchVariant: "mmx", ID: "my-id", OS: "linux", Distro: nil}
-			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT="+tm.ArchVariant)
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME=opensesame")
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_VERSION=3.14")
-			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
-			h.AssertEq(t, len(observed), 5)
-		})
-
-		it("does not return the wrong thing", func() {
-			tm := files.TargetMetadata{Arch: "pentium", OS: "linux"}
-			d := &mockDetector{
-				contents: "this is just test contents really",
-				t:        t,
-				HasFile:  false,
-			}
-			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
-			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
-			// note: per the spec only the ID field is optional, so I guess the others should always be set: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md#runtime-metadata
-			// the empty ones:
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT=")
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME=")
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_VERSION=")
-			h.AssertEq(t, len(observed), 5)
 		})
 	})
 

--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -43,7 +43,7 @@ func GetTargetMetadata(fromImage imgutil.Image) (*files.TargetMetadata, error) {
 // TargetSatisfiedForBuild treats empty fields as wildcards and returns true if all populated fields match.
 func TargetSatisfiedForBuild(d fsutil.Detector, base files.TargetMetadata, module buildpack.TargetMetadata, logger log.Logger) bool {
 	// ensure we have all available data
-	if base.OS == "" || base.Distro == nil {
+	if base.Distro == nil {
 		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
 		GetTargetOSFromFileSystem(d, &base, logger)
 	}
@@ -91,9 +91,6 @@ func GetTargetOSFromFileSystem(d fsutil.Detector, tm *files.TargetMetadata, logg
 			return
 		}
 		info := d.GetInfo(contents)
-		if tm.OS == "" {
-			tm.OS = "linux"
-		}
 		if info.Version != "" || info.Name != "" {
 			tm.Distro = &files.OSDistro{Name: info.Name, Version: info.Version}
 		}
@@ -105,7 +102,7 @@ func GetTargetOSFromFileSystem(d fsutil.Detector, tm *files.TargetMetadata, logg
 func EnvVarsFor(d fsutil.Detector, tm files.TargetMetadata, logger log.Logger) []string {
 	// we should always have os & arch,
 	// if they are not populated try to get target information from the build-time base image
-	if tm.OS == "" || tm.Distro == nil {
+	if tm.Distro == nil {
 		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
 		GetTargetOSFromFileSystem(d, &tm, logger)
 	}

--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -9,30 +9,6 @@ import (
 	"github.com/buildpacks/lifecycle/platform/files"
 )
 
-// EnvVarsFor fulfills the prophecy set forth in https://github.com/buildpacks/rfcs/blob/b8abe33f2bdc58792acf0bd094dc4ce3c8a54dbb/text/0096-remove-stacks-mixins.md?plain=1#L97
-// by returning an array of "VARIABLE=value" strings suitable for inclusion in your environment or complete breakfast.
-func EnvVarsFor(d fsutil.Detector, tm files.TargetMetadata, logger log.Logger) []string {
-	// we should always have os & arch,
-	// if they are not populated try to get target information from the build-time base image
-	if tm.OS == "" || tm.Distro == nil {
-		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
-		GetTargetOSFromFileSystem(d, &tm, logger)
-	}
-	ret := []string{
-		"CNB_TARGET_OS=" + tm.OS,
-		"CNB_TARGET_ARCH=" + tm.Arch,
-		"CNB_TARGET_ARCH_VARIANT=" + tm.ArchVariant,
-	}
-	var distName, distVersion string
-	if tm.Distro != nil {
-		distName = tm.Distro.Name
-		distVersion = tm.Distro.Version
-	}
-	ret = append(ret, "CNB_TARGET_DISTRO_NAME="+distName)
-	ret = append(ret, "CNB_TARGET_DISTRO_VERSION="+distVersion)
-	return ret
-}
-
 func GetTargetMetadata(fromImage imgutil.Image) (*files.TargetMetadata, error) {
 	tm := files.TargetMetadata{}
 	var err error
@@ -62,23 +38,6 @@ func GetTargetMetadata(fromImage imgutil.Image) (*files.TargetMetadata, error) {
 	}
 
 	return &tm, nil
-}
-
-// GetTargetOSFromFileSystem populates the target metadata you pass in if the information is available
-// returns a boolean indicating whether it populated any data.
-func GetTargetOSFromFileSystem(d fsutil.Detector, tm *files.TargetMetadata, logger log.Logger) {
-	if d.HasSystemdFile() {
-		contents, err := d.ReadSystemdFile()
-		if err != nil {
-			logger.Warnf("Encountered error trying to read /etc/os-release file: %s", err.Error())
-			return
-		}
-		info := d.GetInfo(contents)
-		if info.Version != "" || info.Name != "" {
-			tm.OS = "linux"
-			tm.Distro = &files.OSDistro{Name: info.Name, Version: info.Version}
-		}
-	}
 }
 
 // TargetSatisfiedForBuild treats empty fields as wildcards and returns true if all populated fields match.
@@ -113,6 +72,47 @@ func matches(target1, target2 string) bool {
 		return true
 	}
 	return target1 == target2
+}
+
+// GetTargetOSFromFileSystem populates the target metadata you pass in if the information is available
+// returns a boolean indicating whether it populated any data.
+func GetTargetOSFromFileSystem(d fsutil.Detector, tm *files.TargetMetadata, logger log.Logger) {
+	if d.HasSystemdFile() {
+		contents, err := d.ReadSystemdFile()
+		if err != nil {
+			logger.Warnf("Encountered error trying to read /etc/os-release file: %s", err.Error())
+			return
+		}
+		info := d.GetInfo(contents)
+		if info.Version != "" || info.Name != "" {
+			tm.OS = "linux"
+			tm.Distro = &files.OSDistro{Name: info.Name, Version: info.Version}
+		}
+	}
+}
+
+// EnvVarsFor fulfills the prophecy set forth in https://github.com/buildpacks/rfcs/blob/b8abe33f2bdc58792acf0bd094dc4ce3c8a54dbb/text/0096-remove-stacks-mixins.md?plain=1#L97
+// by returning an array of "VARIABLE=value" strings suitable for inclusion in your environment or complete breakfast.
+func EnvVarsFor(d fsutil.Detector, tm files.TargetMetadata, logger log.Logger) []string {
+	// we should always have os & arch,
+	// if they are not populated try to get target information from the build-time base image
+	if tm.OS == "" || tm.Distro == nil {
+		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
+		GetTargetOSFromFileSystem(d, &tm, logger)
+	}
+	ret := []string{
+		"CNB_TARGET_OS=" + tm.OS,
+		"CNB_TARGET_ARCH=" + tm.Arch,
+		"CNB_TARGET_ARCH_VARIANT=" + tm.ArchVariant,
+	}
+	var distName, distVersion string
+	if tm.Distro != nil {
+		distName = tm.Distro.Name
+		distVersion = tm.Distro.Version
+	}
+	ret = append(ret, "CNB_TARGET_DISTRO_NAME="+distName)
+	ret = append(ret, "CNB_TARGET_DISTRO_VERSION="+distVersion)
+	return ret
 }
 
 // TargetSatisfiedForRebase treats optional fields (ArchVariant and Distribution fields) as wildcards if empty, returns true if all populated fields match


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

This will fix an issue reported by our friends from Paketo. Without this fallback, when combined with the stricter validation in https://github.com/buildpacks/lifecycle/pull/1348, we could fail builds that we actually want to proceed with.

https://github.com/buildpacks/lifecycle/pull/1347 reads the file when providing target env vars to buildpacks during detect, but we also need to consider this info when deciding whether or not to run detect for the buildpack.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

The `detector`, when determining if a base image satisfies target constraints declared by a buildpack, also uses information from `/etc/os-release` when distro information is not present in the run image labels

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

I moved some functions around in files, so ignore the first commit when parsing the diff (it just moves stuff doesn't change any logic)