### PR TITLE
Bump go to 1.24.5

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -68,8 +68,8 @@ jobs:
           script: |
             apt-get update -y
             apt-get install -y wget curl git make gcc jq docker.io
-            wget https://go.dev/dl/go1.24.0.linux-s390x.tar.gz
-            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.0.linux-s390x.tar.gz
+            wget https://go.dev/dl/go1.24.5.linux-s390x.tar.gz
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.5.linux-s390x.tar.gz
             export PATH=$PATH:/usr/local/go/bin
             git clone ${GH_REPOSITORY} lifecycle
             cd lifecycle && git checkout ${GH_REF}

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.24.5 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/go.mod
+++ b/go.mod
@@ -323,4 +323,4 @@ tool github.com/golang/mock/mockgen
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-go 1.24.4
+go 1.24.5


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
This pull request updates the Go runtime version used across the project to `1.24.5`, ensuring compatibility with the latest features and bug fixes. The changes span configuration files, Dockerfiles, and module dependencies.

### Updates to Go runtime version:

* [`.github/workflows/test-s390x.yml`](diffhunk://#diff-2aec1bc6514a4be82b0e1fb600245e2749d70663e8aed77fc2de41336b0ce87eL71-R72): Updated the Go download link to use version `1.24.5` instead of `1.24.0`.
* [`acceptance/testdata/launcher/Dockerfile`](diffhunk://#diff-00dd8594a34fe1e28a9353b0894b2da71882dbd87b4edd4d0b1c3dc529626dc2L1-R1): Changed the base image from `golang:1.24` to `golang:1.24.5`.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L326-R326): Updated the Go version declaration from `1.24.4` to `1.24.5`.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

- Bumped go to 1.24.5


