### PR TITLE
go 1.24

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -68,8 +68,8 @@ jobs:
           script: |
             apt-get update -y
             apt-get install -y wget curl git make gcc jq docker.io
-            wget https://go.dev/dl/go1.23.2.linux-s390x.tar.gz
-            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.2.linux-s390x.tar.gz
+            wget https://go.dev/dl/go1.24.0.linux-s390x.tar.gz
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.0.linux-s390x.tar.gz
             export PATH=$PATH:/usr/local/go/bin
             git clone ${GH_REPOSITORY} lifecycle
             cd lifecycle && git checkout ${GH_REF}

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ install-mockgen:
 
 install-golangci-lint:
 	@echo "> Installing golangci-lint..."
-	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
 
 lint: install-golangci-lint
 	@echo "> Linting code..."

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/cache/image_comparer.go
+++ b/cache/image_comparer.go
@@ -9,7 +9,7 @@ import (
 
 // ImageComparer provides a way to compare images
 type ImageComparer interface {
-	ImagesEq(orig imgutil.Image, new imgutil.Image) (bool, error)
+	ImagesEq(origImage imgutil.Image, newImage imgutil.Image) (bool, error)
 }
 
 // ImageComparerImpl implements the ImageComparer interface

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -60,6 +60,6 @@ func Exit(err error) {
 }
 
 func ExitWithVersion() {
-	DefaultLogger.Infof(buildVersion())
+	DefaultLogger.Info(buildVersion())
 	os.Exit(0)
 }

--- a/go.mod
+++ b/go.mod
@@ -136,4 +136,4 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 )
 
-go 1.23
+go 1.24

--- a/log/default_logger.go
+++ b/log/default_logger.go
@@ -36,7 +36,7 @@ func (l *DefaultLogger) LogLevel() log.Level {
 }
 
 func (l *DefaultLogger) Phase(name string) {
-	l.Infof(phaseStyle("===> %s", name))
+	l.Info(phaseStyle("===> %s", name))
 }
 
 func (l *DefaultLogger) SetLevel(requested string) error {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
Update to go 1.24


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
Update to go 1.24

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->
I think this could delay the go toolchain weirdness we've seen elsewhere. When I run the build on 1.24 I don't get the toolchain directive put into go.mod. If I run on the latest 1.23 version, I do. That toolchain directive breaks our "do nothing to update go patch versions" flow.
