### PR TITLE
lint: Replace `exportloopref` by `copyloopvar` and `intrange`

### DIFF
--- a/golangci.yaml
+++ b/golangci.yaml
@@ -5,15 +5,16 @@ linters:
   disable-all: true
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - errcheck
-    - exportloopref
     - gocritic
     - goimports
     - gosec
     - gosimple
     - govet
     - ineffassign
+    - intrange
     - misspell
     - nakedret
     - revive

--- a/internal/name/ref_test.go
+++ b/internal/name/ref_test.go
@@ -73,7 +73,6 @@ func testRef(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 			for _, tc := range testCases {
-				tc := tc
 				w := when
 				w(tc.condition, func() {
 					it(tc.does, func() {

--- a/phase/extender_test.go
+++ b/phase/extender_test.go
@@ -247,8 +247,6 @@ func testExtender(t *testing.T, when spec.G, it spec.S) {
 			api.MustParse("0.12"),
 			api.MustParse("0.13"),
 		} {
-			platformAPI := platformAPI
-
 			when(fmt.Sprintf("using the platform API %s", platformAPI), func() {
 				it.Before(func() {
 					extender.PlatformAPI = platformAPI
@@ -379,7 +377,6 @@ func testExtender(t *testing.T, when spec.G, it spec.S) {
 							expectedImageSHA:          notRebasableSHA,
 						},
 					} {
-						tc := tc
 						when := when
 						desc := func(b bool) string {
 							if b {

--- a/phase/generator_test.go
+++ b/phase/generator_test.go
@@ -179,8 +179,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 			api.MustParse("0.12"),
 			api.MustParse("0.13"),
 		} {
-			platformAPI := platformAPI
-
 			when(fmt.Sprintf("using the platform API %s", platformAPI), func() {
 				it.Before(func() {
 					generator.PlatformAPI = platformAPI
@@ -586,7 +584,6 @@ func testGenerator(t *testing.T, when spec.G, it spec.S) {
 							},
 						},
 					} {
-						tc := tc
 						when := when
 						when(tc.descCondition, func() {
 							if tc.before != nil {


### PR DESCRIPTION
### Summary

The golangci-lint linter `exportloopref` is deprecated. As far as I understood, it can be replaced by the linters `copyloopvar` and `intrange`

```shell
$ make lint
> Installing golangci-lint...
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
> Linting code...
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```