### PR TITLE
Add regression test for podman API version negotiation

### DIFF
--- a/priv/docker_test.go
+++ b/priv/docker_test.go
@@ -18,7 +18,7 @@ import (
 // breaking compatibility with all released versions of podman (which top out at v1.41).
 func TestDockerClient_SupportsOlderAPIVersions(t *testing.T) {
 	// podman (as of v5.7) reports API version 1.41 on ping.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Api-Version", "1.41")
 		w.Header().Set("Docker-Experimental", "false")
 		w.Header().Set("Ostype", "linux")

--- a/priv/docker_test.go
+++ b/priv/docker_test.go
@@ -1,0 +1,37 @@
+package priv_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moby/moby/client"
+
+	"github.com/buildpacks/lifecycle/priv"
+	h "github.com/buildpacks/lifecycle/testhelpers"
+)
+
+// TestDockerClient_SupportsOlderAPIVersions is a regression test for
+// https://github.com/buildpacks/lifecycle/issues/1607, where a dependency bump
+// implicitly raised the minimum supported Docker Engine API version to v1.44,
+// breaking compatibility with all released versions of podman (which top out at v1.41).
+func TestDockerClient_SupportsOlderAPIVersions(t *testing.T) {
+	// podman (as of v5.7) reports API version 1.41 on ping.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Api-Version", "1.41")
+		w.Header().Set("Docker-Experimental", "false")
+		w.Header().Set("Ostype", "linux")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("DOCKER_HOST", server.URL)
+
+	cli, err := priv.DockerClient()
+	h.AssertNil(t, err)
+
+	result, err := cli.Ping(context.Background(), client.PingOptions{NegotiateAPIVersion: true})
+	h.AssertNil(t, err)
+	h.AssertEq(t, result.APIVersion, "1.41")
+}


### PR DESCRIPTION
Resolves #1607

### Summary
Adds a regression test (`priv/docker_test.go`) that guards against a repeat of the podman compatibility break reported in #1607: a dependency bump had implicitly raised the minimum Docker Engine API version required by `priv.DockerClient()` from 1.40 to 1.44, causing negotiation failures against podman (which reports API version 1.41 at most). The incompatibility was already fixed on `main` by a later, unrelated bump of `github.com/moby/moby/client` (v0.2.2 → v0.4.1, which lowered `MinAPIVersion` back to "1.40"), so this PR makes no production code changes — it only adds test coverage so a future dependency bump can't silently reintroduce the regression without failing CI.

The new test spins up an `httptest.Server` mocking Docker's `/_ping` endpoint reporting `Api-Version: 1.41` (podman's version), points `DOCKER_HOST` at it, constructs a client via the production `priv.DockerClient()` constructor, and asserts that `Ping(..., PingOptions{NegotiateAPIVersion: true})` succeeds and negotiates down to API version 1.41. It was verified to fail against the old `github.com/moby/moby/client` v0.2.2 pin (reproducing the exact error from the issue) and to pass against the current, unmodified `go.mod`/`go.sum`.

#### Release notes
Add a regression test ensuring `priv.DockerClient()` continues to negotiate successfully with podman's Docker API version (1.41), preventing future dependency bumps from silently reintroducing the incompatibility fixed after v0.21.2.

---

### Related

Resolves #1607

---

### Context
This PR is test-only; no production code is changed. The `moby/moby/client` dependency was already bumped to v0.4.1 on `main` for unrelated reasons, which coincidentally restored `MinAPIVersion` to "1.40" and resolved the podman incompatibility. Reviewers may want to confirm the test would have caught the original regression: temporarily pinning `github.com/moby/moby/client` back to v0.2.2 via a `replace` directive and running `go test ./priv/... -run TestDockerClient` reproduces the exact "API version 1.41 is not supported... minimum supported API version is 1.44" error from the issue.

---
AI assistance: this change was drafted with Claude Code.