### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       - main
       - 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-linux-amd64:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-latest-release.yml
+++ b/.github/workflows/check-latest-release.yml
@@ -5,6 +5,9 @@ on:
     - cron: 0 2 * * 1,4
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   check-release:
     runs-on:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -3,6 +3,9 @@ name: draft-release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   draft-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published # trigger for releases and pre-releases
 
+permissions:
+  contents: read
+
 jobs:
   retag-lifecycle-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -9,6 +9,9 @@ on:
       - main
       - 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   test-linux-s390x:
     if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release*')


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->

- [ ] ~Release notes not applicable: this change only tightens GitHub Actions workflow permissions and does not affect end users.~

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1638

Fixes #1638

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

This PR addresses the OpenSSF Scorecard Token-Permissions check by:
- Adding `permissions: contents: read` at the top level of workflows that were missing top-level permissions (`build.yml`, `check-latest-release.yml`, `draft-release.yml`, `post-release.yml`, `test-s390x.yml`).
- Retaining elevated permissions (e.g. `contents: write`) only at the specific job level where they are required (e.g. the draft-release job).

More details on the check: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
