### PR TITLE
more ignores of the same type of thing

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -6,3 +6,5 @@ ignore:
   - vulnerability: GHSA-x744-4wpc-v9h2 # AuthZ plugin bypass; not exploitable as lifecycle only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
   - vulnerability: GHSA-pxq6-2prw-chj9 # plugin privilege validation off-by-one; not exploitable as lifecycle only uses docker as a client. Fixed in moby/moby/v2 but not backported to docker/docker module.
   - vulnerability: GHSA-vp62-88p7-qqf5 # docker cp symlink race; not exploitable as lifecycle does not use docker cp in production code.
+  - vulnerability: GHSA-rg2x-37c3-w2rh # docker cp bind mount redirection race; not exploitable as lifecycle does not use docker cp in production code. No upstream fix available.
+  - vulnerability: GHSA-x86f-5xw2-fm2r # daemon-side PUT /containers/{id}/archive RCE; not exploitable as lifecycle only uses docker as a client. No upstream fix available.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
This pull request updates the `.grype.yaml` configuration to ignore two additional Docker-related vulnerabilities that are not exploitable in the current usage context.

Security configuration updates:

* Added `GHSA-rg2x-37c3-w2rh` (docker cp bind mount redirection race) and `GHSA-x86f-5xw2-fm2r` (daemon-side PUT /containers/{id}/archive RCE) to the ignore list, with comments explaining why these are not exploitable in this project. (.grype.yaml)

