### PR TITLE
System Buildpacks

### DIFF
--- a/acceptance/testdata/detector/container/cnb/orders/middle_order.toml
+++ b/acceptance/testdata/detector/container/cnb/orders/middle_order.toml
@@ -1,0 +1,5 @@
+[[order]]
+
+  [[order.group]]
+    id = "buildpack_for_ext"
+    version = "buildpack_for_ext_version"

--- a/acceptance/testdata/detector/container/cnb/system.toml
+++ b/acceptance/testdata/detector/container/cnb/system.toml
@@ -1,0 +1,10 @@
+[system]
+  [system.pre]
+    [[system.pre.buildpacks]]
+      id = "always_detect_buildpack"
+      version = "always_detect_buildpack_version"
+
+  [system.post]
+    [[system.post.buildpacks]]
+      id = "simple_buildpack"
+      version = "simple_buildpack_version"

--- a/buildpack/testmock/env.go
+++ b/buildpack/testmock/env.go
@@ -7,9 +7,8 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	env "github.com/buildpacks/lifecycle/env"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBuildEnv is a mock of BuildEnv interface.

--- a/cmd/lifecycle/cli/flags.go
+++ b/cmd/lifecycle/cli/flags.go
@@ -150,6 +150,10 @@ func FlagStackPath(stackPath *string) {
 	flagSet.StringVar(stackPath, "stack", *stackPath, "path to stack.toml")
 }
 
