### PR TITLE
Add retry logic for retrieving top layer SHA with registry mirrors

### DIFF
--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -217,18 +217,18 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 
 	g.Go(func() error {
 		report, err := exporter.Export(phase.ExportOptions{
-			AdditionalNames:     e.AdditionalTags,
-			AppDir:              e.AppDir,
-			DefaultProcessType:  e.DefaultProcessType,
-			ExecEnv:             e.ExecEnv,
-			ExtendedDir:         e.ExtendedDir,
-			LauncherConfig:      launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
-			LayersDir:           e.LayersDir,
-			OrigMetadata:        analyzedMD.LayersMetadata,
-			Project:             projectMD,
-			RunImageRef:         runImageID,
-			RunImageForExport:   runImageForExport,
-			WorkingImage:        appImage,
+			AdditionalNames:    e.AdditionalTags,
+			AppDir:             e.AppDir,
+			DefaultProcessType: e.DefaultProcessType,
+			ExecEnv:            e.ExecEnv,
+			ExtendedDir:        e.ExtendedDir,
+			LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
+			LayersDir:          e.LayersDir,
+			OrigMetadata:       analyzedMD.LayersMetadata,
+			Project:            projectMD,
+			RunImageRef:        runImageID,
+			RunImageForExport:  runImageForExport,
+			WorkingImage:       appImage,
 		})
 		if err != nil {
 			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
@@ -345,7 +345,11 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 	}
 
 	appImage, err := phase.OpenRemoteImage(cmd.DefaultLogger, func() (imgutil.Image, error) {
-		return remote.NewImage(e.OutputImageRef, e.keychain, appOpts...)
+		return remote.NewImage(
+			e.OutputImageRef,
+			e.keychain,
+			appOpts...,
+		)
 	})
 	if err != nil {
 		return nil, "", cmd.FailErr(err, "create new app image")
@@ -372,6 +376,7 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 	if err != nil {
 		return nil, "", cmd.FailErr(err, "get run image ID")
 	}
+
 	return appImage, runImageID, nil
 }
 

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -195,8 +195,9 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 	}
 
 	var (
-		appImage   imgutil.Image
-		runImageID string
+		appImage            imgutil.Image
+		runImageID          string
+		workingImageFactory func() (imgutil.Image, error)
 	)
 	switch {
 	case e.UseLayout:
@@ -204,7 +205,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 	case e.UseDaemon:
 		appImage, runImageID, err = e.initDaemonAppImage(analyzedMD, cmd.DefaultLogger)
 	default:
-		appImage, runImageID, err = e.initRemoteAppImage(analyzedMD)
+		appImage, workingImageFactory, runImageID, err = e.initRemoteAppImage(analyzedMD)
 	}
 	if err != nil {
 		return err
@@ -217,18 +218,19 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 
 	g.Go(func() error {
 		report, err := exporter.Export(phase.ExportOptions{
-			AdditionalNames:    e.AdditionalTags,
-			AppDir:             e.AppDir,
-			DefaultProcessType: e.DefaultProcessType,
-			ExecEnv:            e.ExecEnv,
-			ExtendedDir:        e.ExtendedDir,
-			LauncherConfig:     launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
-			LayersDir:          e.LayersDir,
-			OrigMetadata:       analyzedMD.LayersMetadata,
-			Project:            projectMD,
-			RunImageRef:        runImageID,
-			RunImageForExport:  runImageForExport,
-			WorkingImage:       appImage,
+			AdditionalNames:     e.AdditionalTags,
+			AppDir:              e.AppDir,
+			DefaultProcessType:  e.DefaultProcessType,
+			ExecEnv:             e.ExecEnv,
+			ExtendedDir:         e.ExtendedDir,
+			LauncherConfig:      launcherConfig(e.LauncherPath, e.LauncherSBOMDir),
+			LayersDir:           e.LayersDir,
+			OrigMetadata:        analyzedMD.LayersMetadata,
+			Project:             projectMD,
+			RunImageRef:         runImageID,
+			RunImageForExport:   runImageForExport,
+			WorkingImage:        appImage,
+			WorkingImageFactory: workingImageFactory,
 		})
 		if err != nil {
 			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
@@ -313,7 +315,7 @@ func (e *exportCmd) initDaemonAppImage(analyzedMD files.Analyzed, logger log.Log
 	return appImage, runImageID.String(), nil
 }
 
-func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image, string, error) {
+func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image, func() (imgutil.Image, error), string, error) {
 	var appOpts = []imgutil.ImageOption{
 		remote.FromBaseImage(e.RunImageRef),
 	}
@@ -321,7 +323,7 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 	if e.supportsRunImageExtension() {
 		extendedConfig, err := e.getExtendedConfig(analyzedMD.RunImage)
 		if err != nil {
-			return nil, "", cmd.FailErr(err, "get extended image config")
+			return nil, nil, "", cmd.FailErr(err, "get extended image config")
 		}
 		if extendedConfig != nil {
 			cmd.DefaultLogger.Debugf("Using config from extensions...")
@@ -344,13 +346,16 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 		appOpts = append(appOpts, remote.WithCreatedAt(e.customSourceDateEpoch()))
 	}
 
-	appImage, err := remote.NewImage(
-		e.OutputImageRef,
-		e.keychain,
-		appOpts...,
-	)
+	workingImageFactory := func() (imgutil.Image, error) {
+		return remote.NewImage(
+			e.OutputImageRef,
+			e.keychain,
+			appOpts...,
+		)
+	}
+	appImage, err := workingImageFactory()
 	if err != nil {
-		return nil, "", cmd.FailErr(err, "create new app image")
+		return nil, nil, "", cmd.FailErr(err, "create new app image")
 	}
 
 	runImageID, err := func() (string, error) {
@@ -372,10 +377,10 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 		return runImageID.String(), nil
 	}()
 	if err != nil {
-		return nil, "", cmd.FailErr(err, "get run image ID")
+		return nil, nil, "", cmd.FailErr(err, "get run image ID")
 	}
 
-	return appImage, runImageID, nil
+	return appImage, workingImageFactory, runImageID, nil
 }
 
 func (e *exportCmd) initLayoutAppImage(analyzedMD files.Analyzed) (imgutil.Image, string, error) {

--- a/cmd/lifecycle/exporter.go
+++ b/cmd/lifecycle/exporter.go
@@ -195,9 +195,8 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 	}
 
 	var (
-		appImage            imgutil.Image
-		runImageID          string
-		workingImageFactory func() (imgutil.Image, error)
+		appImage   imgutil.Image
+		runImageID string
 	)
 	switch {
 	case e.UseLayout:
@@ -205,7 +204,7 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 	case e.UseDaemon:
 		appImage, runImageID, err = e.initDaemonAppImage(analyzedMD, cmd.DefaultLogger)
 	default:
-		appImage, workingImageFactory, runImageID, err = e.initRemoteAppImage(analyzedMD)
+		appImage, runImageID, err = e.initRemoteAppImage(analyzedMD)
 	}
 	if err != nil {
 		return err
@@ -230,7 +229,6 @@ func (e *exportCmd) export(group buildpack.Group, cacheStore phase.Cache, analyz
 			RunImageRef:         runImageID,
 			RunImageForExport:   runImageForExport,
 			WorkingImage:        appImage,
-			WorkingImageFactory: workingImageFactory,
 		})
 		if err != nil {
 			return cmd.FailErrCode(err, e.CodeFor(platform.ExportError), "export")
@@ -315,7 +313,7 @@ func (e *exportCmd) initDaemonAppImage(analyzedMD files.Analyzed, logger log.Log
 	return appImage, runImageID.String(), nil
 }
 
-func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image, func() (imgutil.Image, error), string, error) {
+func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image, string, error) {
 	var appOpts = []imgutil.ImageOption{
 		remote.FromBaseImage(e.RunImageRef),
 	}
@@ -323,7 +321,7 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 	if e.supportsRunImageExtension() {
 		extendedConfig, err := e.getExtendedConfig(analyzedMD.RunImage)
 		if err != nil {
-			return nil, nil, "", cmd.FailErr(err, "get extended image config")
+			return nil, "", cmd.FailErr(err, "get extended image config")
 		}
 		if extendedConfig != nil {
 			cmd.DefaultLogger.Debugf("Using config from extensions...")
@@ -346,16 +344,11 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 		appOpts = append(appOpts, remote.WithCreatedAt(e.customSourceDateEpoch()))
 	}
 
-	workingImageFactory := func() (imgutil.Image, error) {
-		return remote.NewImage(
-			e.OutputImageRef,
-			e.keychain,
-			appOpts...,
-		)
-	}
-	appImage, err := workingImageFactory()
+	appImage, err := phase.OpenRemoteImage(cmd.DefaultLogger, func() (imgutil.Image, error) {
+		return remote.NewImage(e.OutputImageRef, e.keychain, appOpts...)
+	})
 	if err != nil {
-		return nil, nil, "", cmd.FailErr(err, "create new app image")
+		return nil, "", cmd.FailErr(err, "create new app image")
 	}
 
 	runImageID, err := func() (string, error) {
@@ -377,10 +370,9 @@ func (e *exportCmd) initRemoteAppImage(analyzedMD files.Analyzed) (imgutil.Image
 		return runImageID.String(), nil
 	}()
 	if err != nil {
-		return nil, nil, "", cmd.FailErr(err, "get run image ID")
+		return nil, "", cmd.FailErr(err, "get run image ID")
 	}
-
-	return appImage, workingImageFactory, runImageID, nil
+	return appImage, runImageID, nil
 }
 
 func (e *exportCmd) initLayoutAppImage(analyzedMD files.Analyzed) (imgutil.Image, string, error) {

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -106,7 +106,6 @@ func (r *rebaseCmd) Exec() error {
 		}
 	}
 	var newBaseImage imgutil.Image
-	var newBaseImageFactory func() (imgutil.Image, error)
 	if r.UseDaemon {
 		newBaseImage, err = local.NewImage(
 			r.RunImageRef,
@@ -114,15 +113,10 @@ func (r *rebaseCmd) Exec() error {
 			local.FromBaseImage(r.RunImageRef),
 		)
 	} else {
-		newBaseImageFactory = func() (imgutil.Image, error) {
+		newBaseImage, err = phase.OpenRemoteImage(cmd.DefaultLogger, func() (imgutil.Image, error) {
 			opts := append(image.GetInsecureOptions(r.InsecureRegistries), remote.FromBaseImage(r.RunImageRef))
-			return remote.NewImage(
-				r.RunImageRef,
-				r.keychain,
-				opts...,
-			)
-		}
-		newBaseImage, err = newBaseImageFactory()
+			return remote.NewImage(r.RunImageRef, r.keychain, opts...)
+		})
 	}
 	if err != nil || !newBaseImage.Found() {
 		return cmd.FailErr(err, "access run image")
@@ -132,7 +126,6 @@ func (r *rebaseCmd) Exec() error {
 		Logger:              cmd.DefaultLogger,
 		PlatformAPI:         r.PlatformAPI,
 		Force:               r.ForceRebase,
-		NewBaseImageFactory: newBaseImageFactory,
 	}
 	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.OutputImageRef, r.AdditionalTags)
 	if err != nil {

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -106,6 +106,7 @@ func (r *rebaseCmd) Exec() error {
 		}
 	}
 	var newBaseImage imgutil.Image
+	var newBaseImageFactory func() (imgutil.Image, error)
 	if r.UseDaemon {
 		newBaseImage, err = local.NewImage(
 			r.RunImageRef,
@@ -113,23 +114,25 @@ func (r *rebaseCmd) Exec() error {
 			local.FromBaseImage(r.RunImageRef),
 		)
 	} else {
-		var opts []imgutil.ImageOption
-		opts = append(opts, append(image.GetInsecureOptions(r.InsecureRegistries), remote.FromBaseImage(r.RunImageRef))...)
-
-		newBaseImage, err = remote.NewImage(
-			r.RunImageRef,
-			r.keychain,
-			opts...,
-		)
+		newBaseImageFactory = func() (imgutil.Image, error) {
+			opts := append(image.GetInsecureOptions(r.InsecureRegistries), remote.FromBaseImage(r.RunImageRef))
+			return remote.NewImage(
+				r.RunImageRef,
+				r.keychain,
+				opts...,
+			)
+		}
+		newBaseImage, err = newBaseImageFactory()
 	}
 	if err != nil || !newBaseImage.Found() {
 		return cmd.FailErr(err, "access run image")
 	}
 
 	rebaser := &phase.Rebaser{
-		Logger:      cmd.DefaultLogger,
-		PlatformAPI: r.PlatformAPI,
-		Force:       r.ForceRebase,
+		Logger:              cmd.DefaultLogger,
+		PlatformAPI:         r.PlatformAPI,
+		Force:               r.ForceRebase,
+		NewBaseImageFactory: newBaseImageFactory,
 	}
 	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.OutputImageRef, r.AdditionalTags)
 	if err != nil {

--- a/cmd/lifecycle/rebaser.go
+++ b/cmd/lifecycle/rebaser.go
@@ -115,7 +115,11 @@ func (r *rebaseCmd) Exec() error {
 	} else {
 		newBaseImage, err = phase.OpenRemoteImage(cmd.DefaultLogger, func() (imgutil.Image, error) {
 			opts := append(image.GetInsecureOptions(r.InsecureRegistries), remote.FromBaseImage(r.RunImageRef))
-			return remote.NewImage(r.RunImageRef, r.keychain, opts...)
+			return remote.NewImage(
+				r.RunImageRef,
+				r.keychain,
+				opts...,
+			)
 		})
 	}
 	if err != nil || !newBaseImage.Found() {
@@ -123,9 +127,9 @@ func (r *rebaseCmd) Exec() error {
 	}
 
 	rebaser := &phase.Rebaser{
-		Logger:              cmd.DefaultLogger,
-		PlatformAPI:         r.PlatformAPI,
-		Force:               r.ForceRebase,
+		Logger:      cmd.DefaultLogger,
+		PlatformAPI: r.PlatformAPI,
+		Force:       r.ForceRebase,
 	}
 	report, err := rebaser.Rebase(r.appImage, newBaseImage, r.OutputImageRef, r.AdditionalTags)
 	if err != nil {

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -116,11 +116,10 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	}
 
 	meta := files.LayersMetadata{}
-	topLayer, err := opts.WorkingImage.TopLayer()
+	meta.RunImage.TopLayer, err = opts.WorkingImage.TopLayer()
 	if err != nil {
 		return files.Report{}, errors.Wrap(err, "get run image top layer SHA")
 	}
-	meta.RunImage.TopLayer = topLayer
 	meta.RunImage.Reference = opts.RunImageRef
 
 	if e.PlatformAPI.AtLeast("0.12") {

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -2,9 +2,11 @@ package phase
 
 import (
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,7 @@ import (
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/local"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/lifecycle/api"
@@ -89,6 +92,10 @@ type ExportOptions struct {
 	RunImageForExport files.RunImageForExport
 	// Project is project metadata for the project metadata label.
 	Project files.ProjectMetadata
+	// WorkingImageFactory creates a new WorkingImage for retry attempts.
+	// This is needed because go-containerregistry caches manifests, so retrying
+	// with the same image object won't work for transient registry mirror errors.
+	WorkingImageFactory func() (imgutil.Image, error)
 }
 
 func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
@@ -112,7 +119,12 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	}
 
 	meta := files.LayersMetadata{}
-	topLayer, err := TopLayerWithRetry(opts.WorkingImage, e.Logger)
+	var topLayer string
+	if opts.WorkingImageFactory != nil {
+		topLayer, err = TopLayerWithRetry(opts.WorkingImageFactory, e.Logger)
+	} else {
+		topLayer, err = TopLayerWithRetry(func() (imgutil.Image, error) { return opts.WorkingImage, nil }, e.Logger)
+	}
 	if err != nil {
 		return files.Report{}, errors.Wrap(err, "get run image top layer SHA")
 	}
@@ -675,8 +687,7 @@ func (e *Exporter) addSBOMLaunchLayer(opts ExportOptions, meta *files.LayersMeta
 	return nil
 }
 
-const topLayerMaxRetries = 5
-
+// topLayerDelays is hardcoded array of delays
 var topLayerDelays = []time.Duration{
 	100 * time.Millisecond,
 	200 * time.Millisecond,
@@ -685,28 +696,58 @@ var topLayerDelays = []time.Duration{
 	2 * time.Second,
 }
 
-// TopLayerWithRetry calls TopLayer() on an imgutil.Image with retry logic.
-// This handles transient registry errors when using registry mirrors.
+// topLayerSleep is the function used for sleeping between retries.
+// It can be replaced for testing.
+var topLayerSleep = time.Sleep
+
+// isRetryable returns true if the error is likely transient and should be retried.
+// 401 Unauthorized and 403 Forbidden are not retryable as they indicate auth/config issues.
+func isRetryable(err error) bool {
+	if tErr, ok := stderrors.AsType[*transport.Error](err); ok {
+		return tErr.StatusCode != http.StatusUnauthorized && tErr.StatusCode != http.StatusForbidden
+	}
+	return true
+}
+
+// TopLayerWithRetry calls TopLayer() on an imgutil.Image with retry logic, creating a fresh image
+// for each retry attempt. This is necessary because go-containerregistry caches the manifest,
+// so retrying with the same image object would not work for transient registry mirror errors.
 // The backoff delays are chosen to be conservative - registry mirrors may need time to sync.
-func TopLayerWithRetry(img imgutil.Image, logger log.Logger) (string, error) {
+func TopLayerWithRetry(imgFactory func() (imgutil.Image, error), logger log.Logger) (string, error) {
 	var lastErr error
-	for attempt := range topLayerMaxRetries {
+	for attempt, delay := range topLayerDelays {
+		img, err := imgFactory()
+		if err != nil {
+			lastErr = err
+			logger.Warnf("Attempt %d/%d: Failed to create new image for top layer retrieval: %v", attempt+1, len(topLayerDelays)+1, err)
+			topLayerSleep(delay)
+			continue
+		}
 		topLayer, err := img.TopLayer()
 		if err == nil {
 			if attempt > 0 {
-				logger.Debugf("Successfully retrieved top layer SHA after %d retries", attempt)
+				logger.Warnf("Successfully retrieved top layer SHA after %d retries", attempt)
 			}
 			return topLayer, nil
 		}
 		lastErr = err
-
-		// Log the error and wait before retrying
-		if attempt < topLayerMaxRetries-1 {
-			duration := topLayerDelays[attempt]
-			logger.Debugf("Attempt %d/%d: Failed to get top layer SHA: %v. Retrying in %v...", attempt+1, topLayerMaxRetries, err, duration)
-			time.Sleep(duration)
+		if !isRetryable(err) {
+			return "", err
 		}
+		logger.Warnf("Attempt %d/%d: Failed to get top layer SHA: %v. Retrying in %v...", attempt+1, len(topLayerDelays)+1, err, delay)
+		topLayerSleep(delay)
 	}
-
+	// Final attempt after exhausting all delays
+	img, err := imgFactory()
+	if err != nil {
+		return "", err
+	}
+	topLayer, err := img.TopLayer()
+	if err == nil {
+		return topLayer, nil
+	}
+	if !isRetryable(err) {
+		return "", err
+	}
 	return "", lastErr
 }

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/imgutil"
@@ -111,10 +112,11 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	}
 
 	meta := files.LayersMetadata{}
-	meta.RunImage.TopLayer, err = opts.WorkingImage.TopLayer()
+	topLayer, err := TopLayerWithRetry(opts.WorkingImage, e.Logger)
 	if err != nil {
 		return files.Report{}, errors.Wrap(err, "get run image top layer SHA")
 	}
+	meta.RunImage.TopLayer = topLayer
 	meta.RunImage.Reference = opts.RunImageRef
 
 	if e.PlatformAPI.AtLeast("0.12") {
@@ -671,4 +673,40 @@ func (e *Exporter) addSBOMLaunchLayer(opts ExportOptions, meta *files.LayersMeta
 	}
 
 	return nil
+}
+
+const topLayerMaxRetries = 5
+
+var topLayerDelays = []time.Duration{
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+}
+
+// TopLayerWithRetry calls TopLayer() on an imgutil.Image with retry logic.
+// This handles transient registry errors when using registry mirrors.
+// The backoff delays are chosen to be conservative - registry mirrors may need time to sync.
+func TopLayerWithRetry(img imgutil.Image, logger log.Logger) (string, error) {
+	var lastErr error
+	for attempt := range topLayerMaxRetries {
+		topLayer, err := img.TopLayer()
+		if err == nil {
+			if attempt > 0 {
+				logger.Debugf("Successfully retrieved top layer SHA after %d retries", attempt)
+			}
+			return topLayer, nil
+		}
+		lastErr = err
+
+		// Log the error and wait before retrying
+		if attempt < topLayerMaxRetries-1 {
+			duration := topLayerDelays[attempt]
+			logger.Debugf("Attempt %d/%d: Failed to get top layer SHA: %v. Retrying in %v...", attempt+1, topLayerMaxRetries, err, duration)
+			time.Sleep(duration)
+		}
+	}
+
+	return "", lastErr
 }

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -93,10 +93,6 @@ type ExportOptions struct {
 	RunImageForExport files.RunImageForExport
 	// Project is project metadata for the project metadata label.
 	Project files.ProjectMetadata
-	// WorkingImageFactory creates a new WorkingImage for retry attempts.
-	// This is needed because go-containerregistry caches manifests, so retrying
-	// with the same image object won't work for transient registry mirror errors.
-	WorkingImageFactory func() (imgutil.Image, error)
 }
 
 func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
@@ -120,12 +116,7 @@ func (e *Exporter) Export(opts ExportOptions) (files.Report, error) {
 	}
 
 	meta := files.LayersMetadata{}
-	var topLayer string
-	if opts.WorkingImageFactory != nil {
-		topLayer, err = TopLayerWithRetry(opts.WorkingImageFactory, e.Logger)
-	} else {
-		topLayer, err = TopLayerWithRetry(func() (imgutil.Image, error) { return opts.WorkingImage, nil }, e.Logger)
-	}
+	topLayer, err := opts.WorkingImage.TopLayer()
 	if err != nil {
 		return files.Report{}, errors.Wrap(err, "get run image top layer SHA")
 	}
@@ -710,45 +701,29 @@ func isRetryable(err error) bool {
 	return true
 }
 
-// TopLayerWithRetry calls TopLayer() on an imgutil.Image with retry logic, creating a fresh image
-// for each retry attempt. This is necessary because go-containerregistry caches the manifest,
-// so retrying with the same image object would not work for transient registry mirror errors.
-// The backoff delays are chosen to be conservative - registry mirrors may need time to sync.
-func TopLayerWithRetry(imgFactory func() (imgutil.Image, error), logger log.Logger) (string, error) {
+// OpenRemoteImage opens a remote image with retry logic for registry mirror transient errors.
+// go-containerregistry caches manifests, so each retry attempt creates a fresh image.
+// Non-retryable errors (401, 403) are returned immediately without retry.
+func OpenRemoteImage(logger log.Logger, newImage func() (imgutil.Image, error)) (imgutil.Image, error) {
 	var lastErr error
-	for attempt, delay := range topLayerDelays {
-		img, err := imgFactory()
-		if err != nil {
-			lastErr = err
-			logger.Warnf("Attempt %d/%d: Failed to create new image for top layer retrieval: %v", attempt+1, len(topLayerDelays)+1, err)
-			topLayerSleep(delay)
-			continue
-		}
-		topLayer, err := img.TopLayer()
+	for attempt := 0; attempt <= len(topLayerDelays); attempt++ {
+		img, err := newImage()
 		if err == nil {
-			if attempt > 0 {
-				logger.Warnf("Successfully retrieved top layer SHA after %d retries", attempt)
+			if _, err = img.TopLayer(); err == nil {
+				if attempt > 0 {
+					logger.Warnf("Successfully opened remote image after %d retries", attempt)
+				}
+				return img, nil
 			}
-			return topLayer, nil
 		}
 		lastErr = err
 		if !isRetryable(err) {
-			return "", err
+			return nil, err
 		}
-		logger.Warnf("Attempt %d/%d: Failed to get top layer SHA: %v. Retrying in %v...", attempt+1, len(topLayerDelays)+1, err, delay)
-		topLayerSleep(delay)
+		if attempt < len(topLayerDelays) {
+			logger.Warnf("Failed to open remote image (attempt %d/%d): %v, retrying in %v", attempt+1, len(topLayerDelays)+1, err, topLayerDelays[attempt])
+			topLayerSleep(topLayerDelays[attempt])
+		}
 	}
-	// Final attempt after exhausting all delays
-	img, err := imgFactory()
-	if err != nil {
-		return "", err
-	}
-	topLayer, err := img.TopLayer()
-	if err == nil {
-		return topLayer, nil
-	}
-	if !isRetryable(err) {
-		return "", err
-	}
-	return "", lastErr
+	return nil, lastErr
 }

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -2,21 +2,17 @@ package phase
 
 import (
 	"encoding/json"
-	stderrors "errors"
 	"fmt"
 	"io"
 	"io/fs"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/buildpacks/imgutil"
 	"github.com/buildpacks/imgutil/local"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/pkg/errors"
 
 	"github.com/buildpacks/lifecycle/api"
@@ -676,53 +672,4 @@ func (e *Exporter) addSBOMLaunchLayer(opts ExportOptions, meta *files.LayersMeta
 	}
 
 	return nil
-}
-
-// topLayerDelays is hardcoded array of delays
-var topLayerDelays = []time.Duration{
-	100 * time.Millisecond,
-	200 * time.Millisecond,
-	500 * time.Millisecond,
-	1 * time.Second,
-	2 * time.Second,
-}
-
-// topLayerSleep is the function used for sleeping between retries.
-// It can be replaced for testing.
-var topLayerSleep = time.Sleep
-
-// isRetryable returns true if the error is likely transient and should be retried.
-// 401 Unauthorized and 403 Forbidden are not retryable as they indicate auth/config issues.
-func isRetryable(err error) bool {
-	if tErr, ok := stderrors.AsType[*transport.Error](err); ok {
-		return tErr.StatusCode != http.StatusUnauthorized && tErr.StatusCode != http.StatusForbidden
-	}
-	return true
-}
-
-// OpenRemoteImage opens a remote image with retry logic for registry mirror transient errors.
-// go-containerregistry caches manifests, so each retry attempt creates a fresh image.
-// Non-retryable errors (401, 403) are returned immediately without retry.
-func OpenRemoteImage(logger log.Logger, newImage func() (imgutil.Image, error)) (imgutil.Image, error) {
-	var lastErr error
-	for attempt := 0; attempt <= len(topLayerDelays); attempt++ {
-		img, err := newImage()
-		if err == nil {
-			if _, err = img.TopLayer(); err == nil {
-				if attempt > 0 {
-					logger.Warnf("Successfully opened remote image after %d retries", attempt)
-				}
-				return img, nil
-			}
-		}
-		lastErr = err
-		if !isRetryable(err) {
-			return nil, err
-		}
-		if attempt < len(topLayerDelays) {
-			logger.Warnf("Failed to open remote image (attempt %d/%d): %v, retrying in %v", attempt+1, len(topLayerDelays)+1, err, topLayerDelays[attempt])
-			topLayerSleep(topLayerDelays[attempt])
-		}
-	}
-	return nil, lastErr
 }

--- a/phase/exporter.go
+++ b/phase/exporter.go
@@ -67,6 +67,7 @@ type LauncherConfig struct {
 	Metadata files.LauncherMetadata
 }
 
+// ExportOptions is the set of options for exporting an image.
 type ExportOptions struct {
 	// WorkingImage is the image to save.
 	WorkingImage imgutil.Image

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -25,6 +25,7 @@ var (
 	msgUnableToSatisfyTargetConstraints = "unable to satisfy target os/arch constraints; new run image: %s, old run image: %s"
 )
 
+// Rebaser changes the underlying base image for an application image.
 type Rebaser struct {
 	Logger      log.Logger
 	PlatformAPI *api.Version

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -29,6 +29,10 @@ type Rebaser struct {
 	Logger      log.Logger
 	PlatformAPI *api.Version
 	Force       bool
+	// NewBaseImageFactory creates a new base image for retry attempts.
+	// This is needed because go-containerregistry caches manifests, so retrying
+	// with the same image object won't work for transient registry mirror errors.
+	NewBaseImageFactory func() (imgutil.Image, error)
 }
 
 // Rebase changes the underlying base image for an application image.
@@ -64,9 +68,11 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	}
 
 	// update metadata label
-	topLayer, err := TopLayerWithRetry(newBaseImage, r.Logger)
-	if err != nil {
-		return files.RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
+	var topLayer string
+	if r.NewBaseImageFactory != nil {
+		topLayer, err = TopLayerWithRetry(r.NewBaseImageFactory, r.Logger)
+	} else {
+		topLayer, err = TopLayerWithRetry(func() (imgutil.Image, error) { return newBaseImage, nil }, r.Logger)
 	}
 	origMetadata.RunImage.TopLayer = topLayer
 	identifier, err := newBaseImage.Identifier()

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -74,6 +74,9 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	} else {
 		topLayer, err = TopLayerWithRetry(func() (imgutil.Image, error) { return newBaseImage, nil }, r.Logger)
 	}
+	if err != nil {
+		return files.RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
+	}
 	origMetadata.RunImage.TopLayer = topLayer
 	identifier, err := newBaseImage.Identifier()
 	if err != nil {

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -30,10 +30,6 @@ type Rebaser struct {
 	Logger      log.Logger
 	PlatformAPI *api.Version
 	Force       bool
-	// NewBaseImageFactory creates a new base image for retry attempts.
-	// This is needed because go-containerregistry caches manifests, so retrying
-	// with the same image object won't work for transient registry mirror errors.
-	NewBaseImageFactory func() (imgutil.Image, error)
 }
 
 // Rebase changes the underlying base image for an application image.
@@ -69,12 +65,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	}
 
 	// update metadata label
-	var topLayer string
-	if r.NewBaseImageFactory != nil {
-		topLayer, err = TopLayerWithRetry(r.NewBaseImageFactory, r.Logger)
-	} else {
-		topLayer, err = TopLayerWithRetry(func() (imgutil.Image, error) { return newBaseImage, nil }, r.Logger)
-	}
+	topLayer, err := newBaseImage.TopLayer()
 	if err != nil {
 		return files.RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
 	}

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -67,7 +67,7 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	// update metadata label
 	origMetadata.RunImage.TopLayer, err = newBaseImage.TopLayer()
 	if err != nil {
-		return files.RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
+		return files.RebaseReport{}, fmt.Errorf("get rebase run image top layer SHA: %w", err)
 	}
 	identifier, err := newBaseImage.Identifier()
 	if err != nil {

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -65,11 +65,10 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	}
 
 	// update metadata label
-	topLayer, err := newBaseImage.TopLayer()
+	origMetadata.RunImage.TopLayer, err = newBaseImage.TopLayer()
 	if err != nil {
 		return files.RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
 	}
-	origMetadata.RunImage.TopLayer = topLayer
 	identifier, err := newBaseImage.Identifier()
 	if err != nil {
 		return files.RebaseReport{}, fmt.Errorf("get run image id or digest: %w", err)

--- a/phase/rebaser.go
+++ b/phase/rebaser.go
@@ -64,10 +64,11 @@ func (r *Rebaser) Rebase(workingImage imgutil.Image, newBaseImage imgutil.Image,
 	}
 
 	// update metadata label
-	origMetadata.RunImage.TopLayer, err = newBaseImage.TopLayer()
+	topLayer, err := TopLayerWithRetry(newBaseImage, r.Logger)
 	if err != nil {
-		return files.RebaseReport{}, fmt.Errorf("get rebase run image top layer SHA: %w", err)
+		return files.RebaseReport{}, errors.Wrap(err, "get rebase run image top layer SHA")
 	}
+	origMetadata.RunImage.TopLayer = topLayer
 	identifier, err := newBaseImage.Identifier()
 	if err != nil {
 		return files.RebaseReport{}, fmt.Errorf("get run image id or digest: %w", err)

--- a/phase/retry.go
+++ b/phase/retry.go
@@ -1,0 +1,64 @@
+package phase
+
+import (
+	stderrors "errors"
+	"net/http"
+	"time"
+
+	"github.com/buildpacks/imgutil"
+	"github.com/buildpacks/lifecycle/log"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// topLayerDelays is hardcoded array of delays
+var topLayerDelays = []time.Duration{
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+	500 * time.Millisecond,
+	1 * time.Second,
+	2 * time.Second,
+}
+
+// topLayerSleep is the function used for sleeping between retries.
+// It can be replaced for testing.
+var topLayerSleep = time.Sleep
+
+// isRetryable returns true if the error is likely transient and should be retried.
+// 401 Unauthorized and 403 Forbidden are not retryable as they indicate auth/config issues.
+func isRetryable(err error) bool {
+	if tErr, ok := stderrors.AsType[*transport.Error](err); ok {
+		return tErr.StatusCode != http.StatusBadRequest &&
+			tErr.StatusCode != http.StatusUnauthorized &&
+			tErr.StatusCode != http.StatusForbidden &&
+			tErr.StatusCode != http.StatusMethodNotAllowed &&
+			tErr.StatusCode != http.StatusTooManyRequests
+	}
+	return true
+}
+
+// OpenRemoteImage opens a remote image with retry logic for registry mirror transient errors.
+// go-containerregistry caches manifests, so each retry attempt creates a fresh image.
+// Non-retryable errors (401, 403) are returned immediately without retry.
+func OpenRemoteImage(logger log.Logger, newImage func() (imgutil.Image, error)) (imgutil.Image, error) {
+	var lastErr error
+	for attempt := 0; attempt <= len(topLayerDelays); attempt++ {
+		img, err := newImage()
+		if err == nil {
+			if _, err = img.TopLayer(); err == nil {
+				if attempt > 0 {
+					logger.Infof("Successfully opened remote image after %d retries", attempt)
+				}
+				return img, nil
+			}
+		}
+		lastErr = err
+		if !isRetryable(err) {
+			return nil, err
+		}
+		if attempt < len(topLayerDelays) {
+			logger.Warnf("Failed to open remote image (attempt %d/%d): %v, retrying in %v", attempt+1, len(topLayerDelays)+1, err, topLayerDelays[attempt])
+			topLayerSleep(topLayerDelays[attempt])
+		}
+	}
+	return nil, lastErr
+}

--- a/phase/retry.go
+++ b/phase/retry.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/buildpacks/imgutil"
-	"github.com/buildpacks/lifecycle/log"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+
+	"github.com/buildpacks/lifecycle/log"
 )
 
 // topLayerDelays is hardcoded array of delays

--- a/phase/retry_test.go
+++ b/phase/retry_test.go
@@ -18,8 +18,8 @@ import (
 
 type stubImage struct {
 	imgutil.Image
-	results []topLayerResult
-	calls   int
+	result topLayerResult
+	calls  int
 }
 
 type topLayerResult struct {
@@ -28,9 +28,8 @@ type topLayerResult struct {
 }
 
 func (s *stubImage) TopLayer() (string, error) {
-	r := s.results[s.calls]
 	s.calls++
-	return r.sha, r.err
+	return s.result.sha, s.result.err
 }
 
 // swapRetryTiming replaces the package-level retry timing vars with deterministic
@@ -58,11 +57,11 @@ func swapRetryTiming(t *testing.T, n int) *[]time.Duration {
 	return &recorded
 }
 
-func TestTopLayerWithRetry(t *testing.T) {
-	spec.Run(t, "TopLayerWithRetry", testTopLayerWithRetry, spec.Report(report.Terminal{}))
+func TestOpenRemoteImage(t *testing.T) {
+	spec.Run(t, "OpenRemoteImage", testOpenRemoteImage, spec.Report(report.Terminal{}))
 }
 
-func testTopLayerWithRetry(t *testing.T, when spec.G, it spec.S) {
+func testOpenRemoteImage(t *testing.T, when spec.G, it spec.S) {
 	var (
 		logHandler *memory.Handler
 		logger     *log.Logger
@@ -74,77 +73,81 @@ func testTopLayerWithRetry(t *testing.T, when spec.G, it spec.S) {
 	})
 
 	when("successful first attempt", func() {
-		it("returns the top layer SHA immediately with no retries", func() {
+		it("returns the image immediately with no retries", func() {
 			sleeps := swapRetryTiming(t, 3)
-			img := &stubImage{
-				results: []topLayerResult{
-					{sha: "sha-1"},
-				},
-			}
+			img := &stubImage{result: topLayerResult{sha: "sha-1"}}
 
-			got, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+			got, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				return img, nil
+			})
 
 			h.AssertNil(t, err)
-			h.AssertEq(t, got, "sha-1")
 			h.AssertEq(t, img.calls, 1)
 			h.AssertEq(t, len(*sleeps), 0)
+			// Verify the returned image is the one with the successful TopLayer
+			sha, topLayerErr := got.TopLayer()
+			h.AssertNil(t, topLayerErr)
+			h.AssertEq(t, sha, "sha-1")
 		})
 	})
 
 	when("transient failures", func() {
 		it("succeeds after transient registry errors", func() {
 			sleeps := swapRetryTiming(t, 4)
-			img := &stubImage{
-				results: []topLayerResult{
-					{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
-					{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
-					{sha: "sha-1"},
-				},
+			var calls int
+			results := []topLayerResult{
+				{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
+				{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
+				{sha: "sha-1"},
 			}
 
-			got, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+			got, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				idx := calls
+				calls++
+				return &stubImage{result: results[idx]}, nil
+			})
 
 			h.AssertNil(t, err)
-			h.AssertEq(t, got, "sha-1")
-			h.AssertEq(t, img.calls, 3)
+			h.AssertEq(t, calls, 3)
 			h.AssertEq(t, len(*sleeps), 2)
+			sha, topLayerErr := got.TopLayer()
+			h.AssertNil(t, topLayerErr)
+			h.AssertEq(t, sha, "sha-1")
 		})
 	})
 
 	when("non-retryable errors", func() {
 		it("does not retry on 401 Unauthorized", func() {
 			sleeps := swapRetryTiming(t, 4)
-			img := &stubImage{
-				results: []topLayerResult{
-					{err: &transport.Error{StatusCode: http.StatusUnauthorized}},
-				},
-			}
+			var calls int
 
-			_, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				calls++
+				return &stubImage{result: topLayerResult{err: &transport.Error{StatusCode: http.StatusUnauthorized}}}, nil
+			})
 
 			h.AssertNotNil(t, err)
 			var tErr *transport.Error
 			h.AssertEq(t, errors.As(err, &tErr), true)
 			h.AssertEq(t, tErr.StatusCode, http.StatusUnauthorized)
-			h.AssertEq(t, img.calls, 1)
+			h.AssertEq(t, calls, 1)
 			h.AssertEq(t, len(*sleeps), 0)
 		})
 
 		it("does not retry on 403 Forbidden", func() {
 			sleeps := swapRetryTiming(t, 4)
-			img := &stubImage{
-				results: []topLayerResult{
-					{err: &transport.Error{StatusCode: http.StatusForbidden}},
-				},
-			}
+			var calls int
 
-			_, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				calls++
+				return &stubImage{result: topLayerResult{err: &transport.Error{StatusCode: http.StatusForbidden}}}, nil
+			})
 
 			h.AssertNotNil(t, err)
 			var tErr *transport.Error
 			h.AssertEq(t, errors.As(err, &tErr), true)
 			h.AssertEq(t, tErr.StatusCode, http.StatusForbidden)
-			h.AssertEq(t, img.calls, 1)
+			h.AssertEq(t, calls, 1)
 			h.AssertEq(t, len(*sleeps), 0)
 		})
 	})
@@ -152,21 +155,46 @@ func testTopLayerWithRetry(t *testing.T, when spec.G, it spec.S) {
 	when("all retries exhausted", func() {
 		it("returns the last error after all attempts fail", func() {
 			sleeps := swapRetryTiming(t, 3)
-			img := &stubImage{
-				results: []topLayerResult{
-					{err: errors.New("transient error 1")},
-					{err: errors.New("transient error 2")},
-					{err: errors.New("transient error 3")},
-					{err: errors.New("final error")},
-				},
+			var calls int
+			results := []topLayerResult{
+				{err: errors.New("transient error 1")},
+				{err: errors.New("transient error 2")},
+				{err: errors.New("transient error 3")},
+				{err: errors.New("final error")},
 			}
 
-			_, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				idx := calls
+				calls++
+				return &stubImage{result: results[idx]}, nil
+			})
 
 			h.AssertNotNil(t, err)
-			h.AssertEq(t, img.calls, 4)
+			h.AssertEq(t, calls, 4)
 			h.AssertEq(t, len(*sleeps), 3)
-			h.AssertEq(t, err.Error(), "transient error 3")
+		})
+	})
+
+	when("factory returns error", func() {
+		it("retries when image creation fails", func() {
+			sleeps := swapRetryTiming(t, 3)
+			var calls int
+
+			got, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				idx := calls
+				calls++
+				if idx < 2 {
+					return nil, errors.New("connection refused")
+				}
+				return &stubImage{result: topLayerResult{sha: "sha-1"}}, nil
+			})
+
+			h.AssertNil(t, err)
+			h.AssertEq(t, calls, 3)
+			h.AssertEq(t, len(*sleeps), 2)
+			sha, topLayerErr := got.TopLayer()
+			h.AssertNil(t, topLayerErr)
+			h.AssertEq(t, sha, "sha-1")
 		})
 	})
 }

--- a/phase/retry_test.go
+++ b/phase/retry_test.go
@@ -197,4 +197,138 @@ func testOpenRemoteImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, sha, "sha-1")
 		})
 	})
+
+	when("non-retryable transport errors", func() {
+		it("does not retry on 400 BadRequest", func() {
+			sleeps := swapRetryTiming(t, 4)
+			var calls int
+
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				calls++
+				return &stubImage{result: topLayerResult{err: &transport.Error{StatusCode: http.StatusBadRequest}}}, nil
+			})
+
+			h.AssertNotNil(t, err)
+			var tErr *transport.Error
+			h.AssertEq(t, errors.As(err, &tErr), true)
+			h.AssertEq(t, tErr.StatusCode, http.StatusBadRequest)
+			h.AssertEq(t, calls, 1)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+
+		it("does not retry on 405 MethodNotAllowed", func() {
+			sleeps := swapRetryTiming(t, 4)
+			var calls int
+
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				calls++
+				return &stubImage{result: topLayerResult{err: &transport.Error{StatusCode: http.StatusMethodNotAllowed}}}, nil
+			})
+
+			h.AssertNotNil(t, err)
+			var tErr *transport.Error
+			h.AssertEq(t, errors.As(err, &tErr), true)
+			h.AssertEq(t, tErr.StatusCode, http.StatusMethodNotAllowed)
+			h.AssertEq(t, calls, 1)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+
+		it("does not retry on 429 TooManyRequests", func() {
+			sleeps := swapRetryTiming(t, 4)
+			var calls int
+
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				calls++
+				return &stubImage{result: topLayerResult{err: &transport.Error{StatusCode: http.StatusTooManyRequests}}}, nil
+			})
+
+			h.AssertNotNil(t, err)
+			var tErr *transport.Error
+			h.AssertEq(t, errors.As(err, &tErr), true)
+			h.AssertEq(t, tErr.StatusCode, http.StatusTooManyRequests)
+			h.AssertEq(t, calls, 1)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+	})
+
+	when("retry logging", func() {
+		it("logs warning for failed attempts and info on success", func() {
+			_ = swapRetryTiming(t, 4)
+			var calls int
+			results := []topLayerResult{
+				{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
+				{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
+				{sha: "sha-1"},
+			}
+
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				idx := calls
+				calls++
+				return &stubImage{result: results[idx]}, nil
+			})
+
+			h.AssertNil(t, err)
+			h.AssertEq(t, calls, 3)
+
+			var infoCount, warnCount int
+			for _, entry := range logHandler.Entries {
+				if entry.Level == log.InfoLevel {
+					infoCount++
+				}
+				if entry.Level == log.WarnLevel {
+					warnCount++
+				}
+			}
+			h.AssertEq(t, infoCount, 1)
+			h.AssertEq(t, warnCount, 2)
+		})
+	})
+
+	when("zero retry delays configured", func() {
+		it("makes a single attempt and returns the error", func() {
+			sleeps := swapRetryTiming(t, 0)
+
+			_, err := OpenRemoteImage(logger, func() (imgutil.Image, error) {
+				return &stubImage{result: topLayerResult{err: errors.New("top layer error")}}, nil
+			})
+
+			h.AssertNotNil(t, err)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+	})
+}
+
+func TestIsRetryable(t *testing.T) {
+	spec.Run(t, "isRetryable", testIsRetryable, spec.Report(report.Terminal{}))
+}
+
+func testIsRetryable(t *testing.T, when spec.G, it spec.S) {
+	it("returns true for non-transport errors", func() {
+		h.AssertEq(t, isRetryable(errors.New("generic error")), true)
+	})
+
+	it("returns true for retryable transport errors", func() {
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusInternalServerError}), true)
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusBadGateway}), true)
+	})
+
+	it("returns false for 400 BadRequest", func() {
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusBadRequest}), false)
+	})
+
+	it("returns false for 401 Unauthorized", func() {
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusUnauthorized}), false)
+	})
+
+	it("returns false for 403 Forbidden", func() {
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusForbidden}), false)
+	})
+
+	it("returns false for 405 MethodNotAllowed", func() {
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusMethodNotAllowed}), false)
+	})
+
+	it("returns false for 429 TooManyRequests", func() {
+		h.AssertEq(t, isRetryable(&transport.Error{StatusCode: http.StatusTooManyRequests}), false)
+	})
 }

