### PR TITLE
fix: remove error check that always returns nil

### DIFF
--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -116,9 +116,6 @@ func (c *createCmd) Exec() error {
 		return err
 	}
 	dirStore := platform.NewDirStore(c.BuildpacksDir, c.ExtensionsDir)
-	if err != nil {
-		return err
-	}
 
 	// Analyze
 	var (


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
Remove a nil error check that always returns nil since `platform.NewDirStore` doesn't return an error.


#### Release notes
Remove a nil error check that always returns nil.
