### PR TITLE
Improve detection failure guidance for buildpack order

### DIFF
--- a/phase/detector.go
+++ b/phase/detector.go
@@ -405,6 +405,7 @@ func (r *DefaultDetectResolver) Resolve(done []buildpack.GroupElement, detectRun
 		return r.runTrial(i, trial)
 	})
 	if err != nil {
+		r.Logger.Debug("check the provided order to ensure that buildpacks providing dependencies run before the buildpacks that require them")
 		return nil, nil, err
 	}
 

--- a/phase/detector_test.go
+++ b/phase/detector_test.go
@@ -1443,7 +1443,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"pass: B@v1\n"+
 					"pass: C@v1\n"+
 					"Resolving plan... (try #1)\n"+
-					"fail: B@v1 requires dep1\n",
+					"fail: B@v1 requires dep1\n"+
+					"check the provided order to ensure that buildpacks providing dependencies run before the buildpacks that require them\n",
 			) {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}
@@ -1500,7 +1501,8 @@ func testDetector(t *testing.T, when spec.G, it spec.S) {
 					"pass: B@v1\n"+
 					"skip: C@v1\n"+
 					"Resolving plan... (try #1)\n"+
-					"fail: B@v1 provides unused dep1\n",
+					"fail: B@v1 provides unused dep1\n"+
+					"check the provided order to ensure that buildpacks providing dependencies run before the buildpacks that require them\n",
 			) {
 				t.Fatalf("Unexpected log:\n%s\n", s)
 			}


### PR DESCRIPTION
## Summary

- append a generic buildpack-order hint after all build-plan alternatives fail
- preserve the existing per-buildpack failure details and returned error
- cover both an unmet early requirement and an unused later provide

Fixes #1366

## Why

A group can contain passing buildpacks but still fail plan resolution when a provider runs after a buildpack that requires it. The existing diagnostics identify the unmet dependency but do not point users toward checking the supplied order. This adds the generic guidance proposed in the issue without attempting a detailed dependency-graph diagnosis.

## Validation

- `GOPROXY=off go test ./phase -run TestDetector -count=1`
- `GOPROXY=off go test ./phase -count=1`
- `go vet ./phase`
- `gofmt`, `git diff --check`, and `git show --check`
- independent adversarial review of the two-file diff

A broader `go test ./...` attempt reached Docker-dependent acceptance suites and failed on local registry access and container filesystem capacity. The changed `phase` package remained green. The locally installed `golangci-lint` was built with Go 1.24 and cannot load this repository target of Go 1.26.5, so the pull-request workflow will provide the authoritative lint result.

## AI assistance

OpenAI Codex assisted with source inspection, test design, implementation, and automated review. This pull request remains a draft pending the contributor personal review; the contributor retains responsibility for the final submission.