### PR TITLE
Adapt tools/test-fork.sh to the current GitHub Action workflows.

### DIFF
--- a/tools/test-fork.sh
+++ b/tools/test-fork.sh
@@ -35,10 +35,22 @@ if [[ $registry != "index.docker.io" ]]; then
   sed -i '' "s/username: \${{ secrets.DOCKER_USERNAME }}/login-server: $registry\n          username: $username/g" .github/workflows/*.yml
 fi
 
-# If using ghcr.io, we don't need to set the DOCKER_* secrets. Update the login action to use GitHub token instead.
 if [[ $registry == *"ghcr.io"* ]]; then
+  # If using ghcr.io, we don't need to set the DOCKER_* secrets. Update the login action to use GitHub token instead.
   echo "Updating login action to use GitHub token for ghcr.io"
   sed -i '' "s/secrets.DOCKER_PASSWORD/secrets.GITHUB_TOKEN/g" .github/workflows/*.yml
+
+  echo "Adding workflow permissions to push images to ghcr.io"
+  LF=$'\n'
+  sed -i '' "/      id-token: write/ a\\
+      contents: read\\
+      packages: write\\
+      attestations: write${LF}" .github/workflows/build.yml
+  sed -i '' "/      id-token: write/ a\\
+      contents: read\\
+      packages: write\\
+      attestations: write${LF}" .github/workflows/post-release.yml
+  LF=""
 fi
 
 echo "Removing arm tests (these require a self-hosted runner)"

--- a/tools/test-fork.sh
+++ b/tools/test-fork.sh
@@ -51,7 +51,7 @@ if [[ -z $2 ]]; then
   sed -i '' "s/make acceptance/echo acceptance/g" .github/workflows/*.yml
   echo "$(sed '/pack-acceptance/,$d' .github/workflows/build.yml)" > .github/workflows/build.yml
   echo "Removing Codecov"
-  sed -i '' "/- name: Upload coverage to Codecov/,+6d" .github/workflows/build.yml
+  sed -i '' "/- name: Upload coverage to Codecov/,+7d" .github/workflows/build.yml
   sed -i '' "/- name: Prepare Codecov/,+6d" .github/workflows/build.yml
 else
   echo "Retaining tests"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

The helper script for testing GitHub Actions on forked repositories, `tools/test-fork.sh`, has a few issues with applying current workflows. This PR fixes them.

1. It removes only a part of the Codecov step from `build.yml`.
2. It lacks adding the necessary permissions to push images to ghcr.io in the `build.xml` and the `post-release.yml`.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

The helper script for testing GitHub Actions on fork repositories, `tools/test-fork.sh`, now works correctly.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

N/A

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

I've referenced the permissions for pushing images to ghcr.io from [this source](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages).