### PR TITLE
Fix containerd CVE-2026-53488 and suppress docker/cli false positive

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,3 +10,4 @@ ignore:
   - vulnerability: GHSA-vp62-88p7-qqf5 # docker cp symlink race; not exploitable as lifecycle does not use docker cp in production code.
   - vulnerability: GHSA-rg2x-37c3-w2rh # docker cp bind mount redirection race; not exploitable as lifecycle does not use docker cp in production code. No upstream fix available.
   - vulnerability: GHSA-x86f-5xw2-fm2r # daemon-side PUT /containers/{id}/archive RCE; not exploitable as lifecycle only uses docker as a client. No upstream fix available.
+  - vulnerability: GO-2026-4610 # false positive (CVE-2025-15558); affects docker/cli <29.2.0, but lifecycle vendors v29.5.0 which is already patched. grype mismatches the version because of +incompatible comparison. Also Windows-only plugin path issue, not applicable to lifecycle.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.12.0
 	github.com/buildpacks/imgutil v0.0.0-20260415151438-73856e68b72b
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
-	github.com/containerd/containerd v1.7.32
+	github.com/containerd/containerd v1.7.33
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb2
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589/go.mod h1:OuDyvmLnMCwa2ep4Jkm6nyA0ocJuZlGyk2gGseVzERM=
 github.com/ckaznocha/intrange v0.3.1 h1:j1onQyXvHUsPWujDH6WIjhyH26gkRt/txNlV7LspvJs=
 github.com/ckaznocha/intrange v0.3.1/go.mod h1:QVepyz1AkUoFQkpEqksSYpNpUo3c5W7nWh/s6SHIJJk=
-github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
-github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
+github.com/containerd/containerd v1.7.33 h1:iAkYGC/ifR/V+0eR4iXWHNGYUF0DF2PmGV5iz4Irj5M=
+github.com/containerd/containerd v1.7.33/go.mod h1:gSbSCVjPCdkfJCjyrzz7aRC+xFlqVbatNpfHfVCYGUM=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->
The image security scan (grype, --fail-on medium) failed on the latest main commit with three findings in the lifecycle binaries:

- containerd v1.7.32: GHSA-xhf5-7wjv-pqxp (CVE-2026-53488, High) and GHSA-jpcc-p29g-p8mq (Medium). Fixed by bumping to v1.7.33.

- docker/cli GO-2026-4610 (CVE-2025-15558, High): false positive. The advisory affects docker/cli <29.2.0, but lifecycle vendors v29.5.0 which is already patched. grype mismatches the version due to its +incompatible comparison. Added to .grype.yaml with justification.

Verified by building the linux/amd64 lifecycle binary and scanning it with grype --fail-on medium: no vulnerabilities found.


#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->
- bump containerd to v1.7.33

---

