### PR TITLE
Migrate 23 test files from sclevine/spec to native Go subtests

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -120,7 +120,6 @@ func TestVersion(t *testing.T) {
 					args:        []string{"-version"},
 				},
 			} {
-				tc := tc
 				t.Run(tc.description, func(t *testing.T) {
 					t.Run("only prints the version", func(t *testing.T) {
 						cmd := lifecycleCmd(tc.command, tc.args...)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -8,9 +8,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/api"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
@@ -43,19 +40,9 @@ func TestVersion(t *testing.T) {
 		"LIFECYCLE_VERSION=some-version",
 		"SCM_COMMIT="+expectedCommit,
 	)
-	spec.Run(t, "acceptance", testVersion, spec.Parallel(), spec.Report(report.Terminal{}))
-}
-
-type testCase struct {
-	description string
-	focus       bool
-	command     string
-	args        []string
-}
-
-func testVersion(t *testing.T, when spec.G, it spec.S) {
-	when("All", func() {
-		when("version flag is set", func() {
+	t.Parallel()
+	t.Run("All", func(t *testing.T) {
+		t.Run("version flag is set", func(t *testing.T) {
 			for _, tc := range []testCase{
 				{
 					description: "detector: only -version is present",
@@ -133,12 +120,9 @@ func testVersion(t *testing.T, when spec.G, it spec.S) {
 					args:        []string{"-version"},
 				},
 			} {
-				w := when
-				if tc.focus {
-					w = when.Focus
-				}
-				w(tc.description, func() {
-					it("only prints the version", func() {
+				tc := tc
+				t.Run(tc.description, func(t *testing.T) {
+					t.Run("only prints the version", func(t *testing.T) {
 						cmd := lifecycleCmd(tc.command, tc.args...)
 						cmd.Env = []string{fmt.Sprintf("CNB_PLATFORM_API=%s", api.Platform.Latest().String())}
 						output, err := cmd.CombinedOutput()
@@ -151,6 +135,12 @@ func testVersion(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 	})
+}
+
+type testCase struct {
+	description string
+	command     string
+	args        []string
 }
 
 func lifecycleCmd(phase string, args ...string) *exec.Cmd {

--- a/acceptance/launcher_test.go
+++ b/acceptance/launcher_test.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
@@ -32,13 +29,9 @@ func TestLauncher(t *testing.T) {
 
 	launchImage = launchTest.testImageRef
 	launcherPath = launchTest.containerBinaryPath
-
-	spec.Run(t, "acceptance", testLauncher, spec.Parallel(), spec.Report(report.Terminal{}))
-}
-
-func testLauncher(t *testing.T, when spec.G, it spec.S) {
-	when("exec.d", func() {
-		it("executes the binaries and modifies env before running profiles", func() {
+	t.Parallel()
+	t.Run("exec.d", func(t *testing.T) {
+		t.Run("executes the binaries and modifies env before running profiles", func(t *testing.T) {
 			cmd := exec.Command("docker", "run", "--rm", //nolint
 				"--env=CNB_PLATFORM_API=0.7",
 				"--entrypoint=exec.d-checker"+exe,
@@ -61,18 +54,16 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			assertOutput(t, cmd, expected)
 		})
 	})
-
-	when("entrypoint is a process", func() {
-		it("launches that process", func() {
+	t.Run("entrypoint is a process", func(t *testing.T) {
+		t.Run("launches that process", func(t *testing.T) {
 			cmd := exec.Command("docker", "run", "--rm", //nolint
 				"--entrypoint=web",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
 				launchImage)
 			assertOutput(t, cmd, "Executing web process-type")
 		})
-
-		when("process contains a period", func() {
-			it("launches that process", func() {
+		t.Run("process contains a period", func(t *testing.T) {
+			t.Run("launches that process", func(t *testing.T) {
 				cmd := exec.Command("docker", "run", "--rm",
 					"--entrypoint=process.with.period"+exe,
 					"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -80,8 +71,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				assertOutput(t, cmd, "Executing process.with.period process-type")
 			})
 		})
-
-		it("appends any args to the process args", func() {
+		t.Run("appends any args to the process args", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--entrypoint=web",
@@ -91,9 +81,8 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			assertOutput(t, cmd, "Executing web process-type with user provided args")
 		})
 	})
-
-	when("entrypoint is a not a process", func() {
-		it("builds a process from the arguments", func() {
+	t.Run("entrypoint is a not a process", func(t *testing.T) {
+		t.Run("builds a process from the arguments", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--entrypoint=launcher",
@@ -108,9 +97,8 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			)
 		})
 	})
-
-	when("CNB_PROCESS_TYPE is set", func() {
-		it("should warn", func() {
+	t.Run("CNB_PROCESS_TYPE is set", func(t *testing.T) {
+		t.Run("should warn", func(t *testing.T) {
 			cmd := exec.Command("docker", "run", "--rm",
 				"--env=CNB_PROCESS_TYPE=direct-process",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -124,9 +112,8 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			h.AssertStringContains(t, string(out), "ERROR: failed to launch: determine start command: when there is no default process a command is required")
 		})
 	})
-
-	when("provided CMD is not a process-type", func() {
-		it("sources profiles and executes the command in a shell", func() {
+	t.Run("provided CMD is not a process-type", func(t *testing.T) {
+		t.Run("sources profiles and executes the command in a shell", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -135,8 +122,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			)
 			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsomething")
 		})
-
-		it("sets env vars from layers", func() {
+		t.Run("sets env vars from layers", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -145,8 +131,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			)
 			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsome-bp-val other-bp-val worker-no-process-val")
 		})
-
-		it("passes through env vars from user, excluding excluded vars", func() {
+		t.Run("passes through env vars from user, excluding excluded vars", func(t *testing.T) {
 			args := []string{"echo", "$SOME_USER_VAR, $CNB_APP_DIR, $OTHER_VAR"}
 			cmd := exec.Command("docker",
 				append(
@@ -163,8 +148,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 
 			assertOutput(t, cmd, "sourced bp profile\nsourced app profile\nsome-user-val, , other-user-val**other-bp-val")
 		})
-
-		it("adds buildpack bin dirs to the path", func() {
+		t.Run("adds buildpack bin dirs to the path", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -174,9 +158,8 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			assertOutput(t, cmd, "bp executable")
 		})
 	})
-
-	when("CMD provided starts with --", func() {
-		it("launches command directly", func() {
+	t.Run("CMD provided starts with --", func(t *testing.T) {
+		t.Run("launches command directly", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -185,8 +168,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 			)
 			assertOutput(t, cmd, "something")
 		})
-
-		it("sets env vars from layers", func() {
+		t.Run("sets env vars from layers", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,
@@ -199,8 +181,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				"OTHER_VAR=other-bp-val",
 			)
 		})
-
-		it("passes through env vars from user, excluding excluded vars", func() {
+		t.Run("passes through env vars from user, excluding excluded vars", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env", "CNB_APP_DIR=/workspace",
@@ -223,8 +204,7 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("env contained white listed env far CNB_APP_DIR:\n\t got: %s\n", output)
 			}
 		})
-
-		it("adds buildpack bin dirs to the path before looking up command", func() {
+		t.Run("adds buildpack bin dirs to the path before looking up command", func(t *testing.T) {
 			cmd := exec.Command( //nolint
 				"docker", "run", "--rm",
 				"--env=CNB_PLATFORM_API="+latestPlatformAPI,

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -3,88 +3,73 @@ package api_test
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/api"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestAPIVersion(t *testing.T) {
-	spec.Run(t, "APIVersion", testAPIVersion, spec.Parallel(), spec.Report(report.Terminal{}))
-}
-
-func testAPIVersion(t *testing.T, when spec.G, it spec.S) {
-	when("#Equal", func() {
-		it("is equal to comparison", func() {
+	t.Parallel()
+	t.Run("#Equal", func(t *testing.T) {
+		t.Run("is equal to comparison", func(t *testing.T) {
 			subject := api.MustParse("0.2")
 			comparison := api.MustParse("0.2")
 
 			h.AssertEq(t, subject.Equal(comparison), true)
 		})
-
-		it("is not equal to comparison", func() {
+		t.Run("is not equal to comparison", func(t *testing.T) {
 			subject := api.MustParse("0.2")
 			comparison := api.MustParse("0.3")
 
 			h.AssertEq(t, subject.Equal(comparison), false)
 		})
 	})
-
-	when("IsSupersetOf", func() {
-		when("0.x", func() {
-			it("matching Minor value", func() {
+	t.Run("IsSupersetOf", func(t *testing.T) {
+		t.Run("0.x", func(t *testing.T) {
+			t.Run("matching Minor value", func(t *testing.T) {
 				v := api.MustParse("0.2")
 				target := api.MustParse("0.2")
 
 				h.AssertEq(t, v.IsSupersetOf(target), true)
 			})
-
-			it("Minor > target Minor", func() {
+			t.Run("Minor > target Minor", func(t *testing.T) {
 				v := api.MustParse("0.2")
 				target := api.MustParse("0.1")
 
 				h.AssertEq(t, v.IsSupersetOf(target), false)
 			})
-
-			it("Minor < target Minor", func() {
+			t.Run("Minor < target Minor", func(t *testing.T) {
 				v := api.MustParse("0.1")
 				target := api.MustParse("0.2")
 
 				h.AssertEq(t, v.IsSupersetOf(target), false)
 			})
 		})
-
-		when("1.x", func() {
-			it("matching Major and Minor", func() {
+		t.Run("1.x", func(t *testing.T) {
+			t.Run("matching Major and Minor", func(t *testing.T) {
 				v := api.MustParse("1.2")
 				target := api.MustParse("1.2")
 
 				h.AssertEq(t, v.IsSupersetOf(target), true)
 			})
-
-			it("matching Major but Minor > target Minor", func() {
+			t.Run("matching Major but Minor > target Minor", func(t *testing.T) {
 				v := api.MustParse("1.2")
 				target := api.MustParse("1.1")
 
 				h.AssertEq(t, v.IsSupersetOf(target), true)
 			})
-
-			it("matching Major but Minor < target Minor", func() {
+			t.Run("matching Major but Minor < target Minor", func(t *testing.T) {
 				v := api.MustParse("1.1")
 				target := api.MustParse("1.2")
 
 				h.AssertEq(t, v.IsSupersetOf(target), false)
 			})
-
-			it("Major < target Major", func() {
+			t.Run("Major < target Major", func(t *testing.T) {
 				v := api.MustParse("1.0")
 				target := api.MustParse("2.0")
 
 				h.AssertEq(t, v.IsSupersetOf(target), false)
 			})
-
-			it("Major > target Major", func() {
+			t.Run("Major > target Major", func(t *testing.T) {
 				v := api.MustParse("2.0")
 				target := api.MustParse("1.0")
 
@@ -92,29 +77,27 @@ func testAPIVersion(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-
-	when("#LessThan", func() {
+	t.Run("#LessThan", func(t *testing.T) {
 		var subject = api.MustParse("0.3")
 		var toTest = map[string]bool{
 			"0.2": false,
 			"0.3": false,
 			"0.4": true,
 		}
-		it("returns the expected value", func() {
+		t.Run("returns the expected value", func(t *testing.T) {
 			for comparison, expected := range toTest {
 				h.AssertEq(t, subject.LessThan(comparison), expected)
 			}
 		})
 	})
-
-	when("#AtLeast", func() {
+	t.Run("#AtLeast", func(t *testing.T) {
 		var subject = api.MustParse("0.3")
 		var toTest = map[string]bool{
 			"0.2": true,
 			"0.3": true,
 			"0.4": false,
 		}
-		it("returns the expected value", func() {
+		t.Run("returns the expected value", func(t *testing.T) {
 			for comparison, expected := range toTest {
 				h.AssertEq(t, subject.AtLeast(comparison), expected)
 			}

--- a/buildpack/bp_descriptor_test.go
+++ b/buildpack/bp_descriptor_test.go
@@ -4,22 +4,15 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/buildpack"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestBpDescriptor(t *testing.T) {
-	spec.Run(t, "BpDescriptor", testBpDescriptor, spec.Report(report.Terminal{}))
-}
-
-func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
-	when("TargetMetadata", func() {
-		when("#String()", func() {
-			when("there is a distribution", func() {
-				it("prints the target", func() {
+	t.Run("TargetMetadata", func(t *testing.T) {
+		t.Run("#String()", func(t *testing.T) {
+			t.Run("there is a distribution", func(t *testing.T) {
+				t.Run("prints the target", func(t *testing.T) {
 					tm := &buildpack.TargetMetadata{
 						OS:          "some-os",
 						Arch:        "some-arch",
@@ -34,9 +27,8 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 					h.AssertEq(t, tm.String(), `{"os":"some-os","arch":"some-arch","arch-variant":"some-arch-variant","distros":[{"name":"some-os-dist","version":"some-os-dist-version"}]}`)
 				})
 			})
-
-			when("there is no distribution", func() {
-				it("prints the target", func() {
+			t.Run("there is no distribution", func(t *testing.T) {
+				t.Run("prints the target", func(t *testing.T) {
 					tm := &buildpack.TargetMetadata{
 						OS:          "some-os",
 						Arch:        "some-arch",
@@ -47,9 +39,8 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-
-	when("#ReadBpDescriptor", func() {
-		it("returns a buildpack descriptor", func() {
+	t.Run("#ReadBpDescriptor", func(t *testing.T) {
+		t.Run("returns a buildpack descriptor", func(t *testing.T) {
 			path := filepath.Join("testdata", "buildpack", "by-id", "A", "v1", "buildpack.toml")
 			descriptor, err := buildpack.ReadBpDescriptor(path)
 			h.AssertNil(t, err)
@@ -61,8 +52,7 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, descriptor.Buildpack.Homepage, "Buildpack A Homepage")
 			h.AssertEq(t, descriptor.Buildpack.SBOM, []string{"application/vnd.cyclonedx+json"})
 		})
-
-		it("reads new target fields", func() {
+		t.Run("reads new target fields", func(t *testing.T) {
 			path := filepath.Join("testdata", "buildpack", "by-id", "D", "v1", "buildpack.toml")
 			descriptor, err := buildpack.ReadBpDescriptor(path)
 			h.AssertNil(t, err)
@@ -80,11 +70,10 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, descriptor.Targets[0].Distros[0].Name, "VSI OpenVMS")
 			h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "V8.4-2L3")
 		})
-
-		when("translating stacks to targets", func() {
-			when("older buildpacks", func() {
-				when("there is only bionic", func() {
-					it("creates a target", func() {
+		t.Run("translating stacks to targets", func(t *testing.T) {
+			t.Run("older buildpacks", func(t *testing.T) {
+				t.Run("there is only bionic", func(t *testing.T) {
+					t.Run("creates a target", func(t *testing.T) {
 						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1", "buildpack.toml")
 						descriptor, err := buildpack.ReadBpDescriptor(path)
 						h.AssertNil(t, err)
@@ -104,9 +93,8 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 						h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
 					})
 				})
-
-				when("there are multiple stacks", func() {
-					it("does NOT create a target", func() {
+				t.Run("there are multiple stacks", func(t *testing.T) {
+					t.Run("does NOT create a target", func(t *testing.T) {
 						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1.2", "buildpack.toml")
 						descriptor, err := buildpack.ReadBpDescriptor(path)
 						h.AssertNil(t, err)
@@ -122,9 +110,8 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 						h.AssertEq(t, len(descriptor.Targets), 0)
 					})
 				})
-
-				when("there is a wildcard stack", func() {
-					it("creates a wildcard target", func() {
+				t.Run("there is a wildcard stack", func(t *testing.T) {
+					t.Run("creates a wildcard target", func(t *testing.T) {
 						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v1.star", "buildpack.toml")
 						descriptor, err := buildpack.ReadBpDescriptor(path)
 						h.AssertNil(t, err)
@@ -146,10 +133,9 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 					})
 				})
 			})
-
-			when("newer buildpacks", func() {
-				when("there is only bionic", func() {
-					it("creates a target", func() {
+			t.Run("newer buildpacks", func(t *testing.T) {
+				t.Run("there is only bionic", func(t *testing.T) {
+					t.Run("creates a target", func(t *testing.T) {
 						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2", "buildpack.toml")
 						descriptor, err := buildpack.ReadBpDescriptor(path)
 						h.AssertNil(t, err)
@@ -169,9 +155,8 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 						h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
 					})
 				})
-
-				when("there are multiple stacks", func() {
-					it("creates a target", func() {
+				t.Run("there are multiple stacks", func(t *testing.T) {
+					t.Run("creates a target", func(t *testing.T) {
 						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2.2", "buildpack.toml")
 						descriptor, err := buildpack.ReadBpDescriptor(path)
 						h.AssertNil(t, err)
@@ -191,9 +176,8 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 						h.AssertEq(t, descriptor.Targets[0].Distros[0].Version, "18.04")
 					})
 				})
-
-				when("there is a wildcard stack", func() {
-					it("creates a wildcard target", func() {
+				t.Run("there is a wildcard stack", func(t *testing.T) {
+					t.Run("creates a wildcard target", func(t *testing.T) {
 						path := filepath.Join("testdata", "buildpack", "by-id", "B", "v2.star", "buildpack.toml")
 						descriptor, err := buildpack.ReadBpDescriptor(path)
 						h.AssertNil(t, err)
@@ -216,8 +200,7 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 				})
 			})
 		})
-
-		it("does not translate non-special stack values", func() {
+		t.Run("does not translate non-special stack values", func(t *testing.T) {
 			path := filepath.Join("testdata", "buildpack", "by-id", "C", "v1", "buildpack.toml")
 			descriptor, err := buildpack.ReadBpDescriptor(path)
 			h.AssertNil(t, err)
@@ -232,8 +215,7 @@ func testBpDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, descriptor.Stacks[0].ID, "some.non-magic.value")
 			h.AssertEq(t, len(descriptor.Targets), 0)
 		})
-
-		it("does autodetect linux buildpacks from the bin dir contents", func() {
+		t.Run("does autodetect linux buildpacks from the bin dir contents", func(t *testing.T) {
 			path := filepath.Join("testdata", "buildpack", "by-id", "C", "v2", "buildpack.toml")
 			descriptor, err := buildpack.ReadBpDescriptor(path)
 			h.AssertNil(t, err)

--- a/buildpack/error_test.go
+++ b/buildpack/error_test.go
@@ -4,18 +4,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/sclevine/spec"
-
 	"github.com/buildpacks/lifecycle/buildpack"
 )
 
 func TestError(t *testing.T) {
-	spec.Run(t, "Test Error", testError)
-}
-
-func testError(t *testing.T, when spec.G, it spec.S) {
-	when("#Cause", func() {
-		it("returns the error", func() {
+	t.Run("#Cause", func(t *testing.T) {
+		t.Run("returns the error", func(t *testing.T) {
 			expectedErr := errors.New("root cause")
 			testErr := &buildpack.Error{
 				RootError: expectedErr,
@@ -27,8 +21,7 @@ func testError(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected cause:\n%s\n", cause)
 			}
 		})
-
-		it("returns handles nil state", func() {
+		t.Run("returns handles nil state", func(t *testing.T) {
 			testErr := &buildpack.Error{}
 
 			if testErr.Cause() != nil {
@@ -36,9 +29,8 @@ func testError(t *testing.T, when spec.G, it spec.S) {
 			}
 		})
 	})
-
-	when("#Error", func() {
-		it("returns the underlying error", func() {
+	t.Run("#Error", func(t *testing.T) {
+		t.Run("returns the underlying error", func(t *testing.T) {
 			expectedErr := errors.New("root cause")
 			testErr := &buildpack.Error{
 				RootError: expectedErr,
@@ -48,8 +40,7 @@ func testError(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected error:\n%s\n", testErr.Error())
 			}
 		})
-
-		it("returns the type when there is no error", func() {
+		t.Run("returns the type when there is no error", func(t *testing.T) {
 			testErr := &buildpack.Error{
 				Type: buildpack.ErrTypeBuildpack,
 			}

--- a/buildpack/ext_descriptor_test.go
+++ b/buildpack/ext_descriptor_test.go
@@ -4,20 +4,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/buildpack"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestExtDescriptor(t *testing.T) {
-	spec.Run(t, "ExtDescriptor", testExtDescriptor, spec.Report(report.Terminal{}))
-}
-
-func testExtDescriptor(t *testing.T, when spec.G, it spec.S) {
-	when("#ReadExtDescriptor", func() {
-		it("returns an extension descriptor", func() {
+	t.Run("#ReadExtDescriptor", func(t *testing.T) {
+		t.Run("returns an extension descriptor", func(t *testing.T) {
 			path := filepath.Join("testdata", "extension", "by-id", "A", "v1", "extension.toml")
 			descriptor, err := buildpack.ReadExtDescriptor(path)
 			h.AssertNil(t, err)
@@ -31,7 +24,7 @@ func testExtDescriptor(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, descriptor.Targets[0].OS, "linux")
 			h.AssertEq(t, descriptor.Targets[0].Arch, "")
 		})
-		it("infers */* if there's no files to infer from", func() {
+		t.Run("infers */* if there's no files to infer from", func(t *testing.T) {
 			path := filepath.Join("testdata", "extension", "by-id", "B", "v1", "extension.toml")
 			descriptor, err := buildpack.ReadExtDescriptor(path)
 			h.AssertNil(t, err)

--- a/env/launch_test.go
+++ b/env/launch_test.go
@@ -6,19 +6,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/env"
 )
 
 func TestLaunchEnv(t *testing.T) {
-	spec.Run(t, "LaunchEnv", testLaunchEnv, spec.Report(report.Terminal{}))
-}
-
-func testLaunchEnv(t *testing.T, when spec.G, it spec.S) {
-	when("#NewLaunchEnv", func() {
-		it("excludes vars", func() {
+	t.Run("#NewLaunchEnv", func(t *testing.T) {
+		t.Run("excludes vars", func(t *testing.T) {
 			lenv := env.NewLaunchEnv([]string{
 				"CNB_APP_DIR=excluded",
 				"CNB_LAYERS_DIR=excluded",
@@ -33,9 +27,8 @@ func testLaunchEnv(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected env\n%s\n", s)
 			}
 		})
-
-		when("path contains process and lifecycle dirs", func() {
-			it("strips them", func() {
+		t.Run("path contains process and lifecycle dirs", func(t *testing.T) {
+			t.Run("strips them", func(t *testing.T) {
 				lenv := env.NewLaunchEnv([]string{
 					"PATH=" + strings.Join(
 						[]string{"some-process-dir", "some-path", "some-lifecycle-dir"},
@@ -49,8 +42,7 @@ func testLaunchEnv(t *testing.T, when spec.G, it spec.S) {
 				}
 			})
 		})
-
-		it("allows keys with '='", func() {
+		t.Run("allows keys with '='", func(t *testing.T) {
 			lenv := env.NewLaunchEnv([]string{
 				"CNB_FOO=some=key",
 			}, "", "")
@@ -60,8 +52,7 @@ func testLaunchEnv(t *testing.T, when spec.G, it spec.S) {
 				t.Fatalf("Unexpected env\n%s\n", s)
 			}
 		})
-
-		it("assign the Launch time root dir map", func() {
+		t.Run("assign the Launch time root dir map", func(t *testing.T) {
 			lenv := env.NewLaunchEnv([]string{}, "", "")
 			if s := cmp.Diff(lenv.RootDirMap, env.POSIXLaunchEnv); s != "" {
 				t.Fatalf("Unexpected root dir map\n%s\n", s)

--- a/env/vars_test.go
+++ b/env/vars_test.go
@@ -3,21 +3,14 @@ package env_test
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/env"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestVars(t *testing.T) {
-	spec.Run(t, "Vars", testVars, spec.Report(report.Terminal{}))
-}
-
-func testVars(t *testing.T, when spec.G, it spec.S) {
-	when("#NewVars", func() {
-		when("case sensitive", func() {
-			it("should load values as is", func() {
+	t.Run("#NewVars", func(t *testing.T) {
+		t.Run("case sensitive", func(t *testing.T) {
+			t.Run("should load values as is", func(t *testing.T) {
 				m := env.NewVars(
 					map[string]string{
 						"foo": "bar",
@@ -29,9 +22,8 @@ func testVars(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, m.Get("Foo"), "")
 			})
 		})
-
-		when("case insensitive", func() {
-			it("should load values normalized", func() {
+		t.Run("case insensitive", func(t *testing.T) {
+			t.Run("should load values normalized", func(t *testing.T) {
 				m := env.NewVars(
 					map[string]string{
 						"foo": "bar",
@@ -44,10 +36,9 @@ func testVars(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-
-	when("#Set", func() {
-		when("case sensitive", func() {
-			it("should set value as is", func() {
+	t.Run("#Set", func(t *testing.T) {
+		t.Run("case sensitive", func(t *testing.T) {
+			t.Run("should set value as is", func(t *testing.T) {
 				m := env.NewVars(nil, false)
 				m.Set("foo", "bar")
 
@@ -55,9 +46,8 @@ func testVars(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, m.Get("Foo"), "")
 			})
 		})
-
-		when("case insensitive", func() {
-			it("should set value normalized", func() {
+		t.Run("case insensitive", func(t *testing.T) {
+			t.Run("should set value normalized", func(t *testing.T) {
 				m := env.NewVars(nil, true)
 				m.Set("foo", "bar")
 
@@ -66,10 +56,9 @@ func testVars(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-
-	when("#Values", func() {
-		when("case sensitive", func() {
-			it("should load values as is", func() {
+	t.Run("#Values", func(t *testing.T) {
+		t.Run("case sensitive", func(t *testing.T) {
+			t.Run("should load values as is", func(t *testing.T) {
 				m := env.NewVars(
 					map[string]string{
 						"foo": "bar",
@@ -81,9 +70,8 @@ func testVars(t *testing.T, when spec.G, it spec.S) {
 				h.AssertContains(t, m.List(), "foo=bar", "baz=taz")
 			})
 		})
-
-		when("case insensitive", func() {
-			it("should load values normalized", func() {
+		t.Run("case insensitive", func(t *testing.T) {
+			t.Run("should load values normalized", func(t *testing.T) {
 				m := env.NewVars(
 					map[string]string{
 						"foo": "bar",

--- a/image/registry_handler_test.go
+++ b/image/registry_handler_test.go
@@ -3,36 +3,28 @@ package image
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestRegistryHandler(t *testing.T) {
-	spec.Run(t, "RegistryHandler", testRegistryHandler, spec.Parallel(), spec.Report(report.Terminal{}))
-}
-func testRegistryHandler(t *testing.T, when spec.G, it spec.S) {
-	when("insecure registry", func() {
-		it("returns WithRegistrySetting options for the domain specified", func() {
+	t.Parallel()
+	t.Run("insecure registry", func(t *testing.T) {
+		t.Run("returns WithRegistrySetting options for the domain specified", func(t *testing.T) {
 			registryOptions := GetInsecureOptions([]string{"host.docker.internal"})
 
 			h.AssertEq(t, len(registryOptions), 1)
 		})
-
-		it("returns multiple WithRegistrySetting options for the domains specified", func() {
+		t.Run("returns multiple WithRegistrySetting options for the domains specified", func(t *testing.T) {
 			registryOptions := GetInsecureOptions([]string{"host.docker.internal", "another.docker.internal"})
 
 			h.AssertEq(t, len(registryOptions), 2)
 		})
-
-		it("returns empty options if any domain hasn't been specified", func() {
+		t.Run("returns empty options if any domain hasn't been specified", func(t *testing.T) {
 			options := GetInsecureOptions(nil)
 
 			h.AssertEq(t, len(options), 0)
 		})
-
-		it("returns empty options if an empty list of insecure registries has been passed", func() {
+		t.Run("returns empty options if an empty list of insecure registries has been passed", func(t *testing.T) {
 			options := GetInsecureOptions([]string{})
 
 			h.AssertEq(t, len(options), 0)

--- a/internal/extend/kaniko/dockerfile_applier_test.go
+++ b/internal/extend/kaniko/dockerfile_applier_test.go
@@ -4,21 +4,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/internal/extend"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestDockerApplier(t *testing.T) {
-	spec.Run(t, "DockerApplier", testDockerApplier, spec.Report(report.Terminal{}))
-}
-
-func testDockerApplier(t *testing.T, when spec.G, it spec.S) {
-	when("#createOptions", func() {
-		when("ignore paths", func() {
-			it("adds them to kaniko options", func() {
+	t.Run("#createOptions", func(t *testing.T) {
+		t.Run("ignore paths", func(t *testing.T) {
+			t.Run("adds them to kaniko options", func(t *testing.T) {
 				opts := createOptions(
 					"some-image-ref",
 					extend.Dockerfile{
@@ -38,9 +31,8 @@ func testDockerApplier(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, len(opts.IgnorePaths), 2)
 			})
 		})
-
-		when("cache TTL", func() {
-			it("adds it to kaniko options", func() {
+		t.Run("cache TTL", func(t *testing.T) {
+			t.Run("adds it to kaniko options", func(t *testing.T) {
 				opts := createOptions(
 					"some-image-ref",
 					extend.Dockerfile{
@@ -58,12 +50,12 @@ func testDockerApplier(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, opts.CacheOptions.CacheTTL, 7*(24*time.Hour))
 			})
 		})
-
-		when("cache dir", func() {
+		t.Run("cache dir", func(t *testing.
 			// If we provide cache directory as an option, kaniko looks there for the base image as a tarball;
 			// however the base image is in OCI layout format, so we fail to initialize the base image,
 			// causing a confusing log message to be emitted by kaniko.
-			it("does not add it to kaniko options", func() {
+			T) {
+			t.Run("does not add it to kaniko options", func(t *testing.T) {
 				opts := createOptions(
 					"some-image-ref",
 					extend.Dockerfile{

--- a/internal/fsutil/os_detection_linux_test.go
+++ b/internal/fsutil/os_detection_linux_test.go
@@ -7,21 +7,14 @@ import (
 
 	"github.com/buildpacks/lifecycle/internal/fsutil"
 	h "github.com/buildpacks/lifecycle/testhelpers"
-
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 )
 
 func TestDetectorUnix(t *testing.T) {
-	spec.Run(t, "DetectorUnix", testDetectorUnix, spec.Report(report.Terminal{}))
-}
-
-func testDetectorUnix(t *testing.T, when spec.G, it spec.S) {
-	when("we should have a file", func() {
-		it("returns true correctly", func() {
+	t.Run("we should have a file", func(t *testing.T) {
+		t.Run("returns true correctly", func(t *testing.T) {
 			h.AssertEq(t, (&fsutil.DefaultDetector{}).HasSystemdFile(), true)
 		})
-		it("returns the file contents", func() {
+		t.Run("returns the file contents", func(t *testing.T) {
 			s, err := (&fsutil.DefaultDetector{}).ReadSystemdFile()
 			h.AssertNil(t, err)
 			h.AssertStringContains(t, s, "NAME")

--- a/internal/fsutil/os_detection_notlinux_test.go
+++ b/internal/fsutil/os_detection_notlinux_test.go
@@ -7,21 +7,14 @@ import (
 
 	"github.com/buildpacks/lifecycle/internal/fsutil"
 	h "github.com/buildpacks/lifecycle/testhelpers"
-
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 )
 
 func TestDetectorNonUnix(t *testing.T) {
-	spec.Run(t, "DetectorNonUnix", testDetectorNonUnix, spec.Report(report.Terminal{}))
-}
-
-func testDetectorNonUnix(t *testing.T, when spec.G, it spec.S) {
-	when("we don't have a file", func() {
-		it("returns false correctly", func() {
+	t.Run("we don't have a file", func(t *testing.T) {
+		t.Run("returns false correctly", func(t *testing.T) {
 			h.AssertEq(t, (&fsutil.DefaultDetector{}).HasSystemdFile(), false)
 		})
-		it("returns an error correctly", func() {
+		t.Run("returns an error correctly", func(t *testing.T) {
 			_, err := (&fsutil.DefaultDetector{}).ReadSystemdFile()
 			h.AssertNotNil(t, err)
 		})

--- a/internal/fsutil/os_detection_test.go
+++ b/internal/fsutil/os_detection_test.go
@@ -5,22 +5,16 @@ import (
 
 	"github.com/buildpacks/lifecycle/internal/fsutil"
 	h "github.com/buildpacks/lifecycle/testhelpers"
-
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 )
 
 func TestDetector(t *testing.T) {
-	spec.Run(t, "Detector", testDetector, spec.Report(report.Terminal{}))
-}
+	t.Run(
 
-// there's no state on this object so we can just use the same one forever
-var detect fsutil.DefaultDetector
+		// there's no state on this object so we can just use the same one forever
 
-func testDetector(t *testing.T, when spec.G, it spec.S) {
-	when("we have the contents of an os-release file", func() {
-		it("can parse a debian 10 file", func() {
-			contents := `PRETTY_NAME="Debian GNU/Linux 10 (buster)"
+		"we have the contents of an os-release file", func(t *testing.T) {
+			t.Run("can parse a debian 10 file", func(t *testing.T) {
+				contents := `PRETTY_NAME="Debian GNU/Linux 10 (buster)"
 NAME="Debian GNU/Linux"
 VERSION_ID="10"
 VERSION="10 (buster)"
@@ -30,12 +24,12 @@ HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"
 `
-			data := detect.GetInfo(contents)
-			h.AssertEq(t, data.Name, "debian")
-			h.AssertEq(t, data.Version, "10")
-		})
-		it("can parse a Fedora 37 file", func() {
-			contents := `
+				data := detect.GetInfo(contents)
+				h.AssertEq(t, data.Name, "debian")
+				h.AssertEq(t, data.Version, "10")
+			})
+			t.Run("can parse a Fedora 37 file", func(t *testing.T) {
+				contents := `
 NAME="Fedora Linux"
 VERSION="37 (Cloud Edition)"
 ID=fedora
@@ -55,12 +49,12 @@ REDHAT_BUGZILLA_PRODUCT_VERSION=37
 REDHAT_SUPPORT_PRODUCT="Fedora"
 REDHAT_SUPPORT_PRODUCT_VERSION=37
 `
-			data := detect.GetInfo(contents)
-			h.AssertEq(t, data.Name, "fedora")
-			h.AssertEq(t, data.Version, "37")
-		})
-		it("can parse an Ubuntu 18.04 file", func() {
-			contents := `NAME="Ubuntu"
+				data := detect.GetInfo(contents)
+				h.AssertEq(t, data.Name, "fedora")
+				h.AssertEq(t, data.Version, "37")
+			})
+			t.Run("can parse an Ubuntu 18.04 file", func(t *testing.T) {
+				contents := `NAME="Ubuntu"
 VERSION="18.04.3 LTS (Bionic Beaver)"
 ID=ubuntu
 ID_LIKE=debian
@@ -73,9 +67,11 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
 `
-			data := detect.GetInfo(contents)
-			h.AssertEq(t, data.Name, "ubuntu")
-			h.AssertEq(t, data.Version, "18.04")
+				data := detect.GetInfo(contents)
+				h.AssertEq(t, data.Name, "ubuntu")
+				h.AssertEq(t, data.Version, "18.04")
+			})
 		})
-	})
 }
+
+var detect fsutil.DefaultDetector

--- a/internal/name/ref_test.go
+++ b/internal/name/ref_test.go
@@ -3,19 +3,13 @@ package name_test
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-
 	"github.com/buildpacks/lifecycle/internal/name"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestRef(t *testing.T) {
-	spec.Run(t, "Ref", testRef)
-}
-
-func testRef(t *testing.T, when spec.G, it spec.S) {
-	when(".ParseMaybe", func() {
-		when("provided reference", func() {
+	t.Run(".ParseMaybe", func(t *testing.T) {
+		t.Run("provided reference", func(t *testing.T) {
 			type testCase struct {
 				condition string
 				provided  string
@@ -73,9 +67,9 @@ func testRef(t *testing.T, when spec.G, it spec.S) {
 				},
 			}
 			for _, tc := range testCases {
-				w := when
-				w(tc.condition, func() {
-					it(tc.does, func() {
+				tc := tc
+				t.Run(tc.condition, func(t *testing.T) {
+					t.Run(tc.does, func(t *testing.T) {
 						actual := name.ParseMaybe(tc.provided)
 						h.AssertEq(t, actual, tc.expected)
 					})

--- a/internal/name/ref_test.go
+++ b/internal/name/ref_test.go
@@ -67,7 +67,6 @@ func TestRef(t *testing.T) {
 				},
 			}
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(tc.condition, func(t *testing.T) {
 					t.Run(tc.does, func(t *testing.T) {
 						actual := name.ParseMaybe(tc.provided)

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/google/go-cmp/cmp"
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/internal/encoding"
@@ -16,13 +14,9 @@ import (
 )
 
 func TestLaunch(t *testing.T) {
-	spec.Run(t, "Launch", testLaunch, spec.Sequential(), spec.Report(report.Terminal{}))
-}
-
-func testLaunch(t *testing.T, when spec.G, it spec.S) {
-	when("Process", func() {
-		when("MarshalTOML", func() {
-			it("output command is array", func() {
+	t.Run("Process", func(t *testing.T) {
+		t.Run("MarshalTOML", func(t *testing.T) {
+			t.Run("output command is array", func(t *testing.T) {
 				process := launch.Process{
 					Type:             "some-type",
 					Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
@@ -45,8 +39,7 @@ working-dir = "some-working-directory"
 `
 				h.AssertEq(t, string(bytes), expected)
 			})
-
-			it("handles special characters", func() {
+			t.Run("handles special characters", func(t *testing.T) {
 				process := launch.Process{
 					Type:        "some-type",
 					Command:     launch.RawCommand{Entries: []string{`\r`}},
@@ -64,9 +57,8 @@ buildpack-id = "some-buildpack-id"
 `
 				h.AssertEq(t, string(bytes), expected)
 			})
-
-			when("platform API < 0.10", func() {
-				it("output command is string", func() {
+			t.Run("platform API < 0.10", func(t *testing.T) {
+				t.Run("output command is string", func(t *testing.T) {
 					process := launch.Process{
 						Type:             "some-type",
 						Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
@@ -89,8 +81,7 @@ working-dir = "some-working-directory"
 `
 					h.AssertEq(t, string(bytes), expected)
 				})
-
-				it("handles special characters", func() {
+				t.Run("handles special characters", func(t *testing.T) {
 					process := launch.Process{
 						Type:        "some-type",
 						Command:     launch.RawCommand{Entries: []string{`\r`}},
@@ -110,9 +101,8 @@ buildpack-id = "some-buildpack-id"
 				})
 			})
 		})
-
-		when("MarshalJSON", func() {
-			it("output command is array", func() {
+		t.Run("MarshalJSON", func(t *testing.T) {
+			t.Run("output command is array", func(t *testing.T) {
 				process := launch.Process{
 					Type:             "some-type",
 					Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
@@ -128,8 +118,7 @@ buildpack-id = "some-buildpack-id"
 				expected := `{"type":"some-type","command":["some-command","some-command-arg"],"args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
 				h.AssertEq(t, string(bytes), expected)
 			})
-
-			it("handles special characters", func() {
+			t.Run("handles special characters", func(t *testing.T) {
 				process := launch.Process{
 					Type:        "some-type",
 					Command:     launch.RawCommand{Entries: []string{`\r`}},
@@ -142,9 +131,8 @@ buildpack-id = "some-buildpack-id"
 				expected := `{"type":"some-type","command":["\\r"],"args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
 				h.AssertEq(t, string(bytes), expected)
 			})
-
-			when("platform API < 0.10", func() {
-				it("output command is string", func() {
+			t.Run("platform API < 0.10", func(t *testing.T) {
+				t.Run("output command is string", func(t *testing.T) {
 					process := launch.Process{
 						Type:             "some-type",
 						Command:          launch.NewRawCommand([]string{"some-command", "some-command-arg"}),
@@ -160,8 +148,7 @@ buildpack-id = "some-buildpack-id"
 					expected := `{"type":"some-type","command":"some-command","args":["some-command-arg","some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
 					h.AssertEq(t, string(bytes), expected)
 				})
-
-				it("handles special characters", func() {
+				t.Run("handles special characters", func(t *testing.T) {
 					process := launch.Process{
 						Type:        "some-type",
 						Command:     launch.RawCommand{Entries: []string{`\r`}},
@@ -176,10 +163,9 @@ buildpack-id = "some-buildpack-id"
 				})
 			})
 		})
-
-		when("UnmarshalTOML", func() {
-			when("input command is string", func() {
-				it("populates a launch process", func() {
+		t.Run("UnmarshalTOML", func(t *testing.T) {
+			t.Run("input command is string", func(t *testing.T) {
+				t.Run("populates a launch process", func(t *testing.T) {
 					data := `type = "some-type"
 command = "some-command"
 args = ["some-arg"]
@@ -205,8 +191,7 @@ working-dir = "some-working-directory"
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
 				})
-
-				it("handles special characters", func() {
+				t.Run("handles special characters", func(t *testing.T) {
 					data := `type = "some-type"
 command = "\\r"
 args = ["\\r"]
@@ -226,9 +211,8 @@ buildpack-id = "some-buildpack-id"
 					h.AssertEq(t, process, expected, processCmpOpts...)
 				})
 			})
-
-			when("input command is array", func() {
-				it("populates a launch process", func() {
+			t.Run("input command is array", func(t *testing.T) {
+				t.Run("populates a launch process", func(t *testing.T) {
 					data := `type = "some-type"
 command = ["some-command", "some-command-arg"]
 args = ["some-arg"]
@@ -254,8 +238,7 @@ working-dir = "some-working-directory"
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
 				})
-
-				it("handles special characters", func() {
+				t.Run("handles special characters", func(t *testing.T) {
 					data := `type = "some-type"
 command = ["\\r"]
 args = ["\\r"]
@@ -275,10 +258,9 @@ buildpack-id = "some-buildpack-id"
 				})
 			})
 		})
-
-		when("UnmarshalJSON", func() {
-			when("input command is string", func() {
-				it("populates a launch process", func() {
+		t.Run("UnmarshalJSON", func(t *testing.T) {
+			t.Run("input command is string", func(t *testing.T) {
+				t.Run("populates a launch process", func(t *testing.T) {
 					data := `{"type":"some-type","command":"some-command","args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
 					var process launch.Process
 					err := json.Unmarshal([]byte(data), &process)
@@ -297,8 +279,7 @@ buildpack-id = "some-buildpack-id"
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
 				})
-
-				it("handles special characters", func() {
+				t.Run("handles special characters", func(t *testing.T) {
 					data := `{"type":"some-type","command":"\\r","args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
 					var process launch.Process
 					err := json.Unmarshal([]byte(data), &process)
@@ -312,9 +293,8 @@ buildpack-id = "some-buildpack-id"
 					h.AssertEq(t, process, expected, processCmpOpts...)
 				})
 			})
-
-			when("input command is array", func() {
-				it("populates a launch process", func() {
+			t.Run("input command is array", func(t *testing.T) {
+				t.Run("populates a launch process", func(t *testing.T) {
 					data := `{"type":"some-type","command":["some-command","some-command-arg"],"args":["some-arg"],"direct":true,"default":true,"buildpackID":"some-buildpack-id","working-dir":"some-working-directory"}`
 					var process launch.Process
 					err := json.Unmarshal([]byte(data), &process)
@@ -333,8 +313,7 @@ buildpack-id = "some-buildpack-id"
 						t.Fatalf("Unexpected:\n%s\n", s)
 					}
 				})
-
-				it("handles special characters", func() {
+				t.Run("handles special characters", func(t *testing.T) {
 					data := `{"type":"some-type","command":["\\r"],"args":["\\r"],"direct":false,"buildpackID":"some-buildpack-id"}`
 					var process launch.Process
 					err := json.Unmarshal([]byte(data), &process)

--- a/launch/process_internal_test.go
+++ b/launch/process_internal_test.go
@@ -3,30 +3,23 @@ package launch
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestPrepareWorkingDirectory(t *testing.T) {
-	spec.Run(t, "Process", testProcessInternal, spec.Report(report.Terminal{}))
-}
-
-func testProcessInternal(t *testing.T, when spec.G, it spec.S) {
-	when("getProcessWorkingDirectory", func() {
+	t.Run("getProcessWorkingDirectory", func(t *testing.T) {
 		const (
 			appDir           = "/app"
 			workingDirectory = "/working-directory"
 		)
 
-		it("defaults the working directory to the app dir", func() {
+		t.Run("defaults the working directory to the app dir", func(t *testing.T) {
 			process := Process{}
 			actualWorkingDirectory := getProcessWorkingDirectory(process, appDir)
 			h.AssertEq(t, actualWorkingDirectory, appDir)
 		})
 
-		it("respects a configured working directory", func() {
+		t.Run("respects a configured working directory", func(t *testing.T) {
 			process := Process{WorkingDirectory: workingDirectory}
 			actualWorkingDirectory := getProcessWorkingDirectory(process, appDir)
 			h.AssertEq(t, actualWorkingDirectory, workingDirectory)

--- a/log/timelog_test.go
+++ b/log/timelog_test.go
@@ -4,9 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/log"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
@@ -50,12 +47,9 @@ func (m mockLog) Errorf(_ string, _ ...any) {
 }
 
 func TestTimeLog(t *testing.T) {
-	spec.Run(t, "Exporter", testTimeLog, spec.Parallel(), spec.Report(report.Terminal{}))
-}
-
-func testTimeLog(t *testing.T, when spec.G, it spec.S) {
-	when("we use the time log", func() {
-		it("the granular api works step by step", func() {
+	t.Parallel()
+	t.Run("we use the time log", func(t *testing.T) {
+		t.Run("the granular api works step by step", func(t *testing.T) {
 			logger := mockLog{callCount: map[string]int{}}
 			c1 := log.Chronit{}
 			nullTime := time.Time{}
@@ -72,7 +66,7 @@ func testTimeLog(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, logger.callCount["Debug"], 2)
 			h.AssertEq(t, c1.EndTime.Equal(nullTime), false)
 		})
-		it("the convenience functions call the logger", func() {
+		t.Run("the convenience functions call the logger", func(t *testing.T) {
 			logger := mockLog{callCount: map[string]int{}}
 			endfunc := log.NewMeasurement("value", logger)
 			h.AssertEq(t, logger.callCount["Debug"], 1)

--- a/phase/utils_test.go
+++ b/phase/utils_test.go
@@ -4,34 +4,26 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
 
 	"github.com/buildpacks/lifecycle/phase"
 )
 
 func TestUtils(t *testing.T) {
-	spec.Run(t, "Utils", testUtils, spec.Report(report.Terminal{}))
-}
-
-func testUtils(t *testing.T, when spec.G, it spec.S) {
-	when(".TruncateSha", func() {
-		it("should truncate the sha", func() {
+	t.Run(".TruncateSha", func(t *testing.T) {
+		t.Run("should truncate the sha", func(t *testing.T) {
 			actual := phase.TruncateSha("ed649d0a36b218c476b64d61f85027477ef5742045799f45c8c353562279065a")
 			if s := cmp.Diff(actual, "ed649d0a36b2"); s != "" {
 				t.Fatalf("Unexpected sha:\n%s\n", s)
 			}
 		})
-
-		it("should not truncate the sha with it's short", func() {
+		t.Run("should not truncate the sha with it's short", func(t *testing.T) {
 			sha := "not-a-sha"
 			actual := phase.TruncateSha(sha)
 			if s := cmp.Diff(actual, sha); s != "" {
 				t.Fatalf("Unexpected sha:\n%s\n", s)
 			}
 		})
-
-		it("should remove the prefix", func() {
+		t.Run("should remove the prefix", func(t *testing.T) {
 			sha := "sha256:ed649d0a36b218c476b64d61f85027477ef5742045799f45c8c353562279065a"
 			actual := phase.TruncateSha(sha)
 			if s := cmp.Diff(actual, "ed649d0a36b2"); s != "" {

--- a/platform/files/analyzed_test.go
+++ b/platform/files/analyzed_test.go
@@ -4,21 +4,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sclevine/spec"
-
 	"github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/lifecycle/platform/files"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestAnalyzed(t *testing.T) {
-	spec.Run(t, "Analyzed", testAnalyzed)
-}
-
-func testAnalyzed(t *testing.T, when spec.G, it spec.S) {
-	when("analyzed.toml", func() {
-		when("it is old it stays old", func() {
-			it("serializes and deserializes", func() {
+	t.Run("analyzed.toml", func(t *testing.T) {
+		t.Run("it is old it stays old", func(t *testing.T) {
+			t.Run("serializes and deserializes", func(t *testing.T) {
 				amd := files.Analyzed{
 					PreviousImage: &files.ImageIdentifier{Reference: "previous-img"},
 					LayersMetadata: files.LayersMetadata{
@@ -36,8 +30,7 @@ func testAnalyzed(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, amd.LayersMetadata, amd2.LayersMetadata)
 				h.AssertEq(t, amd.BuildImage, amd2.BuildImage)
 			})
-
-			it("serializes to the old format", func() {
+			t.Run("serializes to the old format", func(t *testing.T) {
 				amd := files.Analyzed{
 					PreviousImage: &files.ImageIdentifier{Reference: "previous-img"},
 					LayersMetadata: files.LayersMetadata{
@@ -74,9 +67,8 @@ func testAnalyzed(t *testing.T, when spec.G, it spec.S) {
 				h.AssertEq(t, string(contents), expectedContents)
 			})
 		})
-
-		when("it is new it stays new", func() {
-			it("serializes and deserializes", func() {
+		t.Run("it is new it stays new", func(t *testing.T) {
+			t.Run("serializes and deserializes", func(t *testing.T) {
 				amd := files.Analyzed{
 					PreviousImage: &files.ImageIdentifier{Reference: "the image formerly known as prince"},
 					RunImage: &files.RunImage{

--- a/platform/launch/defaults_test.go
+++ b/platform/launch/defaults_test.go
@@ -3,20 +3,13 @@ package launch_test
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/platform"
 	"github.com/buildpacks/lifecycle/platform/launch"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestDefaults(t *testing.T) {
-	spec.Run(t, "Defaults", testDefaults, spec.Report(report.Terminal{}))
-}
-
-func testDefaults(t *testing.T, when spec.G, it spec.S) {
-	it("values match the platform package", func() {
+	t.Run("values match the platform package", func(t *testing.T) {
 		h.AssertEq(t, launch.EnvAppDir, platform.EnvAppDir)
 		h.AssertEq(t, launch.EnvLayersDir, platform.EnvLayersDir)
 		h.AssertEq(t, launch.EnvNoColor, platform.EnvNoColor)

--- a/platform/launch/platform_test.go
+++ b/platform/launch/platform_test.go
@@ -11,7 +11,6 @@ import (
 func TestPlatform(t *testing.T) {
 	t.Parallel()
 	for _, platformAPI := range api.Platform.Supported {
-		platformAPI := platformAPI
 		t.Run("unit-platform/"+platformAPI.String(), func(t *testing.T) {
 			t.Parallel()
 			t.Run("#NewPlatform", func(t *testing.T) {

--- a/platform/launch/platform_test.go
+++ b/platform/launch/platform_test.go
@@ -3,32 +3,28 @@ package launch_test
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/api"
 	platform "github.com/buildpacks/lifecycle/platform/launch"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestPlatform(t *testing.T) {
-	for _, api := range api.Platform.Supported {
-		spec.Run(t, "unit-platform/"+api.String(), testPlatform(api), spec.Parallel(), spec.Report(report.Terminal{}))
-	}
-}
+	t.Parallel()
+	for _, platformAPI := range api.Platform.Supported {
+		platformAPI := platformAPI
+		t.Run("unit-platform/"+platformAPI.String(), func(t *testing.T) {
+			t.Parallel()
+			t.Run("#NewPlatform", func(t *testing.T) {
+				t.Run("configures the platform", func(t *testing.T) {
+					foundPlatform := platform.NewPlatform(platformAPI.String())
 
-func testPlatform(platformAPI *api.Version) func(t *testing.T, when spec.G, it spec.S) {
-	return func(t *testing.T, when spec.G, it spec.S) {
-		when("#NewPlatform", func() {
-			it("configures the platform", func() {
-				foundPlatform := platform.NewPlatform(platformAPI.String())
+					t.Log("with a default exiter")
+					_, ok := foundPlatform.Exiter.(*platform.DefaultExiter)
+					h.AssertEq(t, ok, true)
 
-				t.Log("with a default exiter")
-				_, ok := foundPlatform.Exiter.(*platform.DefaultExiter)
-				h.AssertEq(t, ok, true)
-
-				t.Log("with an api")
-				h.AssertEq(t, foundPlatform.API(), platformAPI)
+					t.Log("with an api")
+					h.AssertEq(t, foundPlatform.API(), platformAPI)
+				})
 			})
 		})
 	}

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -3,32 +3,28 @@ package platform_test
 import (
 	"testing"
 
-	"github.com/sclevine/spec"
-	"github.com/sclevine/spec/report"
-
 	"github.com/buildpacks/lifecycle/api"
 	"github.com/buildpacks/lifecycle/platform"
 	h "github.com/buildpacks/lifecycle/testhelpers"
 )
 
 func TestPlatform(t *testing.T) {
+	t.Parallel()
 	for _, platformAPI := range api.Platform.Supported {
-		spec.Run(t, "unit-platform/"+platformAPI.String(), testPlatform(platformAPI), spec.Parallel(), spec.Report(report.Terminal{}))
-	}
-}
+		platformAPI := platformAPI
+		t.Run("unit-platform/"+platformAPI.String(), func(t *testing.T) {
+			t.Parallel()
+			t.Run("#NewPlatformFor", func(t *testing.T) {
+				t.Run("configures the platform", func(t *testing.T) {
+					foundPlatform := platform.NewPlatformFor(platformAPI.String())
 
-func testPlatform(platformAPI *api.Version) func(t *testing.T, when spec.G, it spec.S) {
-	return func(t *testing.T, when spec.G, it spec.S) {
-		when("#NewPlatformFor", func() {
-			it("configures the platform", func() {
-				foundPlatform := platform.NewPlatformFor(platformAPI.String())
+					t.Log("with a default exiter")
+					_, ok := foundPlatform.Exiter.(*platform.DefaultExiter)
+					h.AssertEq(t, ok, true)
 
-				t.Log("with a default exiter")
-				_, ok := foundPlatform.Exiter.(*platform.DefaultExiter)
-				h.AssertEq(t, ok, true)
-
-				t.Log("with an api")
-				h.AssertEq(t, foundPlatform.API(), platformAPI)
+					t.Log("with an api")
+					h.AssertEq(t, foundPlatform.API(), platformAPI)
+				})
 			})
 		})
 	}

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -11,7 +11,6 @@ import (
 func TestPlatform(t *testing.T) {
 	t.Parallel()
 	for _, platformAPI := range api.Platform.Supported {
-		platformAPI := platformAPI
 		t.Run("unit-platform/"+platformAPI.String(), func(t *testing.T) {
 			t.Parallel()
 			t.Run("#NewPlatformFor", func(t *testing.T) {

--- a/platform/target_data_test.go
+++ b/platform/target_data_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/memory"
-	"github.com/sclevine/spec"
 
 	"github.com/buildpacks/lifecycle/buildpack"
 	"github.com/buildpacks/lifecycle/internal/fsutil"
@@ -18,46 +17,38 @@ import (
 )
 
 func TestTargetData(t *testing.T) {
-	spec.Run(t, "target_data", testTargetData)
-}
-
-func testTargetData(t *testing.T, when spec.G, it spec.S) {
-	when(".TargetSatisfiedForBuild", func() {
+	t.Run(".TargetSatisfiedForBuild", func(t *testing.T) {
 		baseTarget := &files.TargetMetadata{OS: "Win95", Arch: "Pentium"}
 		d := mockDetector{
 			contents: "this is just test contents really",
 			t:        t,
 			HasFile:  false, // by default, don't use info from /etc/os-release for these tests
 		}
-
-		when("base image data", func() {
-			when("has os and arch", func() {
-				when("buildpack data", func() {
-					when("has os and arch", func() {
-						it("must match", func() {
+		t.Run("base image data", func(t *testing.T) {
+			t.Run("has os and arch", func(t *testing.T) {
+				t.Run("buildpack data", func(t *testing.T) {
+					t.Run("has os and arch", func(t *testing.T) {
+						t.Run("must match", func(t *testing.T) {
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch}, &log.Logger{Handler: memory.New()}), true)
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: "Win98", Arch: baseTarget.Arch}, &log.Logger{Handler: memory.New()}), false)
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: "Pentium MMX"}, &log.Logger{Handler: memory.New()}), false)
 						})
 					})
-
-					when("missing os and arch", func() {
-						it("matches", func() {
+					t.Run("missing os and arch", func(t *testing.T) {
+						t.Run("matches", func(t *testing.T) {
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: "", Arch: ""}, &log.Logger{Handler: memory.New()}), true)
 						})
 					})
-
-					when("has distro information", func() {
-						it("does not match", func() {
+					t.Run("has distro information", func(t *testing.T) {
+						t.Run("does not match", func(t *testing.T) {
 							h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{
 								OS:      baseTarget.OS,
 								Arch:    baseTarget.Arch,
 								Distros: []buildpack.OSDistro{{Name: "a", Version: "2"}},
 							}, &log.Logger{Handler: memory.New()}), false)
 						})
-
-						when("/etc/os-release has information", func() {
-							it("must match", func() {
+						t.Run("/etc/os-release has information", func(t *testing.T) {
+							t.Run("must match", func(t *testing.T) {
 								d := mockDetector{
 									contents: "this is just test contents really",
 									t:        t,
@@ -81,39 +72,33 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 				})
-
-				when("has arch variant", func() {
+				t.Run("has arch variant", func(t *testing.T) {
 					baseTarget.ArchVariant = "some-arch-variant"
-
-					when("buildpack data", func() {
-						when("has arch variant", func() {
-							it("must match", func() {
+					t.Run("buildpack data", func(t *testing.T) {
+						t.Run("has arch variant", func(t *testing.T) {
+							t.Run("must match", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, ArchVariant: "some-arch-variant"}, &log.Logger{Handler: memory.New()}), true)
 								h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, ArchVariant: "some-other-arch-variant"}, &log.Logger{Handler: memory.New()}), false)
 							})
 						})
-
-						when("missing arch variant", func() {
-							it("matches", func() {
+						t.Run("missing arch variant", func(t *testing.T) {
+							t.Run("matches", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch}, &log.Logger{Handler: memory.New()}), true)
 							})
 						})
 					})
 				})
-
-				when("has distro information", func() {
+				t.Run("has distro information", func(t *testing.T) {
 					baseTarget.Distro = &files.OSDistro{Name: "A", Version: "1"}
-
-					when("buildpack data", func() {
-						when("has distro information", func() {
-							it("must match", func() {
+					t.Run("buildpack data", func(t *testing.T) {
+						t.Run("has distro information", func(t *testing.T) {
+							t.Run("must match", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, Distros: []buildpack.OSDistro{{Name: "B", Version: "2"}, {Name: "A", Version: "1"}}}, &log.Logger{Handler: memory.New()}), true)
 								h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, Distros: []buildpack.OSDistro{{Name: "g", Version: "2"}, {Name: "B", Version: "2"}}}, &log.Logger{Handler: memory.New()}), false)
 							})
 						})
-
-						when("missing distro information", func() {
-							it("matches", func() {
+						t.Run("missing distro information", func(t *testing.T) {
+							t.Run("matches", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForBuild(&d, baseTarget, buildpack.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch}, &log.Logger{Handler: memory.New()}), true)
 							})
 						})
@@ -122,9 +107,8 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-
-	when(".GetTargetOSFromFileSystem", func() {
-		it("populates appropriately", func() {
+	t.Run(".GetTargetOSFromFileSystem", func(t *testing.T) {
+		t.Run("populates appropriately", func(t *testing.T) {
 			logr := &log.Logger{Handler: memory.New()}
 			tm := files.TargetMetadata{}
 			d := mockDetector{contents: "this is just test contents really",
@@ -136,8 +120,7 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, "opensesame", tm.Distro.Name)
 			h.AssertEq(t, "3.14", tm.Distro.Version)
 		})
-
-		it("doesn't populate if there's no file", func() {
+		t.Run("doesn't populate if there's no file", func(t *testing.T) {
 			logr := &log.Logger{Handler: memory.New()}
 			tm := files.TargetMetadata{}
 			d := mockDetector{contents: "in unit tests 2.0 the users will generate the content but we'll serve them ads",
@@ -146,8 +129,7 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			platform.GetTargetOSFromFileSystem(&d, &tm, logr)
 			h.AssertNil(t, tm.Distro)
 		})
-
-		it("doesn't populate if there's an error reading the file", func() {
+		t.Run("doesn't populate if there's an error reading the file", func(t *testing.T) {
 			logr := &log.Logger{Handler: memory.New()}
 			tm := files.TargetMetadata{}
 			d := mockDetector{contents: "contentment is the greatest wealth",
@@ -159,9 +141,8 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			h.AssertNil(t, tm.Distro)
 		})
 	})
-
-	when(".EnvVarsFor", func() {
-		it("returns the right thing", func() {
+	t.Run(".EnvVarsFor", func(t *testing.T) {
+		t.Run("returns the right thing", func(t *testing.T) {
 			tm := files.TargetMetadata{Arch: "pentium", ArchVariant: "mmx", ID: "my-id", OS: "linux", Distro: &files.OSDistro{Name: "nix", Version: "22.11"}}
 			d := &mockDetector{
 				contents: "this is just test contents really",
@@ -176,8 +157,7 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
 			h.AssertEq(t, len(observed), 5)
 		})
-
-		it("returns the right thing from /etc/os-release", func() {
+		t.Run("returns the right thing from /etc/os-release", func(t *testing.T) {
 			d := &mockDetector{
 				contents: "this is just test contents really",
 				t:        t,
@@ -192,8 +172,7 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
 			h.AssertEq(t, len(observed), 5)
 		})
-
-		it("does not return the wrong thing", func() {
+		t.Run("does not return the wrong thing", func(t *testing.T) {
 			tm := files.TargetMetadata{Arch: "pentium", OS: "linux"}
 			d := &mockDetector{
 				contents: "this is just test contents really",
@@ -205,9 +184,8 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			h.AssertContains(t, observed, "CNB_TARGET_OS="+tm.OS)
 			h.AssertEq(t, len(observed), 2)
 		})
-
-		when("optional vars are empty", func() {
-			it("omits them", func() {
+		t.Run("optional vars are empty", func(t *testing.T) {
+			t.Run("omits them", func(t *testing.T) {
 				tm := files.TargetMetadata{
 					// required
 					OS:   "linux",
@@ -227,22 +205,19 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
-
-	when(".TargetSatisfiedForRebase", func() {
+	t.Run(".TargetSatisfiedForRebase", func(t *testing.T) {
 		var baseTarget files.TargetMetadata
-		when("orig image data", func() {
-			when("has os and arch", func() {
+		t.Run("orig image data", func(t *testing.T) {
+			t.Run("has os and arch", func(t *testing.T) {
 				baseTarget = files.TargetMetadata{OS: "Win95", Arch: "Pentium"}
-
-				when("new image data", func() {
-					it("must match", func() {
+				t.Run("new image data", func(t *testing.T) {
+					t.Run("must match", func(t *testing.T) {
 						h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch}), true)
 						h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: "Win98", Arch: baseTarget.Arch}), false)
 						h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: "Pentium MMX"}), false)
 					})
-
-					when("has extra information", func() {
-						it("matches", func() {
+					t.Run("has extra information", func(t *testing.T) {
+						t.Run("matches", func(t *testing.T) {
 							h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, ArchVariant: "MMX"}), true)
 							h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{
 								OS:     baseTarget.OS,
@@ -252,32 +227,27 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 						})
 					})
 				})
-
-				when("has arch variant", func() {
+				t.Run("has arch variant", func(t *testing.T) {
 					baseTarget.ArchVariant = "some-arch-variant"
-
-					when("new image data", func() {
-						when("has arch variant", func() {
-							it("must match", func() {
+					t.Run("new image data", func(t *testing.T) {
+						t.Run("has arch variant", func(t *testing.T) {
+							t.Run("must match", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, ArchVariant: "some-arch-variant"}), true)
 								h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch, ArchVariant: "some-other-arch-variant"}), false)
 							})
 						})
-
-						when("missing arch variant", func() {
-							it("matches", func() {
+						t.Run("missing arch variant", func(t *testing.T) {
+							t.Run("matches", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch}), true)
 							})
 						})
 					})
 				})
-
-				when("has distro information", func() {
+				t.Run("has distro information", func(t *testing.T) {
 					baseTarget.Distro = &files.OSDistro{Name: "A", Version: "1"}
-
-					when("new image data", func() {
-						when("has distro information", func() {
-							it("must match", func() {
+					t.Run("new image data", func(t *testing.T) {
+						t.Run("has distro information", func(t *testing.T) {
+							t.Run("must match", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{
 									OS:     baseTarget.OS,
 									Arch:   baseTarget.Arch,
@@ -290,9 +260,8 @@ func testTargetData(t *testing.T, when spec.G, it spec.S) {
 								}), false)
 							})
 						})
-
-						when("missing distro information", func() {
-							it("errors", func() {
+						t.Run("missing distro information", func(t *testing.T) {
+							t.Run("errors", func(t *testing.T) {
 								h.AssertEq(t, platform.TargetSatisfiedForRebase(baseTarget, files.TargetMetadata{OS: baseTarget.OS, Arch: baseTarget.Arch}), false)
 							})
 						})

--- a/tools/spec-migrate/main.go
+++ b/tools/spec-migrate/main.go
@@ -1,0 +1,577 @@
+// spec-migrate rewrites test files that use github.com/sclevine/spec into
+// idiomatic native Go subtests using t.Run and t.Cleanup.
+//
+// It handles the mechanical transformations described in the "Migrate Test
+// Framework from sclevine/spec" RFC:
+//
+//   - Removes imports of github.com/sclevine/spec and .../spec/report.
+//   - Rewrites `spec.Run(t, "Name", testX, spec.Report(...))` (called from a
+//     TestX function that immediately delegates) into inlined subtests.
+//   - Converts `when("desc", func() { ... })` and `it("desc", func() { ... })`
+//     to `t.Run("desc", func(t *testing.T) { ... })`.
+//   - Converts `it.After(func() { ... })` to `t.Cleanup(func() { ... })`.
+//   - Adds `t.Parallel()` at the top of the test function when `spec.Parallel()`
+//     was present on the spec.Run call.
+//
+// It DOES NOT attempt to convert `it.Before` blocks: those require human
+// judgment about whether the enclosed subtests mutate shared state (see
+// Option A vs. Option B in the RFC). Files containing `it.Before` are
+// reported and left untouched unless --allow-before is passed.
+//
+// Usage:
+//
+//	go run ./tools/spec-migrate [flags] <file-or-package-path>...
+//
+// Flags:
+//
+//	-w        Write results back to source files (default: print diff to stdout).
+//	-dry-run  Report what would be done without writing changes.
+//	-allow-before  Convert files even when they contain it.Before (best-effort).
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	specPkgPath   = "github.com/sclevine/spec"
+	reportPkgPath = "github.com/sclevine/spec/report"
+)
+
+type options struct {
+	write        bool
+	dryRun       bool
+	allowBefore  bool
+	writtenFiles []string
+	skipped      []string
+	unchanged    []string
+	errors       []string
+}
+
+func main() {
+	var opts options
+	flag.BoolVar(&opts.write, "w", false, "write results back to source files")
+	flag.BoolVar(&opts.dryRun, "dry-run", false, "report actions without writing")
+	flag.BoolVar(&opts.allowBefore, "allow-before", false, "convert files with it.Before (best-effort; may leave TODOs)")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: spec-migrate [flags] <path>...\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	for _, arg := range flag.Args() {
+		if err := opts.processPath(arg); err != nil {
+			opts.errors = append(opts.errors, fmt.Sprintf("%s: %v", arg, err))
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\n=== summary ===\n")
+	fmt.Fprintf(os.Stderr, "converted: %d file(s)\n", len(opts.writtenFiles))
+	for _, f := range opts.writtenFiles {
+		fmt.Fprintf(os.Stderr, "  %s\n", f)
+	}
+	fmt.Fprintf(os.Stderr, "skipped (it.Before / non-mechanical): %d\n", len(opts.skipped))
+	for _, f := range opts.skipped {
+		fmt.Fprintf(os.Stderr, "  %s\n", f)
+	}
+	if len(opts.unchanged) > 0 {
+		fmt.Fprintf(os.Stderr, "no spec usage: %d\n", len(opts.unchanged))
+	}
+	if len(opts.errors) > 0 {
+		fmt.Fprintf(os.Stderr, "errors: %d\n", len(opts.errors))
+		for _, e := range opts.errors {
+			fmt.Fprintf(os.Stderr, "  %s\n", e)
+		}
+		os.Exit(1)
+	}
+}
+
+func (o *options) processPath(root string) error {
+	info, err := os.Stat(root)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return o.processFile(root)
+	}
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		return o.processFile(path)
+	})
+}
+
+func (o *options) processFile(path string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if !bytes.Contains(src, []byte(specPkgPath)) {
+		o.unchanged = append(o.unchanged, path)
+		return nil
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parse: %w", err)
+	}
+
+	hasBefore := containsIdent(file, "it", "Before")
+	if hasBefore && !o.allowBefore {
+		o.skipped = append(o.skipped, path)
+		return nil
+	}
+
+	changed, err := transformFile(fset, file)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		o.unchanged = append(o.unchanged, path)
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, file); err != nil {
+		return fmt.Errorf("format: %w", err)
+	}
+	out := buf.Bytes()
+
+	if o.write {
+		if err := os.WriteFile(path, out, 0o644); err != nil {
+			return err
+		}
+		o.writtenFiles = append(o.writtenFiles, path)
+	} else if o.dryRun {
+		o.writtenFiles = append(o.writtenFiles, path)
+	} else {
+		fmt.Printf("=== %s ===\n%s\n", path, out)
+		o.writtenFiles = append(o.writtenFiles, path)
+	}
+	return nil
+}
+
+// containsIdent reports whether pkg.name is referenced anywhere in the file
+// as a selector expression (e.g., it.Before).
+func containsIdent(file *ast.File, pkg, name string) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		x, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if x.Name == pkg && sel.Sel.Name == name {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// transformFile mutates file in place and returns true if anything changed.
+func transformFile(fset *token.FileSet, file *ast.File) (bool, error) {
+	changed := false
+
+	// 1. Remove imports of sclevine/spec and sclevine/spec/report.
+	newImports := file.Imports[:0]
+	newDecls := file.Decls[:0]
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.IMPORT {
+			newDecls = append(newDecls, decl)
+			continue
+		}
+		specs := gd.Specs[:0]
+		for _, s := range gd.Specs {
+			is := s.(*ast.ImportSpec)
+			path := strings.Trim(is.Path.Value, `"`)
+			if path == specPkgPath || path == reportPkgPath {
+				changed = true
+				continue
+			}
+			specs = append(specs, s)
+		}
+		gd.Specs = specs
+		if len(specs) > 0 {
+			newDecls = append(newDecls, gd)
+		} else {
+			changed = true
+		}
+	}
+	file.Decls = newDecls
+
+	for _, imp := range file.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path == specPkgPath || path == reportPkgPath {
+			continue
+		}
+		newImports = append(newImports, imp)
+	}
+	file.Imports = newImports
+
+	// 2. Find pairs of (TestX func that calls spec.Run, testX func with (t, when, it)).
+	//    Merge them into a single native TestX(t *testing.T).
+	testFns := map[string]*ast.FuncDecl{}
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		testFns[fd.Name.Name] = fd
+	}
+
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if !isTestFunc(fd) {
+			continue
+		}
+		specRunIdx, specRun := findSpecRunStmt(fd)
+		if specRun == nil {
+			continue
+		}
+		if len(specRun.Args) < 3 {
+			return false, fmt.Errorf("%s: unexpected spec.Run signature", posOf(fset, specRun))
+		}
+		bodyFnName, ok := identOf(specRun.Args[2])
+		if !ok {
+			// Not a simple identifier reference (e.g., testPlatform(api)); leave alone.
+			continue
+		}
+		bodyFn, ok := testFns[bodyFnName]
+		if !ok {
+			continue
+		}
+		parallel := hasSpecOption(specRun.Args[3:], "Parallel")
+
+		// Rewrite the body of bodyFn.
+		if err := rewriteSpecBody(bodyFn); err != nil {
+			return false, err
+		}
+
+		// Splice the rewritten body in place of the spec.Run statement so any
+		// pre-setup or post-cleanup around spec.Run is preserved.
+		prefix := append([]ast.Stmt(nil), fd.Body.List[:specRunIdx]...)
+		suffix := append([]ast.Stmt(nil), fd.Body.List[specRunIdx+1:]...)
+		var replacement []ast.Stmt
+		if parallel {
+			replacement = append(replacement, tParallelStmt())
+		}
+		replacement = append(replacement, bodyFn.Body.List...)
+		fd.Body.List = append(append(prefix, replacement...), suffix...)
+		removeFuncDecl(file, bodyFn)
+		changed = true
+	}
+
+	// 3. Recursively convert any remaining when/it/it.After calls in the file
+	//    (covers files where spec.Run wraps something more elaborate).
+	ast.Inspect(file, func(n ast.Node) bool {
+		bs, ok := n.(*ast.BlockStmt)
+		if !ok {
+			return true
+		}
+		for i, stmt := range bs.List {
+			bs.List[i] = convertStmt(stmt)
+		}
+		return true
+	})
+
+	return changed, nil
+}
+
+func isTestFunc(fd *ast.FuncDecl) bool {
+	if fd.Recv != nil {
+		return false
+	}
+	if !strings.HasPrefix(fd.Name.Name, "Test") {
+		return false
+	}
+	if fd.Type.Params == nil || len(fd.Type.Params.List) != 1 {
+		return false
+	}
+	return true
+}
+
+func findSpecRunStmt(fd *ast.FuncDecl) (int, *ast.CallExpr) {
+	if fd.Body == nil {
+		return -1, nil
+	}
+	for i, stmt := range fd.Body.List {
+		es, ok := stmt.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		call, ok := es.X.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		if isSelectorCall(call, "spec", "Run") {
+			return i, call
+		}
+	}
+	return -1, nil
+}
+
+func isSelectorCall(call *ast.CallExpr, pkg, name string) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return id.Name == pkg && sel.Sel.Name == name
+}
+
+func identOf(e ast.Expr) (string, bool) {
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return id.Name, true
+}
+
+func hasSpecOption(args []ast.Expr, name string) bool {
+	for _, a := range args {
+		call, ok := a.(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		if isSelectorCall(call, "spec", name) {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFuncDecl(file *ast.File, target *ast.FuncDecl) {
+	out := file.Decls[:0]
+	for _, d := range file.Decls {
+		if d == target {
+			continue
+		}
+		out = append(out, d)
+	}
+	file.Decls = out
+}
+
+// rewriteSpecBody rewrites a func(t, when spec.G, it spec.S) so that:
+//   - its parameter list becomes (t *testing.T),
+//   - the body's when()/it()/it.After() calls are converted.
+func rewriteSpecBody(fd *ast.FuncDecl) error {
+	if fd.Type == nil || fd.Type.Params == nil {
+		return nil
+	}
+	// Force signature to (t *testing.T).
+	fd.Type.Params.List = []*ast.Field{
+		{
+			Names: []*ast.Ident{ast.NewIdent("t")},
+			Type: &ast.StarExpr{X: &ast.SelectorExpr{
+				X:   ast.NewIdent("testing"),
+				Sel: ast.NewIdent("T"),
+			}},
+		},
+	}
+	if fd.Body != nil {
+		for i, s := range fd.Body.List {
+			fd.Body.List[i] = convertStmt(s)
+		}
+	}
+	return nil
+}
+
+// convertStmt walks a statement and converts recognized when/it/it.After
+// call expressions to their native Go equivalents.
+func convertStmt(stmt ast.Stmt) ast.Stmt {
+	if stmt == nil {
+		return stmt
+	}
+	// Handle ExprStmt: when(...), it(...), it.After(...), it.Focus(...), etc.
+	if es, ok := stmt.(*ast.ExprStmt); ok {
+		if call, ok := es.X.(*ast.CallExpr); ok {
+			if newCall, ok := convertCall(call); ok {
+				es.X = newCall
+			}
+		}
+	}
+	// Recurse into nested blocks.
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		bs, ok := n.(*ast.BlockStmt)
+		if !ok {
+			return true
+		}
+		for i, s := range bs.List {
+			bs.List[i] = convertInner(s)
+		}
+		return true
+	})
+	return stmt
+}
+
+func convertInner(stmt ast.Stmt) ast.Stmt {
+	if stmt == nil {
+		return stmt
+	}
+	if es, ok := stmt.(*ast.ExprStmt); ok {
+		if call, ok := es.X.(*ast.CallExpr); ok {
+			if newCall, ok := convertCall(call); ok {
+				es.X = newCall
+			}
+		}
+	}
+	return stmt
+}
+
+// convertCall rewrites one of:
+//
+//	when("desc", func() { ... })       -> t.Run("desc", func(t *testing.T) { ... })
+//	it("desc", func() { ... })         -> t.Run("desc", func(t *testing.T) { ... })
+//	it.After(func() { ... })           -> t.Cleanup(func() { ... })
+//	it.Focus("desc", func() { ... })   -> t.Run("desc", func(t *testing.T) { ... })
+//
+// It returns the new expression and true if a rewrite happened.
+func convertCall(call *ast.CallExpr) (ast.Expr, bool) {
+	// Detect when(...) or it(...).
+	if id, ok := call.Fun.(*ast.Ident); ok {
+		switch id.Name {
+		case "when", "it":
+			return toTRun(call), true
+		}
+	}
+	// Detect it.After / it.Focus / it.Pend etc.
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+		x, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return call, false
+		}
+		if x.Name != "it" && x.Name != "when" {
+			return call, false
+		}
+		switch sel.Sel.Name {
+		case "After":
+			return toTCleanup(call), true
+		case "Before":
+			// Left for humans; converters may leave this in and mark it.
+			return call, false
+		case "Focus", "Pend":
+			return toTRun(call), true
+		}
+	}
+	return call, false
+}
+
+// toTRun rewrites `X("desc", func() { ... })` to
+// `t.Run("desc", func(t *testing.T) { ... })`. The inner function body is
+// also walked so nested calls get converted.
+func toTRun(call *ast.CallExpr) *ast.CallExpr {
+	if len(call.Args) < 2 {
+		return call
+	}
+	fnLit, ok := call.Args[len(call.Args)-1].(*ast.FuncLit)
+	if !ok {
+		return call
+	}
+	replaceFuncLitParamsWithT(fnLit)
+	// Walk body to convert nested when/it/it.After calls.
+	if fnLit.Body != nil {
+		for i, s := range fnLit.Body.List {
+			fnLit.Body.List[i] = convertInner(s)
+		}
+	}
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   ast.NewIdent("t"),
+			Sel: ast.NewIdent("Run"),
+		},
+		Args: []ast.Expr{call.Args[0], fnLit},
+	}
+}
+
+// toTCleanup rewrites `it.After(func() { ... })` to
+// `t.Cleanup(func() { ... })`. The func literal parameter list stays empty.
+func toTCleanup(call *ast.CallExpr) *ast.CallExpr {
+	if len(call.Args) < 1 {
+		return call
+	}
+	fnLit, ok := call.Args[0].(*ast.FuncLit)
+	if !ok {
+		return call
+	}
+	// Cleanup takes func(), so leave the parameter list empty.
+	if fnLit.Type != nil {
+		fnLit.Type.Params = &ast.FieldList{}
+	}
+	if fnLit.Body != nil {
+		for i, s := range fnLit.Body.List {
+			fnLit.Body.List[i] = convertInner(s)
+		}
+	}
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   ast.NewIdent("t"),
+			Sel: ast.NewIdent("Cleanup"),
+		},
+		Args: []ast.Expr{fnLit},
+	}
+}
+
+func replaceFuncLitParamsWithT(fn *ast.FuncLit) {
+	if fn.Type == nil {
+		return
+	}
+	fn.Type.Params = &ast.FieldList{List: []*ast.Field{
+		{
+			Names: []*ast.Ident{ast.NewIdent("t")},
+			Type: &ast.StarExpr{X: &ast.SelectorExpr{
+				X:   ast.NewIdent("testing"),
+				Sel: ast.NewIdent("T"),
+			}},
+		},
+	}}
+}
+
+func tParallelStmt() ast.Stmt {
+	return &ast.ExprStmt{X: &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   ast.NewIdent("t"),
+			Sel: ast.NewIdent("Parallel"),
+		},
+	}}
+}
+
+func posOf(fset *token.FileSet, n ast.Node) string {
+	return fset.Position(n.Pos()).String()
+}

--- a/tools/spec-migrate/main.go
+++ b/tools/spec-migrate/main.go
@@ -124,7 +124,7 @@ func (o *options) processPath(root string) error {
 }
 
 func (o *options) processFile(path string) error {
-	src, err := os.ReadFile(path)
+	src, err := os.ReadFile(path) // #nosec G304 -- tool intentionally reads paths from CLI args
 	if err != nil {
 		return err
 	}
@@ -160,17 +160,16 @@ func (o *options) processFile(path string) error {
 	}
 	out := buf.Bytes()
 
-	if o.write {
-		if err := os.WriteFile(path, out, 0o644); err != nil {
+	switch {
+	case o.write:
+		if err := os.WriteFile(path, out, 0o600); err != nil {
 			return err
 		}
-		o.writtenFiles = append(o.writtenFiles, path)
-	} else if o.dryRun {
-		o.writtenFiles = append(o.writtenFiles, path)
-	} else {
+	case o.dryRun:
+	default:
 		fmt.Printf("=== %s ===\n%s\n", path, out)
-		o.writtenFiles = append(o.writtenFiles, path)
 	}
+	o.writtenFiles = append(o.writtenFiles, path)
 	return nil
 }
 


### PR DESCRIPTION
Phase 1 of the sclevine/spec migration RFC. Adds an AST-based transformation tool at tools/spec-migrate and applies it to the files that can be converted mechanically (i.e. no it.Before blocks). Files using it.Before remain on sclevine/spec until human-judgment conversion in later phases; sclevine/spec stays in go.mod for now.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
<!-- Please describe your changes at a high level. -->



#### Release notes
<!-- Please provide 1-2 sentences for release notes. -->
<!-- Example: When using platform API `0.7` or greater, the `creator` logs the expected phase header for the analyze phase -->



---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
<!-- Add any other context that may help reviewers (e.g., code that requires special attention, etc.). -->

