### PR TITLE
bumping go to 1.25.3

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -68,8 +68,8 @@ jobs:
           script: |
             apt-get update -y
             apt-get install -y wget curl git make gcc jq docker.io
-            wget https://go.dev/dl/go1.24.6.linux-s390x.tar.gz
-            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.24.6.linux-s390x.tar.gz
+            wget https://go.dev/dl/go1.25.3.linux-s390x.tar.gz
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.25.3.linux-s390x.tar.gz
             export PATH=$PATH:/usr/local/go/bin
             git clone ${GH_REPOSITORY} lifecycle
             cd lifecycle && git checkout ${GH_REF}

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.8 as builder
+FROM golang:1.25.3 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/go.mod
+++ b/go.mod
@@ -326,4 +326,4 @@ tool github.com/golang/mock/mockgen
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-go 1.24.8
+go 1.25.3


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
This pull request updates the Go version used in both the `Dockerfile` and the `go.mod` file to ensure the project is built and run with Go 1.25.3. This helps keep dependencies current and improves compatibility and security.

Go version updates:

* Updated the base image in `acceptance/testdata/launcher/Dockerfile` from `golang:1.24.6` to `golang:1.25.3` to use the latest patch version for building.
* Changed the Go version in `go.mod` from `1.24.6` to `1.25.3` for consistency with the Docker build environment.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
- Updated go to 1.25.3

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves https://github.com/buildpacks/lifecycle/issues/1549

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

