### PR TITLE
Bump go to version 1.24.4 to fix CVE-2025-22874

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,4 +143,4 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-go 1.24.3
+go 1.24.4


### PR DESCRIPTION
### Summary
Bump GO version to 1.24.4 to fix CVE-2025-22874.

#### Release notes
Bump GO version to 1.24.4

---

### Related
Resolves #1506

