### PR TITLE
chore: bump go to 1.26.5

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -83,8 +83,8 @@
 #          script: |
 #            apt-get update -y
 #            apt-get install -y wget curl git make gcc jq docker.io
-#            wget https://go.dev/dl/go1.26.4.linux-s390x.tar.gz
-#            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.4.linux-s390x.tar.gz
+#            wget https://go.dev/dl/go1.26.5.linux-s390x.tar.gz
+#            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.5.linux-s390x.tar.gz
 #            export PATH=$PATH:/usr/local/go/bin
 #            git clone ${GH_REPOSITORY} lifecycle
 #            cd lifecycle && git checkout ${GH_REF}

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 as builder
+FROM golang:1.26.5 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/go.mod
+++ b/go.mod
@@ -318,4 +318,4 @@ tool github.com/golang/mock/mockgen
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-go 1.26.4
+go 1.26.5


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` from `1.26.4` to `1.26.5`, plus the two other places the previous go bump (917d755e) touched:

- `go.mod` — `go` directive
- `acceptance/testdata/launcher/Dockerfile` — `FROM golang:1.26.5`
- `.github/workflows/test-s390x.yml` — commented toolchain download

CI installs the toolchain from `go.mod` via `actions/setup-go` (`go-version-file`), so bumping the directive is what moves CI to the newer toolchain.

### Why: clears grype findings

Grype run against the **built image** (as CI's `anchore/scan-action` does), not the source tree:

**Before (main, go1.26.4):**
| Package | Vuln | Severity | Fixed in |
| --- | --- | --- | --- |
| stdlib | GO-2026-4970 | High | 1.26.5 |
| stdlib | GO-2026-5856 | Medium | 1.26.5 |
| golang.org/x/crypto (openpgp) | GO-2026-5932 | Unknown | no fix (won't-fix) |

**After (this branch):** both stdlib findings gone. Only GO-2026-5932 remains — the `x/crypto/openpgp` "unsafe by design" advisory, which has no fix and is a transitive-only dependency.