### PR TITLE
Guard the empty command case in Process.WithPlatformAPI

### DIFF
--- a/launch/launch.go
+++ b/launch/launch.go
@@ -40,7 +40,7 @@ func (p Process) WithPlatformAPI(platformAPI *api.Version) Process {
 	// for platform versions < 0.10
 	// we only support a single command
 	// push any extra entries into the args so they aren't lost
-	if p.PlatformAPI.LessThan("0.10") {
+	if p.PlatformAPI.LessThan("0.10") && len(p.Command.Entries) > 0 {
 		p.Args = append(p.Command.Entries[1:], p.Args[0:]...)
 		p.Command.Entries = []string{p.Command.Entries[0]}
 	}

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -90,6 +90,20 @@ working-dir = "some-working-directory"
 					h.AssertEq(t, string(bytes), expected)
 				})
 
+				it("handles an empty command", func() {
+					// a buildpack can emit [[processes]] with command = [], and
+					// collapsing the entries used to slice an empty slice
+					process := launch.Process{
+						Type:        "some-type",
+						Command:     launch.NewRawCommand([]string{}),
+						Args:        []string{"some-arg"},
+						BuildpackID: "some-buildpack-id",
+					}.WithPlatformAPI(api.MustParse("0.9"))
+
+					h.AssertEq(t, len(process.Command.Entries), 0)
+					h.AssertEq(t, process.Args, []string{"some-arg"})
+				})
+
 				it("handles special characters", func() {
 					process := launch.Process{
 						Type:        "some-type",


### PR DESCRIPTION
For platform API below 0.10 only a single command is supported, so `WithPlatformAPI` folds the remaining entries into the args:

```go
if p.PlatformAPI.LessThan("0.10") {
    p.Args = append(p.Command.Entries[1:], p.Args[0:]...)
    p.Command.Entries = []string{p.Command.Entries[0]}
}
```

Both lines assume at least one entry. With an empty command they panic:

```
panic: runtime error: slice bounds out of range [1:0]
```

A buildpack can produce that. Under buildpack API 0.9 and later the command is decoded as an array, so `[[processes]]` with `command = []` in launch.toml gives `Command.Entries` of length zero, and I could not find anything that rejects it on the way in. The build phase then calls `WithPlatformAPI` on every process through `processMap.list`, so a buildpack emitting an empty command crashes the lifecycle rather than getting a clean validation error. Platform APIs 0.7 through 0.9 are still supported and non-deprecated, so the combination is a current one.

This adds a length check to the condition. An empty command stays empty and the args are left alone.

Worth flagging separately: `RawCommand.MarshalTOML` and `MarshalJSON` also index `Entries[0]`, and the launcher makes the same assumption. Those felt like a different change to me, since the right answer there is probably rejecting an empty command during launch.toml validation rather than adding more guards, so I left them alone. Happy to take that on if you would like it in the same PR.

Test added to the existing platform API < 0.10 group in launch_test.go: it panics on main with the slice bounds error above and passes with the change. `go test ./launch/ ./phase/...` is green.