### PR TITLE
Bump go directive to 1.26.6 to fix stdlib CVEs from grype scan

### DIFF
--- a/.github/workflows/test-s390x.yml
+++ b/.github/workflows/test-s390x.yml
@@ -83,8 +83,8 @@
 #          script: |
 #            apt-get update -y
 #            apt-get install -y wget curl git make gcc jq docker.io
-#            wget https://go.dev/dl/go1.26.5.linux-s390x.tar.gz
-#            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.5.linux-s390x.tar.gz
+#            wget https://go.dev/dl/go1.26.6.linux-s390x.tar.gz
+#            rm -rf /usr/local/go && tar -C /usr/local -xzf go1.26.6.linux-s390x.tar.gz
 #            export PATH=$PATH:/usr/local/go/bin
 #            git clone ${GH_REPOSITORY} lifecycle
 #            cd lifecycle && git checkout ${GH_REF}

--- a/acceptance/testdata/launcher/Dockerfile
+++ b/acceptance/testdata/launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5 as builder
+FROM golang:1.26.6 as builder
 
 COPY exec.d/ /go/src/exec.d
 RUN GO111MODULE=off go build -o helper ./src/exec.d

--- a/go.mod
+++ b/go.mod
@@ -309,4 +309,4 @@ tool github.com/golang/mock/mockgen
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
-go 1.26.5
+go 1.26.6


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary

Grype flagged several CVEs against the v0.21.15 release image, most of which are Go
standard library issues fixed in the go1.26.6 patch release: `net/url` (quadratic
`resolvePath`, GO-2026-6218), `crypto/tls` (unbounded post-handshake message
handling, GO-2026-6090), `encoding/xml` (missing recursion depth guard,
GO-2026-6088), `encoding/asn1` (missing recursion depth guard, GO-2026-5972), and
`net/http`/`golang.org/x/net/idna` (Punycode ASCII-label handling, GO-2026-5026).

This bumps the `go` directive in `go.mod` from `1.26.5` to `1.26.6` so lifecycle is
built with the patched toolchain. CI installs the toolchain from `go.mod` via
`actions/setup-go`'s `go-version-file` input, so no other files need to change.

The remaining three CVEs from the issue (GO-2026-5064, GO-2026-5338, GO-2026-5622,
all `github.com/containerd/containerd` CRI checkpoint-restore issues) are not new:
they are already suppressed in `.grype.yaml` because lifecycle only imports
`containerd/platforms`, not the CRI plugin, and no fix is available for the v1
module line. `github.com/miekg/dns` (implicated in `CVE-2026-46600` /
`GO-2026-5942` in the issue body) is not a dependency of this module at all
(confirmed via `go list -m all` and `go mod graph`), so no action is needed there.

#### Release notes

Bump the Go toolchain to 1.26.6 to pick up standard library security fixes
(`net/url`, `crypto/tls`, `encoding/xml`, `encoding/asn1`, `net/http`/idna).

---

### Related

Resolves #1701

---

### Context

Validation performed locally:
- `GOTOOLCHAIN=go1.26.6+auto go version` confirms the go1.26.6 toolchain is
  available and downloadable.
- `govulncheck ./...` before this change reported 8 reachable vulnerabilities (5
  stdlib, all showing "Fixed in: go1.26.6"; 3 containerd, "Fixed in: N/A"). After
  bumping the go directive and re-running with `GOTOOLCHAIN=go1.26.6`, only the 3
  containerd findings remain — the 5 stdlib CVEs are resolved.
- `go build ./...` and `go vet ./...` pass cleanly under go1.26.6.
- `go mod tidy` produces no diff beyond the `go.mod` directive change.
- `go test -count=1 $(go list ./... | grep -v acceptance)` has pre-existing
  failures in `./buildpack/...` (missing helper binary, exit status 127) and
  `./image/...` (no local Docker daemon at `/var/run/docker.sock`) — confirmed by
  stashing this change and re-running the same command against an unmodified
  checkout, which reproduces the identical failures. These are sandbox
  environment limitations (no Docker daemon, missing generated helper binary),
  not caused by this change.
- Acceptance tests (`make acceptance`) were not run; they require a Docker daemon
  reachable from this sandbox, which is unavailable here.
- Note: `main`'s own `check-latest-release` and `test-s390x.yml` checks are
  currently failing/red independent of this change (per
  `gh run list --repo buildpacks/lifecycle --branch main --limit 5`).