### PR TITLE
go 1.26.4

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -83,8 +83,8 @@
 #          script: |
 #            apt-get update -y
 #            apt-get install -y wget curl git make gcc jq docker.io
-#            wget https://go.dev/dl/go1.26.3.linux-s390x.tar.gz
-#            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.3.linux-s390x.tar.gz
+#            wget https://go.dev/dl/go1.26.4.linux-s390x.tar.gz
+#            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.4.linux-s390x.tar.gz
 #            export PATH=$PATH:/usr/local/go/bin
 #            git clone ${GH_REPOSITORY} lifecycle
 #            cd lifecycle && git checkout ${GH_REF}

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3 as builder
+FROM golang:1.26.4 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/go.mod
+++ b/go.mod
@@ -316,4 +316,4 @@ tool github.com/golang/mock/mockgen
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-go 1.26.3
+go 1.26.4


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
This pull request updates the Go programming language version used in the project from 1.26.3 to 1.26.4 to fix security vulnerabilities in the Go standard library introduced in 1.26.3: 
CVE-2026-42507, CVE-2026-42504, and CVE-2026-27145

#### Go version update:

- Updated the Go version from 1.26.3 to 1.26.4 in the .github/workflows/test-s390x.yml workflow, although the relevant section appears to be commented out.
- Changed the base image in the acceptance/testdata/launcher/Dockerfile from golang:1.26.3 to golang:1.26.4 for building Docker images with the updated Go version.
- Updated the Go toolchain version in go.mod from 1.26.3 to 1.26.4 for module and dependency management.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
- chore: go 1.26.4
