### PR TITLE
Bump codecov-action to v7 to fix Codecov keybase GPG regression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,10 @@ jobs:
           TEST_COVERAGE: 1
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./out/tests/coverage-unit.txt
+          files: ./out/tests/coverage-unit.txt
           flags: unit,os_linux
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
## Summary

The **Upload coverage to Codecov** CI step is currently failing on **all PRs**, independent of any code change.

### Symptom
The Codecov uploader's GPG self-verification fails with errors like `Can't check signature: No public key` / `Could not verify signature ... Exiting`. Because the workflow sets `fail_ci_if_error: true`, the whole job turns red on every PR.

### Root cause
`codecov/codecov-action@v5` (resolves to 5.5.4) ships Codecov's old `codecovsecurity` keybase GPG key. On 2026-06-07 Codecov lost access to that keybase account, migrated to `codecovsecops`, and intentionally disabled the old account. The uploader can no longer fetch the old public key, so signature verification fails. Codecov fixed this in `v6.0.2` and `v7.0.0` (both published 2026-06-07, code-identical) which use the `codecovsecops` account, but **did not back-port the fix to the `v5` tag** — so anyone pinned to `@v5` stays broken.

### Fix
- Bump `codecov/codecov-action@v5` -> `@v7`.
- Rename the deprecated `file:` input to `files:` (v6/v7 renamed `file` -> `files`; the old name only emitted a non-fatal `Unexpected input(s) 'file'` warning, but this corrects it).

### References
- Upstream issue: codecov/codecov-action#1956

This change is unrelated to but **unblocks** other open PRs (e.g. #1667), whose CI is also red solely due to this Codecov regression.