+func FlagSystemPath(systemPath *string) {
+	flagSet.StringVar(systemPath, "system", *systemPath, "path to system.toml")
+}
+
 func FlagTags(tags *str.Slice) {
 	flagSet.Var(tags, "tag", "additional tags")
 }

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -29,6 +29,9 @@ type createCmd struct {
 
 // DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (c *createCmd) DefineFlags() {
+	if c.PlatformAPI.AtLeast("0.15") {
+		cli.FlagSystemPath(&c.SystemPath)
+	}
 	if c.PlatformAPI.AtLeast("0.13") {
 		cli.FlagInsecureRegistries(&c.InsecureRegistries)
 	}

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -18,6 +18,9 @@ type detectCmd struct {
 
 // DefineFlags defines the flags that are considered valid and reads their values (if provided).
 func (d *detectCmd) DefineFlags() {
+	if d.PlatformAPI.AtLeast("0.15") {
+		cli.FlagSystemPath(&d.SystemPath)
+	}
 	if d.PlatformAPI.AtLeast("0.12") {
 		cli.FlagRunPath(&d.RunPath)
 	}

--- a/phase/detector.go
+++ b/phase/detector.go
@@ -80,7 +80,7 @@ func (f *HermeticFactory) NewDetector(inputs platform.LifecycleInputs, logger lo
 	if detector.AnalyzeMD, err = f.configHandler.ReadAnalyzed(inputs.AnalyzedPath, logger); err != nil {
 		return nil, err
 	}
-	if detector.Order, detector.HasExtensions, err = f.getOrder(inputs.OrderPath, logger); err != nil {
+	if detector.Order, detector.HasExtensions, err = f.getOrderWithSystem(inputs.OrderPath, inputs.SystemPath, logger); err != nil {
 		return nil, err
 	}
 	return detector, nil

--- a/phase/handlers.go
+++ b/phase/handlers.go
@@ -40,4 +40,5 @@ type ConfigHandler interface {
 	ReadOrder(path string) (buildpack.Order, buildpack.Order, error)
 	ReadRun(runPath string, logger log.Logger) (files.Run, error)
 	ReadPlan(path string) (files.Plan, error)
+	ReadSystem(path string, logger log.Logger) (files.System, error)
 }

--- a/phase/system_test.go
+++ b/phase/system_test.go
@@ -1,0 +1,181 @@
+package phase
+
+import (
+	"os"
+	"testing"
+
+	"github.com/buildpacks/lifecycle/buildpack"
+	"github.com/buildpacks/lifecycle/log"
+	"github.com/buildpacks/lifecycle/platform/files"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+func TestMergeSystemBuildpacks(t *testing.T) {
+	logger := log.NewDefaultLogger(os.Stdout)
+
+	t.Run("merges pre and post buildpacks", func(t *testing.T) {
+		order := buildpack.Order{
+			{Group: []buildpack.GroupElement{
+				{ID: "order-bp-1", Version: "1.0.0"},
+				{ID: "order-bp-2", Version: "2.0.0"},
+			}},
+			{Group: []buildpack.GroupElement{
+				{ID: "order-bp-3", Version: "3.0.0"},
+			}},
+		}
+
+		system := files.System{
+			Pre: files.SystemBuildpacks{
+				Buildpacks: []files.SystemBuildpack{
+					{ID: "pre-bp-1", Version: "0.1.0"},
+					{ID: "pre-bp-2", Version: "0.2.0"},
+				},
+			},
+			Post: files.SystemBuildpacks{
+				Buildpacks: []files.SystemBuildpack{
+					{ID: "post-bp-1", Version: "9.0.0"},
+				},
+			},
+		}
+
+		merged := mergeSystemBuildpacks(order, system, logger)
+
+		// Should have same number of groups
+		h.AssertEq(t, len(merged), 2)
+
+		// First group should have: pre-bp-1, pre-bp-2, order-bp-1, order-bp-2, post-bp-1
+		h.AssertEq(t, len(merged[0].Group), 5)
+		h.AssertEq(t, merged[0].Group[0].ID, "pre-bp-1")
+		h.AssertEq(t, merged[0].Group[0].Version, "0.1.0")
+		h.AssertEq(t, merged[0].Group[1].ID, "pre-bp-2")
+		h.AssertEq(t, merged[0].Group[1].Version, "0.2.0")
+		h.AssertEq(t, merged[0].Group[2].ID, "order-bp-1")
+		h.AssertEq(t, merged[0].Group[2].Version, "1.0.0")
+		h.AssertEq(t, merged[0].Group[3].ID, "order-bp-2")
+		h.AssertEq(t, merged[0].Group[3].Version, "2.0.0")
+		h.AssertEq(t, merged[0].Group[4].ID, "post-bp-1")
+		h.AssertEq(t, merged[0].Group[4].Version, "9.0.0")
+
+		// Second group should have: pre-bp-1, pre-bp-2, order-bp-3, post-bp-1
+		h.AssertEq(t, len(merged[1].Group), 4)
+		h.AssertEq(t, merged[1].Group[0].ID, "pre-bp-1")
+		h.AssertEq(t, merged[1].Group[1].ID, "pre-bp-2")
+		h.AssertEq(t, merged[1].Group[2].ID, "order-bp-3")
+		h.AssertEq(t, merged[1].Group[3].ID, "post-bp-1")
+	})
+
+	t.Run("handles only pre buildpacks", func(t *testing.T) {
+		order := buildpack.Order{
+			{Group: []buildpack.GroupElement{
+				{ID: "order-bp", Version: "1.0.0"},
+			}},
+		}
+
+		system := files.System{
+			Pre: files.SystemBuildpacks{
+				Buildpacks: []files.SystemBuildpack{
+					{ID: "pre-bp", Version: "0.5.0"},
+				},
+			},
+		}
+
+		merged := mergeSystemBuildpacks(order, system, logger)
+
+		h.AssertEq(t, len(merged), 1)
+		h.AssertEq(t, len(merged[0].Group), 2)
+		h.AssertEq(t, merged[0].Group[0].ID, "pre-bp")
+		h.AssertEq(t, merged[0].Group[1].ID, "order-bp")
+	})
+
+	t.Run("handles only post buildpacks", func(t *testing.T) {
+		order := buildpack.Order{
+			{Group: []buildpack.GroupElement{
+				{ID: "order-bp", Version: "1.0.0"},
+			}},
+		}
+
+		system := files.System{
+			Post: files.SystemBuildpacks{
+				Buildpacks: []files.SystemBuildpack{
+					{ID: "post-bp", Version: "5.0.0"},
+				},
+			},
+		}
+
+		merged := mergeSystemBuildpacks(order, system, logger)
+
+		h.AssertEq(t, len(merged), 1)
+		h.AssertEq(t, len(merged[0].Group), 2)
+		h.AssertEq(t, merged[0].Group[0].ID, "order-bp")
+		h.AssertEq(t, merged[0].Group[1].ID, "post-bp")
+	})
+
+	t.Run("returns unchanged order when system is empty", func(t *testing.T) {
+		order := buildpack.Order{
+			{Group: []buildpack.GroupElement{
+				{ID: "order-bp", Version: "1.0.0"},
+			}},
+		}
+
+		system := files.System{}
+
+		merged := mergeSystemBuildpacks(order, system, logger)
+
+		h.AssertEq(t, len(merged), 1)
+		h.AssertEq(t, len(merged[0].Group), 1)
+		h.AssertEq(t, merged[0].Group[0].ID, "order-bp")
+	})
+
+	t.Run("preserves group extensions", func(t *testing.T) {
+		order := buildpack.Order{
+			{
+				Group: []buildpack.GroupElement{
+					{ID: "order-bp", Version: "1.0.0"},
+				},
+				GroupExtensions: []buildpack.GroupElement{
+					{ID: "ext-1", Version: "1.0.0", Extension: true},
+				},
+			},
+		}
+
+		system := files.System{
+			Pre: files.SystemBuildpacks{
+				Buildpacks: []files.SystemBuildpack{
+					{ID: "pre-bp", Version: "0.5.0"},
+				},
+			},
+		}
+
+		merged := mergeSystemBuildpacks(order, system, logger)
+
+		h.AssertEq(t, len(merged), 1)
+		h.AssertEq(t, len(merged[0].Group), 2)
+		h.AssertEq(t, len(merged[0].GroupExtensions), 1)
+		h.AssertEq(t, merged[0].GroupExtensions[0].ID, "ext-1")
+	})
+}
+
+func TestConvertSystemToGroupElements(t *testing.T) {
+	t.Run("converts system buildpacks to group elements", func(t *testing.T) {
+		systemBps := []files.SystemBuildpack{
+			{ID: "bp-1", Version: "1.0.0"},
+			{ID: "bp-2", Version: "2.0.0"},
+		}
+
+		elements := convertSystemToGroupElements(systemBps)
+
+		h.AssertEq(t, len(elements), 2)
+		h.AssertEq(t, elements[0].ID, "bp-1")
+		h.AssertEq(t, elements[0].Version, "1.0.0")
+		h.AssertEq(t, elements[1].ID, "bp-2")
+		h.AssertEq(t, elements[1].Version, "2.0.0")
+	})
+
+	t.Run("handles empty list", func(t *testing.T) {
+		systemBps := []files.SystemBuildpack{}
+
+		elements := convertSystemToGroupElements(systemBps)
+
+		h.AssertEq(t, len(elements), 0)
+	})
+}

--- a/phase/testmock/build_env.go
+++ b/phase/testmock/build_env.go
@@ -7,9 +7,8 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	env "github.com/buildpacks/lifecycle/env"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBuildEnv is a mock of BuildEnv interface.

--- a/phase/testmock/build_executor.go
+++ b/phase/testmock/build_executor.go
@@ -7,10 +7,9 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
 	log "github.com/buildpacks/lifecycle/log"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBuildExecutor is a mock of BuildExecutor interface.

--- a/phase/testmock/buildpack_api_verifier.go
+++ b/phase/testmock/buildpack_api_verifier.go
@@ -7,9 +7,8 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	log "github.com/buildpacks/lifecycle/log"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockBuildpackAPIVerifier is a mock of BuildpackAPIVerifier interface.

--- a/phase/testmock/cache_handler.go
+++ b/phase/testmock/cache_handler.go
@@ -7,9 +7,8 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	phase "github.com/buildpacks/lifecycle/phase"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCacheHandler is a mock of CacheHandler interface.

--- a/phase/testmock/component_descriptor.go
+++ b/phase/testmock/component_descriptor.go
@@ -7,9 +7,8 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockDescriptor is a mock of Descriptor interface.

--- a/phase/testmock/config_handler.go
+++ b/phase/testmock/config_handler.go
@@ -7,11 +7,10 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
 	log "github.com/buildpacks/lifecycle/log"
 	files "github.com/buildpacks/lifecycle/platform/files"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockConfigHandler is a mock of ConfigHandler interface.
@@ -111,4 +110,19 @@ func (m *MockConfigHandler) ReadRun(arg0 string, arg1 log.Logger) (files.Run, er
 func (mr *MockConfigHandlerMockRecorder) ReadRun(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadRun", reflect.TypeOf((*MockConfigHandler)(nil).ReadRun), arg0, arg1)
+}
+
+// ReadSystem mocks base method.
+func (m *MockConfigHandler) ReadSystem(arg0 string, arg1 log.Logger) (files.System, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadSystem", arg0, arg1)
+	ret0, _ := ret[0].(files.System)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadSystem indicates an expected call of ReadSystem.
+func (mr *MockConfigHandlerMockRecorder) ReadSystem(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSystem", reflect.TypeOf((*MockConfigHandler)(nil).ReadSystem), arg0, arg1)
 }

--- a/phase/testmock/detect_executor.go
+++ b/phase/testmock/detect_executor.go
@@ -7,10 +7,9 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
 	log "github.com/buildpacks/lifecycle/log"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockDetectExecutor is a mock of DetectExecutor interface.

--- a/phase/testmock/detect_resolver.go
+++ b/phase/testmock/detect_resolver.go
@@ -8,10 +8,9 @@ import (
 	reflect "reflect"
 	sync "sync"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
 	files "github.com/buildpacks/lifecycle/platform/files"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockDetectResolver is a mock of DetectResolver interface.

--- a/phase/testmock/dir_store.go
+++ b/phase/testmock/dir_store.go
@@ -7,9 +7,8 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockDirStore is a mock of DirStore interface.

--- a/phase/testmock/dockerfile_applier.go
+++ b/phase/testmock/dockerfile_applier.go
@@ -7,11 +7,10 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-
 	extend "github.com/buildpacks/lifecycle/internal/extend"
 	log "github.com/buildpacks/lifecycle/log"
+	gomock "github.com/golang/mock/gomock"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 // MockDockerfileApplier is a mock of DockerfileApplier interface.

--- a/phase/testmock/generate_executor.go
+++ b/phase/testmock/generate_executor.go
@@ -7,10 +7,9 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	buildpack "github.com/buildpacks/lifecycle/buildpack"
 	log "github.com/buildpacks/lifecycle/log"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockGenerateExecutor is a mock of GenerateExecutor interface.

--- a/phase/testmock/layer_factory.go
+++ b/phase/testmock/layer_factory.go
@@ -7,10 +7,9 @@ package testmock
 import (
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	launch "github.com/buildpacks/lifecycle/launch"
 	layers "github.com/buildpacks/lifecycle/layers"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockLayerFactory is a mock of LayerFactory interface.

--- a/platform/defaults.go
+++ b/platform/defaults.go
@@ -94,6 +94,10 @@ const (
 	EnvOrderPath     = "CNB_ORDER_PATH"
 	DefaultOrderFile = "order.toml"
 
+	// EnvSystemPath is the location of the system file, which contains information about system buildpacks to prepend/append to the order.
+	EnvSystemPath     = "CNB_SYSTEM_PATH"
+	DefaultSystemFile = "system.toml"
+
 	// EnvRunPath is the location of the run file, which contains information about the runtime base image.
 	EnvRunPath = "CNB_RUN_PATH"
 	// EnvStackPath is the location of the (deprecated) stack file, which contains information about the runtime base image.
@@ -107,6 +111,9 @@ var (
 
 	// CNBOrderPath is the default order path if the order file does not exist in the layers directory.
 	CNBOrderPath = filepath.Join(path.RootDir, "cnb", "order.toml")
+
+	// CNBSystemPath is the default system path.
+	CNBSystemPath = filepath.Join(path.RootDir, "cnb", "system.toml")
 
 	// DefaultRunPath is the default run path.
 	DefaultRunPath = filepath.Join(path.RootDir, "cnb", "run.toml")

--- a/platform/files/handle_toml.go
+++ b/platform/files/handle_toml.go
@@ -195,3 +195,19 @@ func (h *TOMLHandler) ReadStack(path string, logger log.Logger) (Stack, error) {
 	}
 	return stackMD, nil
 }
+
+// ReadSystem reads the provided system.toml file.
+// It logs a debug message and returns an empty System if the file does not exist.
+func (h *TOMLHandler) ReadSystem(path string, logger log.Logger) (System, error) {
+	var system struct {
+		System System `toml:"system"`
+	}
+	if _, err := toml.DecodeFile(path, &system); err != nil {
+		if os.IsNotExist(err) {
+			logger.Debugf("No system buildpacks found at path %q", path)
+			return System{}, nil
+		}
+		return System{}, fmt.Errorf("failed to read system file: %w", err)
+	}
+	return system.System, nil
+}

--- a/platform/files/system.go
+++ b/platform/files/system.go
@@ -1,0 +1,22 @@
+package files
+
+// system.toml is provided by the platform or builder to define system buildpacks
+// that should be prepended or appended to the order during detection.
+// See `buildpack.Order` for further information.
+
+// System represents the contents of the system.toml file.
+type System struct {
+	Pre  SystemBuildpacks `toml:"pre"`
+	Post SystemBuildpacks `toml:"post"`
+}
+
+// SystemBuildpacks contains the list of buildpacks to include.
+type SystemBuildpacks struct {
+	Buildpacks []SystemBuildpack `toml:"buildpacks"`
+}
+
+// SystemBuildpack represents a buildpack reference in the system.toml file.
+type SystemBuildpack struct {
+	ID      string `toml:"id"`
+	Version string `toml:"version"`
+}

--- a/platform/files/system_test.go
+++ b/platform/files/system_test.go
@@ -1,0 +1,140 @@
+package files_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/lifecycle/log"
+	"github.com/buildpacks/lifecycle/platform/files"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+func TestSystem(t *testing.T) {
+	spec.Run(t, "System", testSystem, spec.Report(report.Terminal{}))
+}
+
+func testSystem(t *testing.T, when spec.G, it spec.S) {
+	var (
+		tmpDir string
+		logger *log.DefaultLogger
+	)
+
+	it.Before(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "lifecycle.test")
+		h.AssertNil(t, err)
+		logger = log.NewDefaultLogger(os.Stdout)
+	})
+
+	it.After(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	when("#ReadSystem", func() {
+		when("system.toml exists with pre and post buildpacks", func() {
+			it("returns system buildpacks", func() {
+				systemTOMLContents := `
+[system]
+  [system.pre]
+    [[system.pre.buildpacks]]
+      id = "pre-buildpack-1"
+      version = "1.0.0"
+
+    [[system.pre.buildpacks]]
+      id = "pre-buildpack-2"
+      version = "2.0.0"
+
+  [system.post]
+    [[system.post.buildpacks]]
+      id = "post-buildpack-1"
+      version = "1.5.0"
+`
+				h.Mkfile(t, systemTOMLContents, filepath.Join(tmpDir, "system.toml"))
+
+				handler := files.NewHandler()
+				system, err := handler.ReadSystem(filepath.Join(tmpDir, "system.toml"), logger)
+
+				h.AssertNil(t, err)
+				h.AssertEq(t, len(system.Pre.Buildpacks), 2)
+				h.AssertEq(t, system.Pre.Buildpacks[0].ID, "pre-buildpack-1")
+				h.AssertEq(t, system.Pre.Buildpacks[0].Version, "1.0.0")
+				h.AssertEq(t, system.Pre.Buildpacks[1].ID, "pre-buildpack-2")
+				h.AssertEq(t, system.Pre.Buildpacks[1].Version, "2.0.0")
+				h.AssertEq(t, len(system.Post.Buildpacks), 1)
+				h.AssertEq(t, system.Post.Buildpacks[0].ID, "post-buildpack-1")
+				h.AssertEq(t, system.Post.Buildpacks[0].Version, "1.5.0")
+			})
+		})
+
+		when("system.toml exists with only pre buildpacks", func() {
+			it("returns only pre buildpacks", func() {
+				systemTOMLContents := `
+[system]
+  [system.pre]
+    [[system.pre.buildpacks]]
+      id = "pre-only"
+      version = "0.1.0"
+`
+				h.Mkfile(t, systemTOMLContents, filepath.Join(tmpDir, "system.toml"))
+
+				handler := files.NewHandler()
+				system, err := handler.ReadSystem(filepath.Join(tmpDir, "system.toml"), logger)
+
+				h.AssertNil(t, err)
+				h.AssertEq(t, len(system.Pre.Buildpacks), 1)
+				h.AssertEq(t, system.Pre.Buildpacks[0].ID, "pre-only")
+				h.AssertEq(t, len(system.Post.Buildpacks), 0)
+			})
+		})
+
+		when("system.toml exists with only post buildpacks", func() {
+			it("returns only post buildpacks", func() {
+				systemTOMLContents := `
+[system]
+  [system.post]
+    [[system.post.buildpacks]]
+      id = "post-only"
+      version = "3.0.0"
+`
+				h.Mkfile(t, systemTOMLContents, filepath.Join(tmpDir, "system.toml"))
+
+				handler := files.NewHandler()
+				system, err := handler.ReadSystem(filepath.Join(tmpDir, "system.toml"), logger)
+
+				h.AssertNil(t, err)
+				h.AssertEq(t, len(system.Pre.Buildpacks), 0)
+				h.AssertEq(t, len(system.Post.Buildpacks), 1)
+				h.AssertEq(t, system.Post.Buildpacks[0].ID, "post-only")
+			})
+		})
+
+		when("system.toml does not exist", func() {
+			it("returns empty system without error", func() {
+				handler := files.NewHandler()
+				system, err := handler.ReadSystem(filepath.Join(tmpDir, "nonexistent.toml"), logger)
+
+				h.AssertNil(t, err)
+				h.AssertEq(t, len(system.Pre.Buildpacks), 0)
+				h.AssertEq(t, len(system.Post.Buildpacks), 0)
+			})
+		})
+
+		when("system.toml is empty", func() {
+			it("returns empty system without error", func() {
+				systemTOMLContents := `[system]`
+				h.Mkfile(t, systemTOMLContents, filepath.Join(tmpDir, "system.toml"))
+
+				handler := files.NewHandler()
+				system, err := handler.ReadSystem(filepath.Join(tmpDir, "system.toml"), logger)
+
+				h.AssertNil(t, err)
+				h.AssertEq(t, len(system.Pre.Buildpacks), 0)
+				h.AssertEq(t, len(system.Post.Buildpacks), 0)
+			})
+		})
+	})
+}

--- a/platform/lifecycle_inputs.go
+++ b/platform/lifecycle_inputs.go
@@ -51,6 +51,7 @@ type LifecycleInputs struct {
 	RunImageRef           string
 	RunPath               string
 	StackPath             string
+	SystemPath            string
 	UID                   int
 	GID                   int
 	ForceRebase           bool
@@ -108,6 +109,7 @@ func NewLifecycleInputs(platformAPI *api.Version) *LifecycleInputs {
 		ExtensionsDir:  envOrDefault(EnvExtensionsDir, DefaultExtensionsDir),
 		RunPath:        envOrDefault(EnvRunPath, DefaultRunPath),
 		StackPath:      envOrDefault(EnvStackPath, DefaultStackPath),
+		SystemPath:     envOrDefault(EnvSystemPath, CNBSystemPath),
 
 		// Provided at build time
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
This pull request introduces support for merging system buildpacks (defined in `system.toml`) into the buildpack order for Platform API >= 0.15. It includes changes to the detector phase, CLI flags, configuration handling, and adds comprehensive tests to verify the new behavior. The most important changes are grouped below.

**Platform API 0.15+ system buildpack support:**

* The detector phase now reads and merges system buildpacks (from `system.toml`) with the buildpack order when Platform API >= 0.15. System buildpacks are prepended and appended to each group in the order. [[1]](diffhunk://#diff-9a99bfcd0577fd6f6418e066bad13977f852a5a39ff6d2e67d0eaff7a93b89d8L47-R120) [[2]](diffhunk://#diff-cb5de43c2b5c11b47339c23dc0831e73accedaec8f22acb98c490e2de43c2c36L83-R83) [[3]](diffhunk://#diff-f43c3949f74516c7b685b269b53264871f1e6f646d059fd2aafba39990d31507R421-R486) [[4]](diffhunk://#diff-62be9dec8d93a77b60ea025b354174538b4ded212c04073324b295f5d1d2eefcR100-R198)
* Added CLI flag `--system` to specify the path to `system.toml` for relevant commands, and enabled it for Platform API >= 0.15. [[1]](diffhunk://#diff-13ec6c85079c84f22ebaada04859d6dc3620542d209b76c39b04b3ddd3b2a790R153-R156) [[2]](diffhunk://#diff-0464f21f34e7a8b2ce8b1a9ea0875b11e49c9d05fdc9f0718058df99f04ec3f8R21-R23) [[3]](diffhunk://#diff-6ee1566444f69257a5b28d31a58219b5eefe7c39938a05a42e5107f41a3ad197R32-R34)

**Configuration and handler updates:**

* The `ConfigHandler` interface now supports reading system buildpacks via a new `ReadSystem` method.
* Updated the detector factory to use the new `getOrderWithSystem` method, which merges system buildpacks as needed.

**Testing and validation:**

* Added new acceptance and unit tests for merging system buildpacks, covering various scenarios including only pre/post buildpacks, empty system, and extension preservation. [[1]](diffhunk://#diff-30beea82e2da9ae43ce4cd4b703953c6c98634e347e40cfb79411cdc393f311dR1-R181) [[2]](diffhunk://#diff-f43c3949f74516c7b685b269b53264871f1e6f646d059fd2aafba39990d31507R421-R486) [[3]](diffhunk://#diff-62be9dec8d93a77b60ea025b354174538b4ded212c04073324b295f5d1d2eefcR100-R198)
* Added test data for `system.toml` and `middle_order.toml` to support acceptance tests. [[1]](diffhunk://#diff-c66ea55ab11ee9232dd3bedf28e315c11d00b546855937f114525027fc87da1eR1-R10) [[2]](diffhunk://#diff-e8784d32ead714ab58da93ddb2f1048194c2634ff0366a83d83bbf9cd1d135b8R1-R5)

**Minor code cleanup:**

* Reordered imports in several test mock files for consistency. [[1]](diffhunk://#diff-c5bc7e01b54a74653caf84a2a46953f0cf2e94804a43f57244a2f1a00e065e66L10-R11) [[2]](diffhunk://#diff-4f50c5e9d1ac834d27558ec22cf39cb96883f1820b311fc9b877cb28e7ae33ddL10-R12) [[3]](diffhunk://#diff-cc0122c9d742b0a07d1cc38b21f576cbaf19d101271f647c67e562192e581c73L10-R11) [[4]](diffhunk://#diff-a7d5d549c054eed5138e6ff53a5fcfe96ced21e48441cfb7e8d9e2bfe4e3cc3dL10-R11) [[5]](diffhunk://#diff-6732429e7eccfd4d9ce9d8889bfc27c06f36a4bc5dd8385881dc1fa6b7bfed3aL10-R11) [[6]](diffhunk://#diff-87d1df1b52b393d2895f61c3fcc696a5789fd33beea44c49fe1d08f0ee129294L10-R13)


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
- Added support in Platform 0.15 for [System Buildpacks](https://github.com/buildpacks/rfcs/blob/main/text/0101-system-buildpacks-in-builder.md).


---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Implements Spec Changes [here](https://github.com/buildpacks/spec/pull/419)

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

- [ ] Spec PR has been merged
- [ ] Any updates to spec PR are reflected in changesets