### PR TITLE
When setting up buildpack env, process layers for a given buildpack in alphabetical order

### DIFF
--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -94,7 +94,7 @@ func (e *DefaultBuildExecutor) Build(d BpDescriptor, inputs BuildInputs, logger 
 	}
 
 	logger.Debug("Updating environment")
-	if err := d.setupEnv(createdLayers, inputs.Env); err != nil {
+	if err := d.setupEnv(bpLayersDir, createdLayers, inputs.Env); err != nil {
 		return BuildOutputs{}, err
 	}
 
@@ -162,39 +162,41 @@ func runBuildCmd(d BpDescriptor, bpLayersDir, planPath string, inputs BuildInput
 	return nil
 }
 
-func (d BpDescriptor) processLayers(layersDir string, logger log.Logger) (map[string]LayerMetadataFile, error) {
-	return eachLayer(layersDir, d.WithAPI, func(path, buildpackAPI string) (LayerMetadataFile, error) {
-		layerMetadataFile, err := DecodeLayerMetadataFile(path+".toml", buildpackAPI, logger)
+func (d BpDescriptor) processLayers(bpLayersDir string, logger log.Logger) (map[string]LayerMetadataFile, error) {
+	bpLayers := make(map[string]LayerMetadataFile)
+	if err := eachLayer(bpLayersDir, func(layerPath string) error {
+		layerFile, err := DecodeLayerMetadataFile(layerPath+".toml", d.WithAPI, logger)
 		if err != nil {
-			return LayerMetadataFile{}, err
+			return fmt.Errorf("failed to decode layer metadata file: %w", err)
 		}
-		if err := renameLayerDirIfNeeded(layerMetadataFile, path); err != nil {
-			return LayerMetadataFile{}, err
+		if err = renameLayerDirIfNeeded(layerFile, layerPath); err != nil {
+			return fmt.Errorf("failed to rename layer directory: %w", err)
 		}
-		return layerMetadataFile, nil
-	})
+		bpLayers[layerPath] = layerFile
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to process buildpack layer: %w", err)
+	}
+	return bpLayers, nil
 }
 
-func eachLayer(bpLayersDir, buildpackAPI string, fn func(path, api string) (LayerMetadataFile, error)) (map[string]LayerMetadataFile, error) {
+func eachLayer(bpLayersDir string, fn func(layerPath string) error) error {
 	files, err := os.ReadDir(bpLayersDir)
 	if os.IsNotExist(err) {
-		return map[string]LayerMetadataFile{}, nil
+		return nil
 	} else if err != nil {
-		return map[string]LayerMetadataFile{}, err
+		return err
 	}
-	bpLayers := map[string]LayerMetadataFile{}
 	for _, f := range files {
 		if f.IsDir() || !strings.HasSuffix(f.Name(), ".toml") {
 			continue
 		}
 		path := filepath.Join(bpLayersDir, strings.TrimSuffix(f.Name(), ".toml"))
-		layerMetadataFile, err := fn(path, buildpackAPI)
-		if err != nil {
-			return map[string]LayerMetadataFile{}, err
+		if err = fn(path); err != nil {
+			return err
 		}
-		bpLayers[path] = layerMetadataFile
 	}
-	return bpLayers, nil
+	return nil
 }
 
 func renameLayerDirIfNeeded(layerMetadataFile LayerMetadataFile, layerDir string) error {
@@ -207,23 +209,25 @@ func renameLayerDirIfNeeded(layerMetadataFile LayerMetadataFile, layerDir string
 	return nil
 }
 
-func (d BpDescriptor) setupEnv(createdLayers map[string]LayerMetadataFile, buildEnv BuildEnv) error {
+func (d BpDescriptor) setupEnv(bpLayersDir string, createdLayers map[string]LayerMetadataFile, buildEnv BuildEnv) error {
 	bpAPI := api.MustParse(d.WithAPI)
-	for path, layerMetadataFile := range createdLayers {
+	return eachLayer(bpLayersDir, func(layerPath string) error {
+		var err error
+		layerMetadataFile, ok := createdLayers[layerPath]
+		if !ok {
+			return fmt.Errorf("failed to find layer metadata for %s", layerPath)
+		}
 		if !layerMetadataFile.Build {
-			continue
+			return nil
 		}
-		if err := buildEnv.AddRootDir(path); err != nil {
+		if err = buildEnv.AddRootDir(layerPath); err != nil {
 			return err
 		}
-		if err := buildEnv.AddEnvDir(filepath.Join(path, "env"), env.DefaultActionType(bpAPI)); err != nil {
+		if err = buildEnv.AddEnvDir(filepath.Join(layerPath, "env"), env.DefaultActionType(bpAPI)); err != nil {
 			return err
 		}
-		if err := buildEnv.AddEnvDir(filepath.Join(path, "env.build"), env.DefaultActionType(bpAPI)); err != nil {
-			return err
-		}
-	}
-	return nil
+		return buildEnv.AddEnvDir(filepath.Join(layerPath, "env.build"), env.DefaultActionType(bpAPI))
+	})
 }
 
 func (d BpDescriptor) readOutputFilesBp(bpLayersDir, bpPlanPath string, bpPlanIn Plan, bpLayers map[string]LayerMetadataFile, logger log.Logger) (BuildOutputs, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

When setting up buildpack env, process layers for a given buildpack in alphabetical order

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

When setting up buildpack env, process layers for a given buildpack in alphabetical order

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1393

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