--- a/phase/retry_test.go
+++ b/phase/retry_test.go
@@ -1,0 +1,172 @@
+package phase
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/apex/log/handlers/memory"
+	"github.com/buildpacks/imgutil"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+type stubImage struct {
+	imgutil.Image
+	results []topLayerResult
+	calls   int
+}
+
+type topLayerResult struct {
+	sha string
+	err error
+}
+
+func (s *stubImage) TopLayer() (string, error) {
+	r := s.results[s.calls]
+	s.calls++
+	return r.sha, r.err
+}
+
+// swapRetryTiming replaces the package-level retry timing vars with deterministic
+// values for testing. It returns a pointer to the recorded sleep durations.
+// Cleanup is handled via t.Cleanup.
+func swapRetryTiming(t *testing.T, n int) *[]time.Duration {
+	t.Helper()
+	var recorded []time.Duration
+
+	origDelays := topLayerDelays
+	origSleep := topLayerSleep
+
+	topLayerDelays = make([]time.Duration, n)
+	for i := range topLayerDelays {
+		topLayerDelays[i] = time.Duration(i+1) * time.Millisecond
+	}
+	topLayerSleep = func(d time.Duration) {
+		recorded = append(recorded, d)
+	}
+
+	t.Cleanup(func() {
+		topLayerDelays = origDelays
+		topLayerSleep = origSleep
+	})
+	return &recorded
+}
+
+func TestTopLayerWithRetry(t *testing.T) {
+	spec.Run(t, "TopLayerWithRetry", testTopLayerWithRetry, spec.Report(report.Terminal{}))
+}
+
+func testTopLayerWithRetry(t *testing.T, when spec.G, it spec.S) {
+	var (
+		logHandler *memory.Handler
+		logger     *log.Logger
+	)
+
+	it.Before(func() {
+		logHandler = memory.New()
+		logger = &log.Logger{Handler: logHandler}
+	})
+
+	when("successful first attempt", func() {
+		it("returns the top layer SHA immediately with no retries", func() {
+			sleeps := swapRetryTiming(t, 3)
+			img := &stubImage{
+				results: []topLayerResult{
+					{sha: "sha-1"},
+				},
+			}
+
+			got, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+
+			h.AssertNil(t, err)
+			h.AssertEq(t, got, "sha-1")
+			h.AssertEq(t, img.calls, 1)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+	})
+
+	when("transient failures", func() {
+		it("succeeds after transient registry errors", func() {
+			sleeps := swapRetryTiming(t, 4)
+			img := &stubImage{
+				results: []topLayerResult{
+					{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
+					{err: &transport.Error{StatusCode: http.StatusInternalServerError}},
+					{sha: "sha-1"},
+				},
+			}
+
+			got, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+
+			h.AssertNil(t, err)
+			h.AssertEq(t, got, "sha-1")
+			h.AssertEq(t, img.calls, 3)
+			h.AssertEq(t, len(*sleeps), 2)
+		})
+	})
+
+	when("non-retryable errors", func() {
+		it("does not retry on 401 Unauthorized", func() {
+			sleeps := swapRetryTiming(t, 4)
+			img := &stubImage{
+				results: []topLayerResult{
+					{err: &transport.Error{StatusCode: http.StatusUnauthorized}},
+				},
+			}
+
+			_, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+
+			h.AssertNotNil(t, err)
+			var tErr *transport.Error
+			h.AssertEq(t, errors.As(err, &tErr), true)
+			h.AssertEq(t, tErr.StatusCode, http.StatusUnauthorized)
+			h.AssertEq(t, img.calls, 1)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+
+		it("does not retry on 403 Forbidden", func() {
+			sleeps := swapRetryTiming(t, 4)
+			img := &stubImage{
+				results: []topLayerResult{
+					{err: &transport.Error{StatusCode: http.StatusForbidden}},
+				},
+			}
+
+			_, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+
+			h.AssertNotNil(t, err)
+			var tErr *transport.Error
+			h.AssertEq(t, errors.As(err, &tErr), true)
+			h.AssertEq(t, tErr.StatusCode, http.StatusForbidden)
+			h.AssertEq(t, img.calls, 1)
+			h.AssertEq(t, len(*sleeps), 0)
+		})
+	})
+
+	when("all retries exhausted", func() {
+		it("returns the last error after all attempts fail", func() {
+			sleeps := swapRetryTiming(t, 3)
+			img := &stubImage{
+				results: []topLayerResult{
+					{err: errors.New("transient error 1")},
+					{err: errors.New("transient error 2")},
+					{err: errors.New("transient error 3")},
+					{err: errors.New("final error")},
+				},
+			}
+
+			_, err := TopLayerWithRetry(func() (imgutil.Image, error) { return img, nil }, logger)
+
+			h.AssertNotNil(t, err)
+			h.AssertEq(t, img.calls, 4)
+			h.AssertEq(t, len(*sleeps), 3)
+			h.AssertEq(t, err.Error(), "transient error 3")
+		})
+	})
+}

--- a/phase/retry_test.go
+++ b/phase/retry_test.go
@@ -302,7 +302,7 @@ func TestIsRetryable(t *testing.T) {
 	spec.Run(t, "isRetryable", testIsRetryable, spec.Report(report.Terminal{}))
 }
 
-func testIsRetryable(t *testing.T, when spec.G, it spec.S) {
+func testIsRetryable(t *testing.T, _ spec.G, it spec.S) {
 	it("returns true for non-transport errors", func() {
 		h.AssertEq(t, isRetryable(errors.New("generic error")), true)
 	})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary

This PR adds retry logic to mitigate intermittent failures when retrieving the top layer SHA from registry mirrors. Registry mirrors may temporarily return incomplete manifests as layers sync, causing the `image has no layers` error. The retry mechanism gives the mirror time to stabilize.

#### Release notes

When using registry mirrors, the lifecycle will now retry top layer retrieval up to 5 times with exponential backoff before failing.

---

### Related

Resolves #1674

---

### Context

- Added `OpenRemoteImage` function in `phase/retry.go` with 5 retry attempts
- Exponential backoff delays: 100ms → 200ms → 500ms → 1s → 2s
- Exporter and Rebaser now use `OpenRemoteImage` instead of direct `TopLayer()` calls
- All existing tests pass