### PR TITLE
fix: exit with analyze-phase code on registry access failure

### DIFF
--- a/cmd/lifecycle/analyzer.go
+++ b/cmd/lifecycle/analyzer.go
@@ -109,7 +109,7 @@ func (a *analyzeCmd) Exec() error {
 	)
 	analyzer, err := factory.NewAnalyzer(a.Inputs(), cmd.DefaultLogger)
 	if err != nil {
-		return unwrapErrorFailWithMessage(err, "initialize analyzer")
+		return unwrapErrorFailWithCode(err, a.CodeFor(platform.AnalyzeError), "initialize analyzer")
 	}
 	analyzedMD, err := analyzer.Analyze()
 	if err != nil {

--- a/cmd/lifecycle/creator.go
+++ b/cmd/lifecycle/creator.go
@@ -134,11 +134,11 @@ func (c *createCmd) Exec() error {
 	)
 	analyzer, err := analyzerFactory.NewAnalyzer(c.Inputs(), cmd.DefaultLogger)
 	if err != nil {
-		return unwrapErrorFailWithMessage(err, "initialize analyzer")
+		return unwrapErrorFailWithCode(err, c.CodeFor(platform.AnalyzeError), "initialize analyzer")
 	}
 	analyzedMD, err = analyzer.Analyze()
 	if err != nil {
-		return err
+		return cmd.FailErrCode(err, c.CodeFor(platform.AnalyzeError), "analyze")
 	}
 	if err := files.Handler.WriteAnalyzed(c.AnalyzedPath, &analyzedMD, cmd.DefaultLogger); err != nil {
 		return err

--- a/cmd/lifecycle/detector.go
+++ b/cmd/lifecycle/detector.go
@@ -118,11 +118,17 @@ func (d *detectCmd) Exec() error {
 }
 
 func unwrapErrorFailWithMessage(err error, msg string) error {
+	return unwrapErrorFailWithCode(err, cmd.CodeForFailed, msg)
+}
+
+// unwrapErrorFailWithCode returns err unchanged if it is already a *cmd.ErrorFail (preserving its exit code),
+// otherwise wraps it as a failure with the given fallback exit code.
+func unwrapErrorFailWithCode(err error, code int, msg string) error {
 	errorFail, ok := err.(*cmd.ErrorFail)
 	if ok {
 		return errorFail
 	}
-	return cmd.FailErr(err, msg)
+	return cmd.FailErrCode(err, code, msg)
 }
 
 func (d *detectCmd) unwrapGenerateFail(err error) error {

--- a/cmd/lifecycle/detector_test.go
+++ b/cmd/lifecycle/detector_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+
+	"github.com/buildpacks/lifecycle/cmd"
+	"github.com/buildpacks/lifecycle/platform"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+func TestUnwrapErrorFailWithCode(t *testing.T) {
+	spec.Run(t, "unwrapErrorFailWithCode", testUnwrapErrorFailWithCode, spec.Report(report.Terminal{}))
+}
+
+func testUnwrapErrorFailWithCode(t *testing.T, when spec.G, it spec.S) {
+	when("err is a plain error", func() {
+		it("wraps it with the provided fallback exit code, instead of always using the generic failure code", func() {
+			// simulates the error returned when registry read access validation fails during analyzer initialization,
+			// as reported in https://github.com/buildpacks/lifecycle/issues/1572
+			registryErr := errors.New("validating registry read access: failed to ensure registry read access to some-image: DENIED")
+			analyzeErrorCode := platform.NewExiter("0.99").CodeFor(platform.AnalyzeError)
+
+			// prior to the fix, initialize-analyzer failures always went through unwrapErrorFailWithMessage,
+			// which hard-codes cmd.CodeForFailed regardless of which phase produced the error
+			generic := unwrapErrorFailWithMessage(registryErr, "initialize analyzer")
+			h.AssertEq(t, generic.(*cmd.ErrorFail).Code, cmd.CodeForFailed)
+
+			// the fix routes the same error through unwrapErrorFailWithCode with the analyze phase's exit code (30-39 range),
+			// instead of the generic exit code 1
+			fixed := unwrapErrorFailWithCode(registryErr, analyzeErrorCode, "initialize analyzer")
+			failErr, ok := fixed.(*cmd.ErrorFail)
+			if !ok {
+				t.Fatalf("expected an error of type *cmd.ErrorFail")
+			}
+			h.AssertEq(t, failErr.Code, analyzeErrorCode)
+			h.AssertError(t, fixed, "failed to initialize analyzer: "+registryErr.Error())
+		})
+	})
+
+	when("err is already a *cmd.ErrorFail", func() {
+		it("preserves the original exit code instead of the fallback", func() {
+			original := cmd.FailErrCode(errors.New("some failure"), cmd.CodeForInvalidArgs, "resolve inputs")
+
+			err := unwrapErrorFailWithCode(original, platform.NewExiter("0.99").CodeFor(platform.AnalyzeError), "initialize analyzer")
+
+			failErr, ok := err.(*cmd.ErrorFail)
+			if !ok {
+				t.Fatalf("expected an error of type *cmd.ErrorFail")
+			}
+			h.AssertEq(t, failErr.Code, cmd.CodeForInvalidArgs)
+		})
+	})
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary
When the `analyzer` or `creator` binary fails to initialize the analyzer (for example, because registry read/write access validation fails), it exits with the generic exit code `1` instead of a code in the documented analyze-phase range (30-39). This happens because the initialization-failure path used a helper that always falls back to the generic failure code, while the sibling `Analyze()` failure path in the same command already used the correct analyze-phase code. `creator`'s `Analyze()` failure path had the same problem, but worse: it returned the raw error with no exit-code wrapping at all.

This change gives the initialization-failure path (and, for `creator`, the `Analyze()` failure path) the same analyze-phase exit code (32) that the standalone `analyzer` command already produces for `Analyze()` failures, so a registry access failure now reliably exits in the 30-39 range regardless of which binary triggers it or which step inside the analyze phase it comes from.

#### Release notes
When registry read/write access validation fails during the analyze phase, the `analyzer` and `creator` binaries now exit with a code in the documented 30-39 analyze-phase range instead of the generic exit code 1.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #___

---

### Context
Approach:
- Added `unwrapErrorFailWithCode(err, code, msg)` in `cmd/lifecycle/detector.go`, a variant of the existing `unwrapErrorFailWithMessage` that takes an explicit fallback exit code instead of always defaulting to `cmd.CodeForFailed` (1). `unwrapErrorFailWithMessage` now delegates to it, so its other call sites (detect/generate/extend initialization) are unchanged.
- `cmd/lifecycle/analyzer.go` and `cmd/lifecycle/creator.go` now pass `platform.AnalyzeError`'s code (32) when `NewAnalyzer` fails, instead of the generic fallback.
- `cmd/lifecycle/creator.go`'s `analyzer.Analyze()` failure, previously returned completely unwrapped (defaulting to exit code 1 with no "failed to analyze:" context), is now wrapped the same way the standalone `analyzer` command already wraps it.
- Scope is intentionally limited to the analyze phase, since that's what was reported; the other `unwrapErrorFailWithMessage` call sites (detect, generate, extend) have the same generic-fallback shape but weren't reported as broken, and the new `unwrapErrorFailWithCode` helper makes fixing them the same way a small follow-up if desired.

Validation:
- `go build ./...` passed.
- `go test ./cmd/...` passed.
- Added `cmd/lifecycle/detector_test.go` with a unit test that simulates the exact registry-access error from the report and asserts that `unwrapErrorFailWithMessage` (the old path) yields the generic code `1`, while `unwrapErrorFailWithCode` with the analyze-phase code (the new path used by `analyzer.go`/`creator.go`) yields code `32`; a second case asserts an already-coded `*cmd.ErrorFail` keeps its own code. Ran via `go test ./cmd/lifecycle/... -run TestUnwrapErrorFailWithCode -v`; both subtests pass.
- This is a pure exit-code mapping bug that is fully provable in a unit test; per DEVELOPMENT.md, this repo's docker-dependent acceptance suite is for a different class of test (image/registry integration) and isn't required to validate this change.

Report: https://github.com/buildpacks/lifecycle/issues/1572

Fixes #1572