### PR TITLE
Use `unix` build constraint

### DIFF
--- a/acceptance/testdata/launcher/exec.d/fd_unix.go
+++ b/acceptance/testdata/launcher/exec.d/fd_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package main
 

--- a/acceptance/variables_unix.go
+++ b/acceptance/variables_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package acceptance
 

--- a/archive/tar_unix.go
+++ b/archive/tar_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package archive
 

--- a/internal/path/defaults_unix.go
+++ b/internal/path/defaults_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package path
 

--- a/launch/exec_d_unix.go
+++ b/launch/exec_d_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package launch
 

--- a/launch/launcher_unix.go
+++ b/launch/launcher_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package launch
 

--- a/launch/testdata/cmd/execd/fd_unix.go
+++ b/launch/testdata/cmd/execd/fd_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package main
 

--- a/launch/testhelpers/syscall_unix.go
+++ b/launch/testhelpers/syscall_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package testhelpers
 

--- a/layers/layers_unix_test.go
+++ b/layers/layers_unix_test.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package layers_test
 

--- a/priv/sock_unix.go
+++ b/priv/sock_unix.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build unix
 
 package priv
 


### PR DESCRIPTION
### Summary

Simplify go:build constraint `linux || darwin` to `unix`. This can potentially support also constraint `freebsd` in the future.

The constraint `unix` is available since Go 1.19: https://tip.golang.org/doc/go1.19#go-unix

File name suffixes (filename_unix.go, filename_windows.go, filename_linux.go ...) are also available and being used in this project, but I'm not sure whether one should do both (go:build and file name suffixes) OR not.

### Related
Kind of related: #1271

### Context

I'm working on getting support for `FreeBSD`. This patch helps to simplify the code base so that the diff for FreeBSD support gets smaller.

