### PR TITLE
Surface registry error

### DIFF
--- a/acceptance/analyzer_test.go
+++ b/acceptance/analyzer_test.go
@@ -450,7 +450,7 @@ func testAnalyzerFunc(platformAPI string) func(t *testing.T, when spec.G, it spe
 						output, err := cmd.CombinedOutput()
 
 						h.AssertNotNil(t, err)
-						expected := "validating registry write access: ensure registry read/write access to " + analyzeRegFixtures.InaccessibleImage
+						expected := "ensure registry read/write access to " + analyzeRegFixtures.InaccessibleImage
 						h.AssertStringContains(t, string(output), expected)
 					})
 				})

--- a/image/registry_handler.go
+++ b/image/registry_handler.go
@@ -1,12 +1,11 @@
 package image
 
 import (
+	"fmt"
+
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/remote"
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/pkg/errors"
-
-	"github.com/buildpacks/lifecycle/cmd"
 )
 
 // RegistryHandler takes care of the registry settings and checks
@@ -73,8 +72,7 @@ func verifyReadAccess(imageRef string, keychain authn.Keychain, opts []imgutil.I
 	img, _ := remote.NewImage(imageRef, keychain, opts...)
 	canRead, err := img.CheckReadAccess()
 	if !canRead {
-		cmd.DefaultLogger.Debugf("Error checking read access: %s", err)
-		return errors.Errorf("ensure registry read access to %s", imageRef)
+		return fmt.Errorf("failed to ensure registry read access to %s: %w", imageRef, err)
 	}
 
 	return nil
@@ -88,8 +86,7 @@ func verifyReadWriteAccess(imageRef string, keychain authn.Keychain, opts []imgu
 	img, _ := remote.NewImage(imageRef, keychain, opts...)
 	canReadWrite, err := img.CheckReadWriteAccess()
 	if !canReadWrite {
-		cmd.DefaultLogger.Debugf("Error checking read/write access: %s", err)
-		return errors.Errorf("ensure registry read/write access to %s", imageRef)
+		return fmt.Errorf("failed to ensure registry read/write access to %s: %w", imageRef, err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

When permissions issues are encountered, it can be hard to determine the root cause without the error returned from the registry

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

The lifecycle surfaces error from registry (when it fails to verify image permissions) as an error instead of a debug message

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

