### PR TITLE
Fix CNB_TARGET_* env vars on older Platform API

### DIFF
--- a/phase/builder_test.go
+++ b/phase/builder_test.go
@@ -189,7 +189,6 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			executor.EXPECT().Build(*bpA, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ buildpack.BpDescriptor, inputs buildpack.BuildInputs, logger llog.Logger) (buildpack.BuildOutputs, error) {
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH=amd64")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH_VARIANT=")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_OS=linux")
 					return buildpack.BuildOutputs{}, nil
 				},

--- a/phase/builder_test.go
+++ b/phase/builder_test.go
@@ -200,7 +200,6 @@ func testBuilder(t *testing.T, when spec.G, it spec.S) {
 			executor.EXPECT().Build(*bpB, gomock.Any(), gomock.Any()).Do(
 				func(_ buildpack.BpDescriptor, inputs buildpack.BuildInputs, _ llog.Logger) (buildpack.BuildOutputs, error) {
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH=amd64")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH_VARIANT=")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_OS=linux")
 					return buildpack.BuildOutputs{}, nil
 				})

--- a/phase/detector_test.go
+++ b/phase/detector_test.go
@@ -221,7 +221,6 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 			executor.EXPECT().Detect(bpA1, gomock.Any(), gomock.Any()).Do(
 				func(_ buildpack.Descriptor, inputs buildpack.DetectInputs, _ log.Logger) buildpack.DetectOutputs {
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH=amd64")
-					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_ARCH_VARIANT=")
 					h.AssertContains(t, inputs.TargetEnv, "CNB_TARGET_OS=linux")
 					return buildpack.DetectOutputs{}
 				})

--- a/phase/generator_test.go
+++ b/phase/generator_test.go
@@ -283,7 +283,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 						func(d buildpack.ExtDescriptor, inputs buildpack.GenerateInputs, _ *log.Logger) (buildpack.GenerateOutputs, error) {
 							h.AssertContains(t, inputs.TargetEnv,
 								"CNB_TARGET_ARCH=amd64",
-								"CNB_TARGET_ARCH_VARIANT=",
 								"CNB_TARGET_OS=linux",
 							)
 							return buildpack.GenerateOutputs{Dockerfiles: []buildpack.DockerfileInfo{{ExtensionID: d.Extension.ID,
@@ -293,7 +292,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 						func(d buildpack.ExtDescriptor, inputs buildpack.GenerateInputs, _ *log.Logger) (buildpack.GenerateOutputs, error) {
 							h.AssertContains(t, inputs.TargetEnv,
 								"CNB_TARGET_ARCH=amd64",
-								"CNB_TARGET_ARCH_VARIANT=",
 								"CNB_TARGET_OS=linux",
 							)
 							return buildpack.GenerateOutputs{Dockerfiles: []buildpack.DockerfileInfo{{ExtensionID: d.Extension.ID,

--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -1,6 +1,8 @@
 package platform
 
 import (
+	"runtime"
+
 	"github.com/buildpacks/imgutil"
 
 	"github.com/buildpacks/lifecycle/buildpack"
@@ -87,10 +89,16 @@ func matches(target1, target2 string) bool {
 	return target1 == target2
 }
 
-// GetTargetOSFromFileSystem populates the target metadata you pass in if the information is available
-// returns a boolean indicating whether it populated any data.
+// GetTargetOSFromFileSystem populates the provided target metadata with information from /etc/os-release
+// if it is available.
 func GetTargetOSFromFileSystem(d fsutil.Detector, tm *files.TargetMetadata, logger log.Logger) {
 	if d.HasSystemdFile() {
+		if tm.OS == "" {
+			tm.OS = "linux"
+		}
+		if tm.Arch == "" {
+			tm.Arch = runtime.GOARCH // in a future world where we support cross platform builds, this should be removed
+		}
 		contents, err := d.ReadSystemdFile()
 		if err != nil {
 			logger.Warnf("Encountered error trying to read /etc/os-release file: %s", err.Error())

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -2,6 +2,7 @@ package platform_test
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/apex/log"
@@ -129,6 +130,8 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 				t:       t,
 				HasFile: true}
 			platform.GetTargetOSFromFileSystem(&d, &tm, logr)
+			h.AssertEq(t, "linux", tm.OS)
+			h.AssertEq(t, runtime.GOARCH, tm.Arch)
 			h.AssertEq(t, "opensesame", tm.Distro.Name)
 			h.AssertEq(t, "3.14", tm.Distro.Version)
 		})

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -202,12 +202,28 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
 			h.AssertContains(t, observed, "CNB_TARGET_ARCH="+tm.Arch)
 			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
-			// note: per the spec only the ID field is optional, so I guess the others should always be set: https://github.com/buildpacks/rfcs/blob/main/text/0096-remove-stacks-mixins.md#runtime-metadata
-			// the empty ones:
-			h.AssertContains(t, observed, "CNB_TARGET_ARCH_VARIANT=")
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_NAME=")
-			h.AssertContains(t, observed, "CNB_TARGET_DISTRO_VERSION=")
-			h.AssertEq(t, len(observed), 5)
+			h.AssertEq(t, len(observed), 2)
+		})
+
+		when("optional vars are empty", func() {
+			it("omits them", func() {
+				tm := files.TargetMetadata{
+					// required
+					OS:   "linux",
+					Arch: "pentium",
+					// optional
+					ArchVariant: "",
+					Distro:      &files.OSDistro{Name: "nix", Version: ""},
+					ID:          "",
+				}
+				d := &mockDetector{
+					contents: "this is just test contents really",
+					t:        t,
+					HasFile:  false,
+				}
+				observed := platform.EnvVarsFor(d, tm, &log.Logger{Handler: memory.New()})
+				h.AssertEq(t, len(observed), 3)
+			})
 		})
 	})
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Fixes https://github.com/buildpacks/lifecycle/issues/1371

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

When populating target data for older platforms, populate OS & architecture as well as distro information

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1371

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

