### PR TITLE
Report an empty direct process command instead of panicking

### DIFF
--- a/launch/launcher.go
+++ b/launch/launcher.go
@@ -80,6 +80,9 @@ func (l *Launcher) launchDirect(proc Process) error {
 	if err := l.Setenv("PATH", l.Env.Get("PATH")); err != nil {
 		return errors.Wrap(err, "set path")
 	}
+	if len(proc.Command.Entries) == 0 {
+		return errors.Errorf("no command provided for process type %q", proc.Type)
+	}
 	binary, err := exec.LookPath(proc.Command.Entries[0])
 	if err != nil {
 		return errors.Wrap(err, "path lookup")

--- a/launch/launcher_test.go
+++ b/launch/launcher_test.go
@@ -143,6 +143,19 @@ func testLauncher(t *testing.T, when spec.G, it spec.S) {
 				}
 			})
 
+			it("should report an empty command instead of panicking", func() {
+				// A buildpack can emit [[processes]] with command = [], which
+				// UnmarshalTOML accepts, so this reaches the launcher.
+				empty := process
+				empty.Command = launch.NewRawCommand([]string{})
+
+				err := launcher.LaunchProcess("", empty)
+
+				h.AssertNotNil(t, err)
+				h.AssertStringContains(t, err.Error(), "no command provided for process type")
+				h.AssertEq(t, len(syscallExecArgsColl), 0)
+			})
+
 			it("should set argv0 to absolute path of command", func() {
 				h.AssertNil(t, launcher.LaunchProcess("", process))
 				if len(syscallExecArgsColl) != 1 {


### PR DESCRIPTION
`RawCommand.UnmarshalTOML` accepts `command = []` and stores a zero-length `Entries`. `launch_test.go` already notes this is a shape a buildpack can emit ("a buildpack can emit `[[processes]]` with `command = []`"). `launchDirect` then indexes it directly:

```go
binary, err := exec.LookPath(proc.Command.Entries[0])
```

Decoding that metadata and launching the process:

```
decoded Entries=[]string{} len=0 direct=true
panic: runtime error: index out of range [0] with length 0
  launch.(*Launcher).launchDirect  launcher.go:83
  launch.(*Launcher).LaunchProcess launcher.go:74
```

`handleUserArgs` only special-cases `len(Entries) > 1`, so zero falls straight through to the index. Now it returns an error naming the process type, and `syscall.Exec` is not reached.

One thing I deliberately did **not** change: `RawCommand.MarshalJSON` and the `< 0.10` branch above it also index `Entries[0]` unguarded, so they have the same shape. But since the project treats an empty command as something a buildpack may legitimately emit, making those error could break round-tripping such a process on an older platform API, and that is a bigger behavioural question than this crash. Happy to follow up separately if you would like them handled too.

The test goes in the existing `Direct=true` block and asserts both the error and that nothing was exec'd. It panics without the change.
