### PR TITLE
Only log once (per phase) when we have to get target distro information from /etc/os-release

### DIFF
--- a/internal/fsutil/os_detection.go
+++ b/internal/fsutil/os_detection.go
@@ -17,12 +17,14 @@ type Detector interface {
 	HasSystemdFile() bool
 	ReadSystemdFile() (string, error)
 	GetInfo(osReleaseContents string) OSInfo
+	StoredInfo() *OSInfo
 	InfoOnce(logger log.Logger)
 }
 
 // DefaultDetector implements Detector
 type DefaultDetector struct {
 	once sync.Once
+	info *OSInfo
 }
 
 // HasSystemdFile returns true if /etc/os-release exists with contents
@@ -60,7 +62,13 @@ func (d *DefaultDetector) GetInfo(osReleaseContents string) OSInfo {
 			break
 		}
 	}
+	d.info = &ret // store for future use
 	return ret
+}
+
+// StoredInfo returns any OSInfo found during the last call to GetInfo
+func (d *DefaultDetector) StoredInfo() *OSInfo {
+	return d.info
 }
 
 // InfoOnce logs an info message to the provided logger, but only once in the lifetime of the receiving DefaultDetector.

--- a/internal/fsutil/os_detection_linux_test.go
+++ b/internal/fsutil/os_detection_linux_test.go
@@ -20,10 +20,10 @@ func TestDetectorUnix(t *testing.T) {
 func testDetectorUnix(t *testing.T, when spec.G, it spec.S) {
 	when("we should have a file", func() {
 		it("returns true correctly", func() {
-			h.AssertEq(t, (&fsutil.Detect{}).HasSystemdFile(), true)
+			h.AssertEq(t, (&fsutil.DefaultDetector{}).HasSystemdFile(), true)
 		})
 		it("returns the file contents", func() {
-			s, err := (&fsutil.Detect{}).ReadSystemdFile()
+			s, err := (&fsutil.DefaultDetector{}).ReadSystemdFile()
 			h.AssertNil(t, err)
 			h.AssertStringContains(t, s, "NAME")
 		})

--- a/internal/fsutil/os_detection_notlinux_test.go
+++ b/internal/fsutil/os_detection_notlinux_test.go
@@ -20,10 +20,10 @@ func TestDetectorNonUnix(t *testing.T) {
 func testDetectorNonUnix(t *testing.T, when spec.G, it spec.S) {
 	when("we don't have a file", func() {
 		it("returns false correctly", func() {
-			h.AssertEq(t, (&fsutil.Detect{}).HasSystemdFile(), false)
+			h.AssertEq(t, (&fsutil.DefaultDetector{}).HasSystemdFile(), false)
 		})
 		it("returns an error correctly", func() {
-			_, err := (&fsutil.Detect{}).ReadSystemdFile()
+			_, err := (&fsutil.DefaultDetector{}).ReadSystemdFile()
 			h.AssertNotNil(t, err)
 		})
 	})

--- a/internal/fsutil/os_detection_test.go
+++ b/internal/fsutil/os_detection_test.go
@@ -15,7 +15,7 @@ func TestDetector(t *testing.T) {
 }
 
 // there's no state on this object so we can just use the same one forever
-var detect fsutil.Detect
+var detect fsutil.DefaultDetector
 
 func testDetector(t *testing.T, when spec.G, it spec.S) {
 	when("we have the contents of an os-release file", func() {

--- a/phase/builder.go
+++ b/phase/builder.go
@@ -149,7 +149,7 @@ func (b *Builder) getBuildInputs() buildpack.BuildInputs {
 		LayersDir:      b.LayersDir,
 		PlatformDir:    b.PlatformDir,
 		Env:            env.NewBuildEnv(os.Environ()),
-		TargetEnv:      platform.EnvVarsFor(&fsutil.Detect{}, b.AnalyzeMD.RunImageTarget(), b.Logger),
+		TargetEnv:      platform.EnvVarsFor(&fsutil.DefaultDetector{}, b.AnalyzeMD.RunImageTarget(), b.Logger),
 		Out:            b.Out,
 		Err:            b.Err,
 	}

--- a/phase/generator.go
+++ b/phase/generator.go
@@ -151,7 +151,7 @@ func (g *Generator) getGenerateInputs() buildpack.GenerateInputs {
 		BuildConfigDir: g.BuildConfigDir,
 		PlatformDir:    g.PlatformDir,
 		Env:            env.NewBuildEnv(os.Environ()),
-		TargetEnv:      platform.EnvVarsFor(&fsutil.Detect{}, g.AnalyzedMD.RunImageTarget(), g.Logger),
+		TargetEnv:      platform.EnvVarsFor(&fsutil.DefaultDetector{}, g.AnalyzedMD.RunImageTarget(), g.Logger),
 		Out:            g.Out,
 		Err:            g.Err,
 	}

--- a/platform/run_image.go
+++ b/platform/run_image.go
@@ -72,7 +72,7 @@ func byRegistry(reg string, images []string, checkReadAccess CheckReadAccess, ke
 // - stack.toml for older platforms
 // - run.toml for newer platforms, where the run image information returned is
 //   - the first set of image & mirrors that contains the platform-provided run image, or
-//   - the platform-provided run image if extensions were used and the image was not found, or
+//   - the platform-provided run image if extensions were used and the image was not found in run.toml, or
 //   - the first set of image & mirrors in run.toml
 //
 // The "platform-provided run image" is the run image "image" in analyzed.toml,

--- a/platform/target_data.go
+++ b/platform/target_data.go
@@ -53,7 +53,6 @@ func TargetSatisfiedForBuild(d fsutil.Detector, base *files.TargetMetadata, modu
 	}
 	// ensure we have all available data
 	if base.Distro == nil {
-		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
 		GetTargetOSFromFileSystem(d, base, logger)
 	}
 	// check matches
@@ -93,6 +92,7 @@ func matches(target1, target2 string) bool {
 // GetTargetOSFromFileSystem populates the provided target metadata with information from /etc/os-release
 // if it is available.
 func GetTargetOSFromFileSystem(d fsutil.Detector, tm *files.TargetMetadata, logger log.Logger) {
+	d.InfoOnce(logger)
 	if d.HasSystemdFile() {
 		if tm.OS == "" {
 			tm.OS = "linux"
@@ -118,7 +118,6 @@ func EnvVarsFor(d fsutil.Detector, tm files.TargetMetadata, logger log.Logger) [
 	// we should always have os & arch,
 	// if they are not populated try to get target information from the build-time base image
 	if tm.Distro == nil {
-		logger.Info("target distro name/version labels not found, reading /etc/os-release file")
 		GetTargetOSFromFileSystem(d, &tm, logger)
 	}
 	// required

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/internal/fsutil"
+	llog "github.com/buildpacks/lifecycle/log"
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/buildpacks/lifecycle/platform/files"
 	h "github.com/buildpacks/lifecycle/testhelpers"
@@ -324,3 +325,5 @@ func (d *mockDetector) GetInfo(osReleaseContents string) fsutil.OSInfo {
 		Version: "3.14",
 	}
 }
+
+func (d *mockDetector) InfoOnce(_ llog.Logger) {}

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -327,3 +327,7 @@ func (d *mockDetector) GetInfo(osReleaseContents string) fsutil.OSInfo {
 }
 
 func (d *mockDetector) InfoOnce(_ llog.Logger) {}
+
+func (d *mockDetector) StoredInfo() *fsutil.OSInfo {
+	return nil
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

When the run image does NOT have `io.buildpacks.base.distro.name` or `io.buildpacks.base.distro.version` labels:

We're currently emitting an info message `"target distro name/version labels not found, reading /etc/os-release file"` every time we call `GetTargetOSFromFileSystem` - which happens a LOT, especially during the detect phase. We do this:

* For every buildpack, for every target that the buildpack declares, until we find a target that matches the base image
* For every buildpack, when we run ./bin/detect

This is very noisy, and annoying because it isn't information that buildpack authors need. We should only log the message once, so that platform operators / builder creators can see that the run image needs to be updated with a label.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

The lifecycle only logs once (per phase) when reading distro information from /etc/os-release in order to construct target information

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

The updated code is still a bit inefficient, as we should really only be calling `GetTargetOSFromFileSystem` once per phase, but I've enforced that we only log the info message once, and by saving the distro information the first time we read /etc/os-release, we end up only reading that file once. I didn't want to tear apart too much of the existing code in the interest of time.
