### PR TITLE
Send stdout and stderr to the same stream (build and generate)

### DIFF
--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -132,7 +132,7 @@ func runBuildCmd(d BpDescriptor, bpLayersDir, planPath string, inputs BuildInput
 	) // #nosec G204
 	cmd.Dir = inputs.AppDir
 	cmd.Stdout = inputs.Out
-	cmd.Stderr = inputs.Err
+	cmd.Stderr = inputs.Out
 
 	var err error
 	if d.Buildpack.ClearEnv {

--- a/buildpack/generate.go
+++ b/buildpack/generate.go
@@ -88,7 +88,7 @@ func runGenerateCmd(d ExtDescriptor, extOutputDir, planPath string, inputs Gener
 	) // #nosec G204
 	cmd.Dir = inputs.AppDir
 	cmd.Stdout = inputs.Out
-	cmd.Stderr = inputs.Err
+	cmd.Stderr = inputs.Out
 
 	var err error
 	if d.Extension.ClearEnv {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
To ensure ordering of stdout and stderr in build and generate phases, send the stdout and stderr of the executing command to the same stream (stdout).

This will have an outside effect of anyone consuming `lifecycle` as what was previously in stderr is now in stdout.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

- `lifecycle/builder` and `lifecycle/generate` will no longer send buildpack stderr to stderr, but instead stdout to preserve ordering.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves https://github.com/buildpacks/pack/issues/2330

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->
I looked into and tried a few other options, but ultimately didn't find a path that allowed for us to keep the streams separate and also guarantee ordering. I believe ordering of buildpack produced logs to be more important to more users. We already use a buffer for `detector` but for different reasons (hidden by default).
