### PR TITLE
More fixes for target compat checking during detect

### DIFF
--- a/acceptance/testdata/detector/Dockerfile
+++ b/acceptance/testdata/detector/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:jammy
 
 ARG cnb_uid=1234
 ARG cnb_gid=1000

--- a/acceptance/testdata/detector/container/cnb/buildpacks/simple_buildpack/simple_buildpack_version/bin/detect
+++ b/acceptance/testdata/detector/container/cnb/buildpacks/simple_buildpack/simple_buildpack_version/bin/detect
@@ -12,3 +12,5 @@ name = "some_requirement"
 version = "some_version"     # Optional
 some_metadata_key = "some_metadata_val" # Optional
 EOL
+
+exit 100

--- a/acceptance/testdata/detector/container/cnb/buildpacks/simple_buildpack/simple_buildpack_version/bin/detect
+++ b/acceptance/testdata/detector/container/cnb/buildpacks/simple_buildpack/simple_buildpack_version/bin/detect
@@ -12,5 +12,3 @@ name = "some_requirement"
 version = "some_version"     # Optional
 some_metadata_key = "some_metadata_val" # Optional
 EOL
-
-exit 100

--- a/acceptance/testdata/detector/container/cnb/buildpacks/simple_buildpack/simple_buildpack_version/buildpack.toml
+++ b/acceptance/testdata/detector/container/cnb/buildpacks/simple_buildpack/simple_buildpack_version/buildpack.toml
@@ -1,6 +1,12 @@
-api = "0.10"
+api = "0.9"
 
 [buildpack]
-    id = "simple_buildpack"
-    version = "simple_buildpack_version"
-    name = "Simple Buildpack"
+id = "simple_buildpack"
+version = "simple_buildpack_version"
+name = "Simple Buildpack"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "io.buildpacks.stacks.jammy"

--- a/buildpack/bp_descriptor.go
+++ b/buildpack/bp_descriptor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 
+	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/internal/encoding"
 )
 
@@ -69,7 +70,11 @@ func ReadBpDescriptor(path string) (*BpDescriptor, error) {
 	if len(descriptor.Targets) == 0 {
 		for _, stack := range descriptor.Stacks {
 			if stack.ID == "io.buildpacks.stacks.bionic" {
-				descriptor.Targets = append(descriptor.Targets, TargetMetadata{OS: "linux", Arch: "amd64", Distros: []OSDistro{{Name: "ubuntu", Version: "18.04"}}})
+				if api.MustParse(descriptor.API()).AtLeast("0.10") || len(descriptor.Stacks) == 1 {
+					descriptor.Targets = append(descriptor.Targets, TargetMetadata{OS: "linux", Arch: "amd64", Distros: []OSDistro{{Name: "ubuntu", Version: "18.04"}}})
+				}
+			} else if stack.ID == "*" {
+				descriptor.Targets = append(descriptor.Targets, TargetMetadata{}) // matches any
 			}
 		}
 	}

--- a/buildpack/bp_descriptor.go
+++ b/buildpack/bp_descriptor.go
@@ -70,8 +70,6 @@ func ReadBpDescriptor(path string) (*BpDescriptor, error) {
 		for _, stack := range descriptor.Stacks {
 			if stack.ID == "io.buildpacks.stacks.bionic" {
 				descriptor.Targets = append(descriptor.Targets, TargetMetadata{OS: "linux", Arch: "amd64", Distros: []OSDistro{{Name: "ubuntu", Version: "18.04"}}})
-			} else if stack.ID == "*" {
-				descriptor.Targets = append(descriptor.Targets, TargetMetadata{}) // matches any
 			}
 		}
 	}

--- a/buildpack/bp_descriptor.go
+++ b/buildpack/bp_descriptor.go
@@ -17,7 +17,7 @@ type BpDescriptor struct {
 	Order       Order            `toml:"order"`
 	WithRootDir string           `toml:"-"`
 	Targets     []TargetMetadata `toml:"targets"`
-	Stacks      []StackMetadata  `tome:"stacks"` // just for backwards compat so we can check if it's the bionic stack, which we translate to a target
+	Stacks      []StackMetadata  `toml:"stacks"` // just for backwards compat so we can check if it's the bionic stack, which we translate to a target
 
 }
 

--- a/buildpack/bp_descriptor_test.go
+++ b/buildpack/bp_descriptor_test.go
@@ -81,44 +81,140 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "V8.4-2L3")
 		})
 
