### PR TITLE
workflows: Include FreeBSD amd64 and FreeBSD arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,22 @@ jobs:
         with:
           name: lifecycle-linux-s390x-sha256
           path: out/lifecycle-v*+linux.s390x.tgz.sha256
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lifecycle-freebsd-amd64
+          path: out/lifecycle-v*+freebsd.amd64.tgz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lifecycle-freebsd-amd64-sha256
+          path: out/lifecycle-v*+freebsd.amd64.tgz.sha256
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lifecycle-freebsd-arm64
+          path: out/lifecycle-v*+freebsd.arm64.tgz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lifecycle-freebsd-arm64-sha256
+          path: out/lifecycle-v*+freebsd.arm64.tgz.sha256
       - name: Generate SBOM JSON
         uses: CycloneDX/gh-gomod-generate-sbom@v2
         with:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -24,7 +24,7 @@ jobs:
             exit 1
           fi
           echo "LIFECYCLE_VERSION=$version" >> $GITHUB_ENV
-      - name: Determine download urls for linux-x86-64, linux-arm64, linux-ppc64le, linux-s390x
+      - name: Determine download urls for linux-x86-64, linux-arm64, linux-ppc64le, linux-s390x, freebsd-amd64, freebsd-arm64
         id: artifact-urls
         # FIXME: this script should be updated to work with actions/github-script@v6
         uses: actions/github-script@v3
@@ -82,11 +82,11 @@ jobs:
                 if (urlList.length === 0) {
                   throw "no artifacts found"
                 }
-                if (urlList.length != 10) {
+                if (urlList.length != 14) {
                   // found too many artifacts
                   // list them and throw
                   console.log(urlList);
-                  throw "there should be exactly 10 artifacts, found " + urlList.length + " artifacts"
+                  throw "there should be exactly 14 artifacts, found " + urlList.length + " artifacts"
                 }
                 return urlList.join(",")
               })


### PR DESCRIPTION
### Summary
Include FreeBSD amd64 and FreeBSD arm64 versions of lifecycle in the release.

### Related

#1613 prepares the Makefile and is a dependency. This PR is the more 'dangerous' part, therefore I've split it.

### Context
The workflows have NOT been tested on my side in my own repo.

