### PR TITLE
Exporter exit with error for empty image tag

### DIFF
--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"io"
 	"log"
 	"os"
@@ -61,6 +62,9 @@ func Run(c Command, withPhaseName string, asSubcommand bool) {
 
 	// We print a warning here, so we should disable color if needed and set the log level before exercising this logic.
 	for _, arg := range flagSet.Args() {
+		if arg == "" {
+			cmd.Exit(errors.New("empty image tag"))
+		}
 		if arg[0:1] == "-" {
 			cmd.DefaultLogger.Warnf("Warning: unconsumed flag-like positional arg: \n\t%s\n\t This will not be interpreted as a flag.\n\t Did you mean to put this before the first positional argument?", arg)
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
 
Exit with a proper error message when an empty string is passed for the image tag.

```
❯ CNB_PLATFORM_API="0.14" ./out/linux-arm64/lifecycle/exporter ''
ERROR: empty image tag reference
```

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
Fix exporter crash when passing an empty string for the image tag


---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

Prior to this change passing an empty string would result in a panic:

```
 ❯ CNB_PLATFORM_API="0.14" ./out/linux-arm64/lifecycle/exporter ''
panic: runtime error: slice bounds out of range [:1] with length 0

goroutine 1 [running, locked to thread]:
github.com/buildpacks/lifecycle/cmd/lifecycle/cli.Run({0x111f120, 0x400022e500}, {0xffffff387092, 0x8}, 0x0)
        /home/kevin.hughes/Projects/lifecycle/cmd/lifecycle/cli/command.go:64 +0x488
main.main()
        /home/kevin.hughes/Projects/lifecycle/cmd/lifecycle/main.go:31 +0x524
```

I tried to see if anything further would handle this gracefully but it crashed again so I figured we should handle it here.

```
 ❯ CNB_PLATFORM_API="0.14" ./out/linux-arm64/lifecycle/exporter ' '
Warning: No analyzed metadata found at path "/layers/analyzed.toml"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x836ab0]

goroutine 1 [running, locked to thread]:
github.com/buildpacks/lifecycle/platform.FillExportRunImage(0x40002c4508, {0x1123cd8?, 0x1a39ff8?})
        /home/kevin.hughes/Projects/lifecycle/platform/resolve_inputs.go:142 +0x180
github.com/buildpacks/lifecycle/platform.ResolveInputs(0x0?, 0x40002c4508, {0x1123cd8, 0x1a39ff8})
        /home/kevin.hughes/Projects/lifecycle/platform/resolve_inputs.go:79 +0x404
main.(*exportCmd).Args(0x400020c100, 0xf47611?, {0x400003a0d0?, 0x0?, 0xa?})
        /home/kevin.hughes/Projects/lifecycle/cmd/lifecycle/exporter.go:97 +0xd0
github.com/buildpacks/lifecycle/cmd/lifecycle/cli.Run({0x111f120, 0x400020c100}, {0xffffe9016091, 0x8}, 0x0)
        /home/kevin.hughes/Projects/lifecycle/cmd/lifecycle/cli/command.go:78 +0x3ec
main.main()
        /home/kevin.hughes/Projects/lifecycle/cmd/lifecycle/main.go:31 +0x524
```