-		it("translates one special stack value into target values for older apis", func() {
-			path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1", "buildpack.toml")
-			descriptor, err := buildpack.ReadBpDescriptor(path)
-			h.AssertNil(t, err)
-			// common sanity checks
-			h.AssertEq(t, descriptor.WithAPI, "0.7")
-			h.AssertEq(t, descriptor.Buildpack.ID, "B")
-			h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
-			h.AssertEq(t, descriptor.Buildpack.Version, "v1")
-			h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
-			h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
-			// specific behaviors for this test
-			h.AssertEq(t, descriptor.Stacks[0].ID, "io.buildpacks.stacks.bionic")
-			h.AssertEq(t, len(descriptor.Targets), 1)
-			h.AssertEq(t, descriptor.Targets[0].Arch, "amd64")
-			h.AssertEq(t, descriptor.Targets[0].OS, "linux")
-			h.AssertEq(t, descriptor.Targets[0].Distros[0].Name, "ubuntu")
-			h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
-		})
+		when("translating stacks to targets", func() {
+			when("older buildpacks", func() {
+				when("there is only bionic", func() {
+					it("creates a target", func() {
+						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1", "buildpack.toml")
+						descriptor, err := buildpack.ReadBpDescriptor(path)
+						h.AssertNil(t, err)
+						// common sanity checks
+						h.AssertEq(t, descriptor.WithAPI, "0.7")
+						h.AssertEq(t, descriptor.Buildpack.ID, "B")
+						h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
+						h.AssertEq(t, descriptor.Buildpack.Version, "v1")
+						h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
+						h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+						// specific behaviors for this test
+						h.AssertEq(t, descriptor.Stacks[0].ID, "io.buildpacks.stacks.bionic")
+						h.AssertEq(t, len(descriptor.Targets), 1)
+						h.AssertEq(t, descriptor.Targets[0].Arch, "amd64")
+						h.AssertEq(t, descriptor.Targets[0].OS, "linux")
+						h.AssertEq(t, descriptor.Targets[0].Distros[0].Name, "ubuntu")
+						h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
+					})
+				})
 
-		it("translates one special stack value into target values", func() {
-			path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2", "buildpack.toml")
-			descriptor, err := buildpack.ReadBpDescriptor(path)
-			h.AssertNil(t, err)
-			// common sanity checks
-			h.AssertEq(t, descriptor.WithAPI, "0.12")
-			h.AssertEq(t, descriptor.Buildpack.ID, "B")
-			h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
-			h.AssertEq(t, descriptor.Buildpack.Version, "v1")
-			h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
-			h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
-			// specific behaviors for this test
-			h.AssertEq(t, descriptor.Stacks[0].ID, "io.buildpacks.stacks.bionic")
-			h.AssertEq(t, len(descriptor.Targets), 1)
-			h.AssertEq(t, descriptor.Targets[0].Arch, "amd64")
-			h.AssertEq(t, descriptor.Targets[0].OS, "linux")
-			h.AssertEq(t, descriptor.Targets[0].Distros[0].Name, "ubuntu")
-			h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
+				when("there are multiple stacks", func() {
+					it("does NOT create a target", func() {
+						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1.2", "buildpack.toml")
+						descriptor, err := buildpack.ReadBpDescriptor(path)
+						h.AssertNil(t, err)
+						// common sanity checks
+						h.AssertEq(t, descriptor.WithAPI, "0.7")
+						h.AssertEq(t, descriptor.Buildpack.ID, "B")
+						h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
+						h.AssertEq(t, descriptor.Buildpack.Version, "v1.2")
+						h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
+						h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+						// specific behaviors for this test
+						h.AssertEq(t, descriptor.Stacks[0].ID, "io.buildpacks.stacks.bionic")
+						h.AssertEq(t, len(descriptor.Targets), 0)
+					})
+				})
+
+				when("there is a wildcard stack", func() {
+					it("creates a wildcard target", func() {
+						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1.star", "buildpack.toml")
+						descriptor, err := buildpack.ReadBpDescriptor(path)
+						h.AssertNil(t, err)
+						// common sanity checks
+						h.AssertEq(t, descriptor.WithAPI, "0.7")
+						h.AssertEq(t, descriptor.Buildpack.ID, "B")
+						h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
+						h.AssertEq(t, descriptor.Buildpack.Version, "v1.star")
+						h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
+						h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+						// specific behaviors for this test
+						h.AssertEq(t, descriptor.Stacks[0].ID, "*")
+						h.AssertEq(t, len(descriptor.Targets), 1)
+						// a target that is completely empty will always match whatever is the base image target
+						h.AssertEq(t, descriptor.Targets[0].Arch, "")
+						h.AssertEq(t, descriptor.Targets[0].OS, "")
+						h.AssertEq(t, descriptor.Targets[0].ArchVariant, "")
+						h.AssertEq(t, len(descriptor.Targets[0].Distros), 0)
+					})
+				})
+			})
+
+			when("newer buildpacks", func() {
+				when("there is only bionic", func() {
+					it("creates a target", func() {
+						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2", "buildpack.toml")
+						descriptor, err := buildpack.ReadBpDescriptor(path)
+						h.AssertNil(t, err)
+						// common sanity checks
+						h.AssertEq(t, descriptor.WithAPI, "0.12")
+						h.AssertEq(t, descriptor.Buildpack.ID, "B")
+						h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
+						h.AssertEq(t, descriptor.Buildpack.Version, "v2")
+						h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
+						h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+						// specific behaviors for this test
+						h.AssertEq(t, descriptor.Stacks[0].ID, "io.buildpacks.stacks.bionic")
+						h.AssertEq(t, len(descriptor.Targets), 1)
+						h.AssertEq(t, descriptor.Targets[0].Arch, "amd64")
+						h.AssertEq(t, descriptor.Targets[0].OS, "linux")
+						h.AssertEq(t, descriptor.Targets[0].Distros[0].Name, "ubuntu")
+						h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
+					})
+				})
+
+				when("there are multiple stacks", func() {
+					it("creates a target", func() {
+						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2.2", "buildpack.toml")
+						descriptor, err := buildpack.ReadBpDescriptor(path)
+						h.AssertNil(t, err)
+						// common sanity checks
+						h.AssertEq(t, descriptor.WithAPI, "0.12")
+						h.AssertEq(t, descriptor.Buildpack.ID, "B")
+						h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
+						h.AssertEq(t, descriptor.Buildpack.Version, "v2.2")
+						h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
+						h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+						// specific behaviors for this test
+						h.AssertEq(t, descriptor.Stacks[0].ID, "io.buildpacks.stacks.bionic")
+						h.AssertEq(t, len(descriptor.Targets), 1)
+						h.AssertEq(t, descriptor.Targets[0].Arch, "amd64")
+						h.AssertEq(t, descriptor.Targets[0].OS, "linux")
+						h.AssertEq(t, descriptor.Targets[0].Distros[0].Name, "ubuntu")
+						h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
+					})
+				})
+
+				when("there is a wildcard stack", func() {
+					it("creates a wildcard target", func() {
+						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2.star", "buildpack.toml")
+						descriptor, err := buildpack.ReadBpDescriptor(path)
+						h.AssertNil(t, err)
+						// common sanity checks
+						h.AssertEq(t, descriptor.WithAPI, "0.12")
+						h.AssertEq(t, descriptor.Buildpack.ID, "B")
+						h.AssertEq(t, descriptor.Buildpack.Name, "Buildpack B")
+						h.AssertEq(t, descriptor.Buildpack.Version, "v2.star")
+						h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack B Homepage")
+						h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
+						// specific behaviors for this test
+						h.AssertEq(t, descriptor.Stacks[0].ID, "*")
+						h.AssertEq(t, len(descriptor.Targets), 1)
+						// a target that is completely empty will always match whatever is the base image target
+						h.AssertEq(t, descriptor.Targets[0].Arch, "")
+						h.AssertEq(t, descriptor.Targets[0].OS, "")
+						h.AssertEq(t, descriptor.Targets[0].ArchVariant, "")
+						h.AssertEq(t, len(descriptor.Targets[0].Distros), 0)
+					})
+				})
+			})
 		})
 
 		it("does not translate non-special stack values", func() {

--- a/buildpack/bp_descriptor_test.go
+++ b/buildpack/bp_descriptor_test.go
@@ -81,7 +81,7 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "V8.4-2L3")
 		})
 
-		it("does translate one special stack value into target values for older apis", func() {
+		it("translates one special stack value into target values for older apis", func() {
 			path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1", "buildpack.toml")
 			descriptor, err := buildpack.ReadBpDescriptor(path)
 			h.AssertNil(t, err)

--- a/buildpack/testdata/buildpack/by-id/B/v1.2/buildpack.toml
+++ b/buildpack/testdata/buildpack/by-id/B/v1.2/buildpack.toml
@@ -1,11 +1,14 @@
-api = "0.12"
+api = "0.7"
 
 [buildpack]
 id = "B"
 name = "Buildpack B"
-version = "v2"
+version = "v1.2"
 homepage = "Buildpack B Homepage"
 sbom-formats = ["application/vnd.cyclonedx+json"]
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "io.buildpacks.stacks.jammy"

--- a/buildpack/testdata/buildpack/by-id/B/v1.star/buildpack.toml
+++ b/buildpack/testdata/buildpack/by-id/B/v1.star/buildpack.toml
@@ -1,11 +1,11 @@
-api = "0.12"
+api = "0.7"
 
 [buildpack]
 id = "B"
 name = "Buildpack B"
-version = "v2"
+version = "v1.star"
 homepage = "Buildpack B Homepage"
 sbom-formats = ["application/vnd.cyclonedx+json"]
 
 [[stacks]]
-id = "io.buildpacks.stacks.bionic"
+id = "*"

--- a/buildpack/testdata/buildpack/by-id/B/v2.2/buildpack.toml
+++ b/buildpack/testdata/buildpack/by-id/B/v2.2/buildpack.toml
@@ -3,9 +3,12 @@ api = "0.12"
 [buildpack]
 id = "B"
 name = "Buildpack B"
-version = "v2"
+version = "v2.2"
 homepage = "Buildpack B Homepage"
 sbom-formats = ["application/vnd.cyclonedx+json"]
 
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"
+
+[[stacks]]
+id = "io.buildpacks.stacks.jammy"

--- a/buildpack/testdata/buildpack/by-id/B/v2.star/buildpack.toml
+++ b/buildpack/testdata/buildpack/by-id/B/v2.star/buildpack.toml
@@ -3,9 +3,9 @@ api = "0.12"
 [buildpack]
 id = "B"
 name = "Buildpack B"
-version = "v2"
+version = "v2.star"
 homepage = "Buildpack B Homepage"
 sbom-formats = ["application/vnd.cyclonedx+json"]
 
 [[stacks]]
-id = "io.buildpacks.stacks.bionic"
+id = "*"

--- a/phase/detector.go
+++ b/phase/detector.go
@@ -192,6 +192,8 @@ func (d *Detector) detectGroup(group buildpack.Group, done []buildpack.GroupElem
 		if d.PlatformAPI.AtLeast("0.12") {
 			var targetMatch bool
 			if len(descriptor.TargetsList()) == 0 {
+				// This is actually just for tests. In practice, the lifecycle will infer a target with at least an OS
+				// when targets are missing from buildpack.toml.
 				targetMatch = true
 			} else {
 				for _, target := range descriptor.TargetsList() {

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -21,7 +21,7 @@ func TestTargetData(t *testing.T) {
 
 func testTargetData(t *testing.T, when spec.G, it spec.S) {
 	when(".TargetSatisfiedForBuild", func() {
-		baseTarget := files.TargetMetadata{OS: "Win95", Arch: "Pentium"}
+		baseTarget := &files.TargetMetadata{OS: "Win95", Arch: "Pentium"}
 		d := mockDetector{
 			contents: "this is just test contents really",
 			t:        t,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

- If a buildpack does not specify targets, but DOES specify stack with ID io.buildpacks.stacks.bionic, only translate that to a target if the buildpack is on a newer Buildpack API (where stacks are deprecated, and we expect targets) OR if the buildpack only ever declared one stack. When multiple stacks are declared, specifying only one target actually reduces the number of builds that can succeed. Older Buildpack APIs don't actually specify stack -> target translation so we should do the thing that will work in the maximum number of builds.
- If a buildpack fails to specify os/arch (but specifies distro) still check targets
- If the run image fails to specify os/arch (this should not happen actually as we will fail during analyze) still check targets
- Fix typo in buildpack descriptor struct ~so that we actually get stack information~ (we still see it because of the struct field name)
- If we get distro information from /etc/os-release, persist this information to later invocations so that the log message printed when errors are encountered will be accurate
- Don't override inner `i` in loop (this should not actually affect the outer loop but is confusing)

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

The `detector`, when checking target compatibility, will still perform the check if buildpacks fail to declare os/arch information in targets
