### PR TITLE
Makefile: Extend GOOS_ARCHS by freebsd/amd64 and freebsd/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GOFILES := $(shell $(GOCMD) run tools$/lister$/main.go)
 
 all: test build package
 
-GOOS_ARCHS = linux/amd64 linux/arm64 linux/ppc64le linux/s390x darwin/amd64 darwin/arm64
+GOOS_ARCHS = linux/amd64 linux/arm64 linux/ppc64le linux/s390x darwin/amd64 darwin/arm64 freebsd/amd64 freebsd/arm64
 
 build: build-linux-amd64 build-linux-arm64 build-linux-ppc64le build-linux-s390x
 


### PR DESCRIPTION
### Summary

This patch allows to build lifecycle for FreeBSD, for example:

```shell
make build-freebsd-amd64
```

#### Release notes

No relevant yet I guess.

### Context

This is a required step to be able to build a freebsd lifecycle image later.
