### PR TITLE
Ensure lifecycle arg validation executed as expected.

### DIFF
--- a/cmd/lifecycle/cli/command.go
+++ b/cmd/lifecycle/cli/command.go
@@ -61,6 +61,9 @@ func Run(c Command, withPhaseName string, asSubcommand bool) {
 
 	// We print a warning here, so we should disable color if needed and set the log level before exercising this logic.
 	for _, arg := range flagSet.Args() {
+		if len(arg) == 0 {
+			continue
+		}
 		if arg[0:1] == "-" {
 			cmd.DefaultLogger.Warnf("Warning: unconsumed flag-like positional arg: \n\t%s\n\t This will not be interpreted as a flag.\n\t Did you mean to put this before the first positional argument?", arg)
 		}

--- a/platform/resolve_inputs.go
+++ b/platform/resolve_inputs.go
@@ -31,8 +31,8 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 	switch phase {
 	case Analyze:
 		ops = append(ops,
-			FillAnalyzeImages,
 			ValidateOutputImageProvided,
+			FillAnalyzeImages,
 			CheckLaunchCache,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
@@ -42,8 +42,8 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 		// nop
 	case Create:
 		ops = append(ops,
-			FillCreateImages,
 			ValidateOutputImageProvided,
+			FillCreateImages,
 			CheckCache,
 			CheckLaunchCache,
 			ValidateImageRefs,
@@ -54,8 +54,8 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 		// nop
 	case Export:
 		ops = append(ops,
-			FillExportRunImage,
 			ValidateOutputImageProvided,
+			FillExportRunImage,
 			CheckCache,
 			CheckLaunchCache,
 			ValidateImageRefs,
@@ -65,8 +65,8 @@ func ResolveInputs(phase LifecyclePhase, i *LifecycleInputs, logger log.Logger) 
 		// nop
 	case Rebase:
 		ops = append(ops,
-			ValidateRebaseRunImage,
 			ValidateOutputImageProvided,
+			ValidateRebaseRunImage,
 			ValidateImageRefs,
 			ValidateTargetsAreSameRegistry,
 		)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
Make sure the warning message is safely guarded with a length check before attempting to access the first element of the slice.

Make sure the `ValidateOutputImageProvided` function is called first in the input resolve process to ensure the output image is provided before attempting to resolve the input image in other validation functions.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
Ensure arg parsing is safely guarded with a length check
Ensure output image arg is validated prior to further processing

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

This would solve what https://github.com/buildpacks/lifecycle/pull/1467 reports

---


