### PR TITLE
bump upload-artifacts-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tag
       - name: Set env
@@ -270,17 +270,17 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'pack/go.mod'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: version
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tag
       - name: Set env
         run: |
           cat version.txt >> $GITHUB_ENV
           cat tag.txt >> $GITHUB_ENV
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lifecycle-linux-x86-64
           path: pack
@@ -341,17 +341,17 @@ jobs:
           ${IPAddress} host.docker.internal
           ${IPAddress} gateway.docker.internal
           " | Out-File -Filepath C:\Windows\System32\drivers\etc\hosts -Encoding utf8
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: version
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: tag
       - name: Set env
         run: |
           cat version.txt >> $env:GITHUB_ENV
           cat tag.txt >> $env:GITHUB_ENV
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lifecycle-windows-x86-64
           path: pack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,14 +128,14 @@ jobs:
       - name: Set version
         run: |
           echo "LIFECYCLE_VERSION=$(go run tools/version/main.go)" | tee -a $GITHUB_ENV version.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: version
           path: version.txt
       - name: Set tag
         run: |
           echo "LIFECYCLE_IMAGE_TAG=$(git describe --always --abbrev=7)" >> tag.txt
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: tag
           path: tag.txt
@@ -144,43 +144,43 @@ jobs:
           make clean
           make build
           make package
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-x86-64
           path: out/lifecycle-v*+linux.x86-64.tgz
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-x86-64-sha256
           path: out/lifecycle-v*+linux.x86-64.tgz.sha256
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-arm64
           path: out/lifecycle-v*+linux.arm64.tgz
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-arm64-sha256
           path: out/lifecycle-v*+linux.arm64.tgz.sha256
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-ppc64le
           path: out/lifecycle-v*+linux.ppc64le.tgz
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-ppc64le-sha256
           path: out/lifecycle-v*+linux.ppc64le.tgz.sha256
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-s390x
           path: out/lifecycle-v*+linux.s390x.tgz
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-linux-s390x-sha256
           path: out/lifecycle-v*+linux.s390x.tgz.sha256
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-windows-x86-64
           path: out/lifecycle-v*+windows.x86-64.tgz
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-windows-x86-64-sha256
           path: out/lifecycle-v*+windows.x86-64.tgz.sha256
@@ -189,14 +189,14 @@ jobs:
         with:
           args: mod -licenses -json -output lifecycle-v${{ env.LIFECYCLE_VERSION }}-bom.cdx.json
           version: ^v1
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-bom-cdx
           path: lifecycle-v*-bom.cdx.json
       - name: Calculate SBOM sha
         run: |
           shasum -a 256 lifecycle-v${{ env.LIFECYCLE_VERSION }}-bom.cdx.json > lifecycle-v${{ env.LIFECYCLE_VERSION }}-bom.cdx.json.sha256
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lifecycle-bom-cdx-sha256
           path: lifecycle-v*-bom.cdx.json.sha256


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

Bump upload and download actions to v4 to avoid deprecation affecting our pipelines.



#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

- chore: Bump upload and download github actions to v4 to avoid deprecation affecting our pipelines.


---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Closes https://github.com/buildpacks/lifecycle/pull/1260
Closes https://github.com/buildpacks/lifecycle/pull/1261

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->
Seems as though the limitations we ran into initially have been removed or increased. 

