### PR TITLE
Add logging and sleep to tests

### DIFF
--- a/acceptance/phase_test.go
+++ b/acceptance/phase_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/image"
+
 	ih "github.com/buildpacks/imgutil/testhelpers"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/registry"
@@ -434,6 +436,22 @@ func assertImageOSAndArch(t *testing.T, imageName string, phaseTest *PhaseTest) 
 
 func assertImageOSAndArchAndCreatedAt(t *testing.T, imageName string, phaseTest *PhaseTest, expectedCreatedAt time.Time) { //nolint
 	inspect, _, err := h.DockerCli(t).ImageInspectWithRaw(context.TODO(), imageName)
+
+	if err != nil {
+		list, _ := h.DockerCli(t).ImageList(context.TODO(), image.ListOptions{})
+		fmt.Println("Error encountered running ImageInspectWithRaw. imageName: ", imageName)
+		fmt.Println(err)
+		for _, value := range list {
+			fmt.Println("Image Name: ", value)
+		}
+
+		if strings.Contains(err.Error(), "No such image") {
+			t.Log("Image not found, retrying...")
+			time.Sleep(1 * time.Second)
+			inspect, _, err = h.DockerCli(t).ImageInspectWithRaw(context.TODO(), imageName)
+		}
+	}
+
 	h.AssertNil(t, err)
 	h.AssertEq(t, inspect.Os, phaseTest.targetDaemon.os)
 	h.AssertEq(t, inspect.Architecture, phaseTest.targetDaemon.arch)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->

This change adds a thread sleep at a spot in our unit tests were we identified some flappiness. This change will help ensure our time-sensitive tests fail less often.





---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->
Here's an [example](https://github.com/buildpacks/lifecycle/actions/runs/13247050519/job/37034661620) of failing tests this PR addresses.
