### PR TITLE
Platform 0.15: exec-env support

### DIFF
--- a/api/apis.go
+++ b/api/apis.go
@@ -11,11 +11,11 @@ var (
 	// Platform is a pair of lists of Platform API versions:
 	// 1. All supported versions (including deprecated versions)
 	// 2. The versions that are deprecated
-	Platform = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14"}, []string{})
+	Platform = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11", "0.12", "0.13", "0.14", "0.15"}, []string{})
 	// Buildpack is a pair of lists of Buildpack API versions:
 	// 1. All supported versions (including deprecated versions)
 	// 2. The versions that are deprecated
-	Buildpack = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11"}, []string{})
+	Buildpack = newApisMustParse([]string{"0.7", "0.8", "0.9", "0.10", "0.11", "0.12"}, []string{})
 )
 
 type APIs struct {

--- a/buildpack/build.go
+++ b/buildpack/build.go
@@ -25,7 +25,7 @@ const (
 	// EnvLayersDir is the absolute path of the buildpack layers directory (read-write); a different copy is provided for each buildpack;
 	// contents may be saved to either or both of: the final output image or the cache
 	EnvLayersDir = "CNB_LAYERS_DIR"
-	// Also provided during build: EnvBuildpackDir, EnvPlatformDir (see detect.go)
+	// Also provided during build: EnvBuildpackDir, EnvPlatformDir, EnvExecEnv (see detect.go)
 )
 
 type BuildInputs struct {
@@ -35,6 +35,7 @@ type BuildInputs struct {
 	PlatformDir    string
 	Env            BuildEnv
 	TargetEnv      []string
+	ExecEnv        string
 	Out, Err       io.Writer
 	Plan           Plan
 }
@@ -153,6 +154,9 @@ func runBuildCmd(d BpDescriptor, bpLayersDir, planPath string, inputs BuildInput
 	}
 	if api.MustParse(d.API()).AtLeast("0.10") {
 		cmd.Env = append(cmd.Env, inputs.TargetEnv...)
+	}
+	if api.MustParse(d.API()).AtLeast("0.12") && inputs.ExecEnv != "" {
+		cmd.Env = append(cmd.Env, "CNB_EXEC_ENV="+inputs.ExecEnv)
 	}
 
 	if err = cmd.Run(); err != nil {

--- a/buildpack/descriptor.go
+++ b/buildpack/descriptor.go
@@ -18,9 +18,10 @@ type Descriptor interface {
 // BaseInfo is information shared by both buildpacks and extensions.
 // For buildpacks it winds up under the toml `buildpack` key along with SBOM info, but extensions have no SBOMs.
 type BaseInfo struct {
-	ClearEnv bool   `toml:"clear-env,omitempty"`
-	Homepage string `toml:"homepage,omitempty"`
-	ID       string `toml:"id"`
-	Name     string `toml:"name"`
-	Version  string `toml:"version"`
+	ClearEnv bool     `toml:"clear-env,omitempty"`
+	Homepage string   `toml:"homepage,omitempty"`
+	ID       string   `toml:"id"`
+	Name     string   `toml:"name"`
+	Version  string   `toml:"version"`
+	ExecEnv  []string `toml:"exec-env,omitempty"`
 }

--- a/buildpack/detect.go
+++ b/buildpack/detect.go
@@ -23,6 +23,8 @@ const (
 	EnvExtensionDir = "CNB_EXTENSION_DIR"
 	// EnvPlatformDir is the absolute path of the platform directory (read-only); a single copy is provided for all buildpacks
 	EnvPlatformDir = "CNB_PLATFORM_DIR"
+	// EnvExecEnv is the target execution environment. Standard values include "production", "test", and "development".
+	EnvExecEnv = "CNB_EXEC_ENV"
 )
 
 type DetectInputs struct {
@@ -31,6 +33,7 @@ type DetectInputs struct {
 	PlatformDir    string
 	Env            BuildEnv
 	TargetEnv      []string
+	ExecEnv        string
 }
 
 type DetectOutputs struct {
@@ -181,6 +184,9 @@ func runDetect(d detectable, inputs DetectInputs, planPath string, envRootDirKey
 	}
 	if api.MustParse(d.API()).AtLeast("0.10") {
 		cmd.Env = append(cmd.Env, inputs.TargetEnv...)
+	}
+	if api.MustParse(d.API()).AtLeast("0.12") && inputs.ExecEnv != "" {
+		cmd.Env = append(cmd.Env, EnvExecEnv+"="+inputs.ExecEnv)
 	}
 
 	if err := cmd.Run(); err != nil {

--- a/buildpack/files.go
+++ b/buildpack/files.go
@@ -29,6 +29,7 @@ type ProcessEntry struct {
 	Direct           *bool          `toml:"direct" json:"direct"`
 	Default          bool           `toml:"default,omitempty" json:"default,omitempty"`
 	WorkingDirectory string         `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+	ExecEnv          []string       `toml:"exec-env,omitempty" json:"exec-env,omitempty"`
 }
 
 // DecodeLaunchTOML reads a launch.toml file
@@ -91,6 +92,7 @@ func (p *ProcessEntry) ToLaunchProcess(bpID string) launch.Process {
 		Default:          p.Default,
 		BuildpackID:      bpID,
 		WorkingDirectory: p.WorkingDirectory,
+		ExecEnv:          p.ExecEnv,
 	}
 }
 

--- a/buildpack/testdata/buildpack/bin/build
+++ b/buildpack/testdata/buildpack/bin/build
@@ -19,6 +19,7 @@ echo -n "${CNB_BUILDPACK_DIR:-unset}" > "build-env-cnb-buildpack-dir-${bp_id}-${
 echo -n "${CNB_LAYERS_DIR:-unset}" > "build-env-cnb-layers-dir-${bp_id}-${bp_version}"
 echo -n "${CNB_OUTPUT_DIR:-unset}" > "build-env-cnb-output-dir-${bp_id}-${bp_version}"
 echo -n "${CNB_PLATFORM_DIR:-unset}" > "build-env-cnb-platform-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_EXEC_ENV:-unset}" > "build-env-cnb-exec-env-${bp_id}-${bp_version}"
 
 cp -a "$platform_dir/env" "build-env-${bp_id}-${bp_version}"
 

--- a/buildpack/testdata/buildpack/bin/detect
+++ b/buildpack/testdata/buildpack/bin/detect
@@ -17,6 +17,7 @@ echo -n "$ENV_TYPE" > "detect-env-type-${bp_id}-${bp_version}"
 echo -n "${CNB_BUILDPACK_DIR:-unset}" > "detect-env-cnb-buildpack-dir-${bp_id}-${bp_version}"
 echo -n "${CNB_BUILD_PLAN_PATH:-unset}" > "detect-env-cnb-build-plan-path-${bp_id}-${bp_version}"
 echo -n "${CNB_PLATFORM_DIR:-unset}" > "detect-env-cnb-platform-dir-${bp_id}-${bp_version}"
+echo -n "${CNB_EXEC_ENV:-unset}" > "detect-env-cnb-exec-env-${bp_id}-${bp_version}"
 
 if [[ -f detect-plan-${bp_id}-${bp_version}.toml ]]; then
   cat "detect-plan-${bp_id}-${bp_version}.toml" > "$plan_path"

--- a/cmd/launcher/cli/launcher.go
+++ b/cmd/launcher/cli/launcher.go
@@ -41,6 +41,7 @@ func RunLaunch() error {
 		DefaultProcessType: defaultProcessType,
 		LayersDir:          cmd.EnvOrDefault(platform.EnvLayersDir, platform.DefaultLayersDir),
 		AppDir:             cmd.EnvOrDefault(platform.EnvAppDir, platform.DefaultAppDir),
+		ExecEnv:            cmd.EnvOrDefault(platform.EnvExecEnv, platform.DefaultExecEnv),
 		PlatformAPI:        p.API(),
 		Processes:          md.Processes,
 		Buildpacks:         md.Buildpacks,

--- a/cmd/lifecycle/builder.go
+++ b/cmd/lifecycle/builder.go
@@ -78,6 +78,7 @@ func (b *buildCmd) build(group buildpack.Group, plan files.Plan, analyzedMD file
 		BuildConfigDir: b.BuildConfigDir,
 		LayersDir:      b.LayersDir,
 		PlatformDir:    b.PlatformDir,
+		ExecEnv:        b.ExecEnv,
 		BuildExecutor:  &buildpack.DefaultBuildExecutor{},
 		DirStore:       platform.NewDirStore(b.BuildpacksDir, ""),
 		Group:          group,

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -220,6 +220,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 			AdditionalNames:    e.AdditionalTags,
 			AppDir:             e.AppDir,
 			DefaultProcessType: e.DefaultProcessType,
+			ExecEnv:            e.ExecEnv,
 			ExtendedDir:        e.ExtendedDir,
 			LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
 			LayersDir:          e.LayersDir,

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -22,6 +22,7 @@ type Process struct {
 	Default          bool         `toml:"default,omitempty" json:"default,omitempty"`
 	BuildpackID      string       `toml:"buildpack-id" json:"buildpackID"`
 	WorkingDirectory string       `toml:"working-dir,omitempty" json:"working-dir,omitempty"`
+	ExecEnv          []string     `toml:"exec-env,omitempty" json:"exec-env,omitempty"`
 	PlatformAPI      *api.Version `toml:"-" json:"-"`
 }
 

--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -24,6 +24,7 @@ type Launcher struct {
 	Env                Env
 	Exec               ExecFunc
 	ExecD              ExecD
+	ExecEnv            string
 	Shell              Shell
 	LayersDir          string
 	PlatformAPI        *api.Version

--- a/phase/builder.go
+++ b/phase/builder.go
@@ -40,6 +40,7 @@ type Builder struct {
 	BuildConfigDir string
 	LayersDir      string
 	PlatformDir    string
+	ExecEnv        string
 	BuildExecutor  buildpack.BuildExecutor
 	DirStore       DirStore
 	Group          buildpack.Group
@@ -150,6 +151,7 @@ func (b *Builder) getBuildInputs() buildpack.BuildInputs {
 		PlatformDir:    b.PlatformDir,
 		Env:            env.NewBuildEnv(os.Environ()),
 		TargetEnv:      platform.EnvVarsFor(&fsutil.DefaultDetector{}, b.AnalyzeMD.RunImageTarget(), b.Logger),
+		ExecEnv:        b.ExecEnv,
 		Out:            b.Out,
 		Err:            b.Err,
 	}

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -80,6 +80,8 @@ type ExportOptions struct {
 	LauncherConfig LauncherConfig
 	// DefaultProcessType is the user-provided default process type.
 	DefaultProcessType string
+	// ExecEnv is the target execution environment.
+	ExecEnv string
 	// RunImageRef is the run image reference for the layer metadata label.
 	RunImageRef string
 	// RunImageForExport is run image metadata for the layer metadata label for Platform API >= 0.12.
@@ -524,6 +526,15 @@ func (e *Exporter) setLabels(opts ExportOptions, meta files.LayersMetadata, buil
 		e.Logger.Infof("Adding label '%s'", label.Key)
 		if err := opts.WorkingImage.SetLabel(label.Key, label.Value); err != nil {
 			return errors.Wrapf(err, "set buildpack-provided label '%s'", label.Key)
+		}
+	}
+
+	// Note: This is gated by Platform API 0.15, not Buildpack API
+	// The platform controls the Platform API version and determines when this is available
+	if e.PlatformAPI.AtLeast("0.15") && opts.ExecEnv != "" {
+		e.Logger.Infof("Adding label '%s'", platform.ExecEnvLabel)
+		if err := opts.WorkingImage.SetLabel(platform.ExecEnvLabel, opts.ExecEnv); err != nil {
+			return errors.Wrap(err, "set execution environment label")
 		}
 	}
 	return nil

--- a/phase/exporter_test.go
+++ b/phase/exporter_test.go
@@ -828,6 +828,50 @@ version = "4.5.6"
 				h.AssertNil(t, err)
 				h.AssertEq(t, label, "other-label-value")
 			})
+
+			when("execution environment label", func() {
+				when("Platform API >= 0.15", func() {
+					it.Before(func() {
+						exporter.PlatformAPI = api.MustParse("0.15")
+					})
+
+					it("adds execution environment label when ExecEnv is provided", func() {
+						opts.ExecEnv = "development"
+						_, err := exporter.Export(opts)
+						h.AssertNil(t, err)
+
+						label, err := fakeAppImage.Label("io.buildpacks.exec-env")
+						h.AssertNil(t, err)
+						h.AssertEq(t, label, "development")
+					})
+
+					it("does not add execution environment label when ExecEnv is empty", func() {
+						opts.ExecEnv = ""
+						_, err := exporter.Export(opts)
+						h.AssertNil(t, err)
+
+						label, err := fakeAppImage.Label("io.buildpacks.exec-env")
+						h.AssertNil(t, err)
+						h.AssertEq(t, label, "")
+					})
+				})
+
+				when("Platform API < 0.15", func() {
+					it.Before(func() {
+						exporter.PlatformAPI = api.MustParse("0.14")
+					})
+
+					it("does not add execution environment label even when ExecEnv is provided", func() {
+						opts.ExecEnv = "development"
+						_, err := exporter.Export(opts)
+						h.AssertNil(t, err)
+
+						label, err := fakeAppImage.Label("io.buildpacks.exec-env")
+						h.AssertNil(t, err)
+						h.AssertEq(t, label, "")
+					})
+				})
+			})
 		})
 
 		when("previous image doesn't exist", func() {

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -122,6 +122,10 @@ const (
 	EnvAppDir      = "CNB_APP_DIR"
 	EnvLayersDir   = "CNB_LAYERS_DIR"
 	EnvPlatformDir = "CNB_PLATFORM_DIR"
+
+	// EnvExecEnv is the target execution environment. Standard values include "production", "test", and "development".
+	EnvExecEnv     = "CNB_EXEC_ENV"
+	DefaultExecEnv = "production"
 )
 
 // The following are the default locations of input directories if not specified.

--- a/platform/labels.go
+++ b/platform/labels.go
@@ -2,6 +2,7 @@ package platform
 
 const (
 	BuildMetadataLabel     = "io.buildpacks.build.metadata"
+	ExecEnvLabel           = "io.buildpacks.exec-env"
 	LifecycleMetadataLabel = "io.buildpacks.lifecycle.metadata"
 	MixinsLabel            = "io.buildpacks.stack.mixins"
 	ProjectMetadataLabel   = "io.buildpacks.project.metadata"

--- a/platform/launch/defaults.go
+++ b/platform/launch/defaults.go
@@ -12,6 +12,9 @@ const (
 	EnvNoColor     = "CNB_NO_COLOR" // defaults to false
 	EnvPlatformAPI = "CNB_PLATFORM_API"
 	EnvProcessType = "CNB_PROCESS_TYPE"
+	// EnvExecEnv is the target execution environment. Standard values include "production", "test", and "development".
+	EnvExecEnv     = "CNB_EXEC_ENV"
+	DefaultExecEnv = "production"
 
 	DefaultPlatformAPI = ""
 	DefaultProcessType = "web"

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -29,6 +29,7 @@ type LifecycleInputs struct {
 	CacheImageRef         string
 	DefaultProcessType    string
 	DeprecatedRunImageRef string
+	ExecEnv               string
 	ExtendKind            string
 	ExtendedDir           string
 	ExtensionsDir         string
@@ -112,6 +113,7 @@ func NewLifecycleInputs(platformAPI *api.Version) *LifecycleInputs {
 		// Provided at build time
 
 		AppDir:      envOrDefault(EnvAppDir, DefaultAppDir),
+		ExecEnv:     envOrDefault(EnvExecEnv, DefaultExecEnv),
 		LayersDir:   envOrDefault(EnvLayersDir, DefaultLayersDir),
 		LayoutDir:   os.Getenv(EnvLayoutDir),
 		OrderPath:   envOrDefault(EnvOrderPath, filepath.Join(PlaceholderLayers, DefaultOrderFile)),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
Exec Env support for [0.15](https://github.com/buildpacks/spec/releases/tag/platform%2F0.15)


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

Execution Environments: The lifecycle phases (restorer, extender) can utilize CNB_EXEC_ENV. (https://github.com/buildpacks/spec/pull/416, [RFC 0134](https://github.com/buildpacks/rfcs/blob/main/text/0134-execution-environments.md)).

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

