### PR TITLE
Use GITHUB_REF_NAME for draft action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -188,7 +188,7 @@ jobs:
             --draft \
             --notes-file ../body.txt \
             --prerelease \
-            --target $GITHUB_REF \
+            --target $GITHUB_REF_NAME \
             --title "lifecycle v${{ env.LIFECYCLE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ jobs:
             $(ls | sort | paste -sd " " -) \
             --draft \
             --notes-file ../body.txt \
-            --target $GITHUB_REF \
+            --target $GITHUB_REF_NAME \
             --title "lifecycle v${{ env.LIFECYCLE_VERSION }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
The `GITHUB_REF` includes the full `ref/heads...`and the `gh release create` is expecting the short branch/tag name.

This somehow works fine - but also breaks the UI for generating release notes. This should fix that.




