### PR TITLE
Bump go to 1.26.1

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -68,8 +68,8 @@ jobs:
           script: |
             apt-get update -y
             apt-get install -y wget curl git make gcc jq docker.io
-            wget https://go.dev/dl/go1.26.0.linux-s390x.tar.gz
-            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.0.linux-s390x.tar.gz
+            wget https://go.dev/dl/go1.26.1.linux-s390x.tar.gz
+            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.1.linux-s390x.tar.gz
             export PATH=$PATH:/usr/local/go/bin
             git clone ${GH_REPOSITORY} lifecycle
             cd lifecycle && git checkout ${GH_REF}

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0 as builder
+FROM golang:1.26.1 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/go.mod
+++ b/go.mod
@@ -318,4 +318,4 @@ tool github.com/golang/mock/mockgen
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-go 1.26.0
+go 1.26.1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
Go 1.26.1 release


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
- go updated to 1.26.1


