### PR TITLE
lifecycle.mk: Add creater and extender symlinks

### DIFF
--- a/lifecycle.mk
+++ b/lifecycle.mk
@@ -8,4 +8,6 @@ define build_lifecycle
 	ln -sf lifecycle $(OUT_DIR)/builder
 	ln -sf lifecycle $(OUT_DIR)/exporter
 	ln -sf lifecycle $(OUT_DIR)/rebaser
+	ln -sf lifecycle $(OUT_DIR)/creator
+	ln -sf lifecycle $(OUT_DIR)/extender
 endef


### PR DESCRIPTION
### Summary
The `lifecycle.mk` file is missing the creator and extender symlinks.

### Related
#1171 
