### PR TITLE
Ignore RC versions for all Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  # This block ignores RC versions for all Go dependencies
+  ignore:
+    - dependency-name: "*"
+      versions: ["*-rc*"]
   groups:
     # Group all minor/patch go dependencies into a single PR.
     go-dependencies:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
Add ignore block for RC versions in Go dependencies. Dependabot PRs were being opened for things we don't really want to update to


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
- Updated dependabot configuration to ignore rc release for go libraries.


---

