### PR TITLE
Remove obsolete // +build lines

### DIFF
--- a/acceptance/creator_test.go
+++ b/acceptance/creator_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/detector_test.go
+++ b/acceptance/detector_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/exporter_test.go
+++ b/acceptance/exporter_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/extender_test.go
+++ b/acceptance/extender_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/rebaser_test.go
+++ b/acceptance/rebaser_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/restorer_test.go
+++ b/acceptance/restorer_test.go
@@ -1,5 +1,4 @@
 //go:build acceptance
-// +build acceptance
 
 package acceptance
 

--- a/acceptance/testdata/launcher/exec.d/fd_unix.go
+++ b/acceptance/testdata/launcher/exec.d/fd_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package main
 

--- a/acceptance/variables_unix.go
+++ b/acceptance/variables_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package acceptance
 

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package archive
 

--- a/internal/fsutil/os_detection_linux_test.go
+++ b/internal/fsutil/os_detection_linux_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package fsutil_test
 

--- a/internal/fsutil/os_detection_notlinux_test.go
+++ b/internal/fsutil/os_detection_notlinux_test.go
@@ -1,5 +1,4 @@
 //go:build windows || darwin
-// +build windows darwin
 
 package fsutil_test
 

--- a/internal/path/defaults_unix.go
+++ b/internal/path/defaults_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package path
 

--- a/launch/exec_d_unix.go
+++ b/launch/exec_d_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package launch
 

--- a/launch/launcher_unix.go
+++ b/launch/launcher_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package launch
 

--- a/launch/testdata/cmd/execd/fd_unix.go
+++ b/launch/testdata/cmd/execd/fd_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package main
 

--- a/launch/testhelpers/syscall_unix.go
+++ b/launch/testhelpers/syscall_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package testhelpers
 

--- a/launch/testhelpers/syscall_windows.go
+++ b/launch/testhelpers/syscall_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package testhelpers
 

--- a/layers/layers_unix_test.go
+++ b/layers/layers_unix_test.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package layers_test
 

--- a/priv/sock_unix.go
+++ b/priv/sock_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 package priv
 

--- a/priv/user_linux.go
+++ b/priv/user_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package priv
 

--- a/testhelpers/vars_darwin.go
+++ b/testhelpers/vars_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package testhelpers
 

--- a/testhelpers/vars_linux.go
+++ b/testhelpers/vars_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package testhelpers
 


### PR DESCRIPTION
### Summary

Get rid of obsolete `// +build` lines that are deprecated.

https://tip.golang.org/doc/go1.18#go-build-lines

### Related

Kind of related: #1271

### Context

I'm working on getting support for `FreeBSD`. This patch helps to simplify the code base so that the diff for FreeBSD support gets smaller.



