### PR TITLE
Ignore CVE from grype

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -5,3 +5,4 @@ ignore:
   - vulnerability: GHSA-v23v-6jw2-98fq # non-impactful as we only use docker as a client
   - vulnerability: GHSA-x744-4wpc-v9h2 # AuthZ plugin bypass; not exploitable as lifecycle only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
   - vulnerability: GHSA-pxq6-2prw-chj9 # plugin privilege validation off-by-one; not exploitable as lifecycle only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
+  - vulnerability: GHSA-vp62-88p7-qqf5 # docker cp symlink race; not exploitable as lifecycle does not use docker cp in production code.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
This pull request adds an entry to the `.grype.yaml` configuration to ignore a new vulnerability that is not exploitable in our use case.

Security configuration:

* [`.grype.yaml`](diffhunk://#diff-d929405c8d1f27de6b8eaa31eab07468a9bc588d8466f23666f329595e8a70edR8): Added `GHSA-vp62-88p7-qqf5` (docker cp symlink race) to the ignore list, with an explanation that it is not exploitable since `docker cp` is not used in production code.




