### PR TITLE
fix: pass insecure registry options to image cache

### DIFF
--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -102,7 +102,7 @@ func (a *analyzeCmd) Exec() error {
 	factory := phase.NewConnectedFactory(
 		a.PlatformAPI,
 		&cmd.BuildpackAPIVerifier{},
-		NewCacheHandler(a.keychain),
+		NewCacheHandler(a.keychain, a.InsecureRegistries),
 		files.Handler,
 		image.NewHandler(a.docker, a.keychain, a.LayoutDir, a.UseLayout, a.InsecureRegistries),
 		image.NewRegistryHandler(a.keychain, a.InsecureRegistries),

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -111,7 +111,7 @@ func (c *createCmd) Privileges() error {
 }
 
 func (c *createCmd) Exec() error {
-	cacheStore, err := initCache(c.CacheImageRef, c.CacheDir, c.keychain, c.PlatformAPI.LessThan("0.13"))
+	cacheStore, err := initCache(c.CacheImageRef, c.CacheDir, c.keychain, c.PlatformAPI.LessThan("0.13"), c.InsecureRegistries...)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (c *createCmd) Exec() error {
 	analyzerFactory := phase.NewConnectedFactory(
 		c.PlatformAPI,
 		&cmd.BuildpackAPIVerifier{},
-		NewCacheHandler(c.keychain),
+		NewCacheHandler(c.keychain, c.InsecureRegistries),
 		files.NewHandler(),
 		image.NewHandler(c.docker, c.keychain, c.LayoutDir, c.UseLayout, c.InsecureRegistries),
 		image.NewRegistryHandler(c.keychain, c.InsecureRegistries),

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -141,7 +141,7 @@ func (e *exportCmd) Exec() error {
 	if err = verifyBuildpackApis(group); err != nil {
 		return err
 	}
-	cacheStore, err := initCache(e.CacheImageRef, e.CacheDir, e.keychain, e.PlatformAPI.LessThan("0.13"))
+	cacheStore, err := initCache(e.CacheImageRef, e.CacheDir, e.keychain, e.PlatformAPI.LessThan("0.13"), e.InsecureRegistries...)
 	if err != nil {
 		return err
 	}

--- a/cmd/lifecycle/main.go
+++ b/cmd/lifecycle/main.go
@@ -81,12 +81,14 @@ func subcommand(platformAPI string) {
 // handlers
 
 type DefaultCacheHandler struct {
-	keychain authn.Keychain
+	keychain           authn.Keychain
+	insecureRegistries []string
 }
 
-func NewCacheHandler(keychain authn.Keychain) *DefaultCacheHandler {
+func NewCacheHandler(keychain authn.Keychain, insecureRegistries []string) *DefaultCacheHandler {
 	return &DefaultCacheHandler{
-		keychain: keychain,
+		keychain:           keychain,
+		insecureRegistries: insecureRegistries,
 	}
 }
 
@@ -98,7 +100,7 @@ func (ch *DefaultCacheHandler) InitCache(cacheImageRef string, cacheDir string, 
 	)
 	logger := cmd.DefaultLogger
 	if cacheImageRef != "" {
-		cacheStore, err = cache.NewImageCacheFromName(cacheImageRef, ch.keychain, logger, cache.NewImageDeleter(cache.NewImageComparer(), logger, deletionEnabled))
+		cacheStore, err = cache.NewImageCacheFromName(cacheImageRef, ch.keychain, logger, cache.NewImageDeleter(cache.NewImageComparer(), logger, deletionEnabled), ch.insecureRegistries...)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating image cache")
 		}
@@ -113,14 +115,14 @@ func (ch *DefaultCacheHandler) InitCache(cacheImageRef string, cacheDir string, 
 
 // helpers
 
-func initCache(cacheImageTag, cacheDir string, keychain authn.Keychain, deletionEnabled bool) (phase.Cache, error) {
+func initCache(cacheImageTag, cacheDir string, keychain authn.Keychain, deletionEnabled bool, insecureRegistries ...string) (phase.Cache, error) {
 	var (
 		cacheStore phase.Cache
 		err        error
 	)
 	logger := cmd.DefaultLogger
 	if cacheImageTag != "" {
-		cacheStore, err = cache.NewImageCacheFromName(cacheImageTag, keychain, logger, cache.NewImageDeleter(cache.NewImageComparer(), logger, deletionEnabled))
+		cacheStore, err = cache.NewImageCacheFromName(cacheImageTag, keychain, logger, cache.NewImageDeleter(cache.NewImageComparer(), logger, deletionEnabled), insecureRegistries...)
 		if err != nil {
 			return nil, cmd.FailErr(err, "create image cache")
 		}

--- a/cmd/lifecycle/restorer.go
+++ b/cmd/lifecycle/restorer.go
@@ -165,7 +165,7 @@ func (r *restoreCmd) Exec() error {
 		cmd.DefaultLogger.Warnf("Not using analyzed data, usable file not found: %s", err)
 	}
 
-	cacheStore, err := initCache(r.CacheImageRef, r.CacheDir, r.keychain, r.PlatformAPI.LessThan("0.13"))
+	cacheStore, err := initCache(r.CacheImageRef, r.CacheDir, r.keychain, r.PlatformAPI.LessThan("0.13"), r.InsecureRegistries...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

`NewImageCacheFromName` did not pass insecure registry options to `remote.NewImage()`, causing TLS verification failures when using `-insecure-registry` with cache images stored on
  registries that use self-signed certificates or plain HTTP.                                                                                                                          
   
  Other code paths (`pullSparse`, `initRemoteAppImage`, `RegistryHandler`) already correctly call `image.GetInsecureOptions`, but the cache image path was missed.                     
                  
  This PR adds a variadic `insecureRegistries` parameter to `NewImageCacheFromName` and threads it through `initCache`, `DefaultCacheHandler`, and all callers (creator, restorer,
  exporter, analyzer).


#### Release notes

When using `-insecure-registry`, cache images now correctly skip TLS verification, matching the existing behavior for app images.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context

The bug can be reproduced by running the lifecycle with `-insecure-registry=registry.example.com` against a registry using self-signed certificates. App image operations (analyze,
  export) succeed, but cache image restore/export fails with:

  ERROR: failed to create image cache: accessing cache image "registry.example.com/cache:latest": tls: failed to verify certificate: x509: certificate signed by unknown authority

  The fix uses a variadic parameter (`insecureRegistries ...string`) to maintain backward compatibility — existing callers without insecure registries continue to work unchanged.

  Files changed:
  - `cache/image_cache.go` — add `insecureRegistries` param, apply `GetInsecureOptions` to both `remote.NewImage` calls
  - `cmd/lifecycle/main.go` — add `insecureRegistries` to `DefaultCacheHandler` and `initCache`
  - `cmd/lifecycle/creator.go` — pass `InsecureRegistries` to `initCache` and `NewCacheHandler`
  - `cmd/lifecycle/restorer.go` — pass `InsecureRegistries` to `initCache`
  - `cmd/lifecycle/exporter.go` — pass `InsecureRegistries` to `initCache`
  - `cmd/lifecycle/analyzer.go` — pass `InsecureRegistries` to `NewCacheHandler`