### PR TITLE
Bump golang.org/x/crypto to v0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/mod v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -712,8 +712,8 @@ golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260603202125-055de637280b h1:v1uXiEBHo8QA0LiGCo7UgHMzHT4Kdfpl2zmtH5vaP1Q=
 golang.org/x/exp v0.0.0-20260603202125-055de637280b/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

### Summary

A Grype scan of the v0.21.18 release flagged three CVEs in `golang.org/x/crypto/ssh`:
GO-2026-6355, GO-2026-6303, and GO-2026-6354. GO-2026-6303 was already fixed by the
prior bump to v0.55.0. GO-2026-6355 and GO-2026-6354 (SSH channel deadlock DoS issues)
are fixed upstream in v0.56.0. This bumps `golang.org/x/crypto` from v0.55.0 to v0.56.0
to close out the remaining two.

#### Release notes

Bump `golang.org/x/crypto` to v0.56.0 to resolve GO-2026-6355 and GO-2026-6354 (SSH
channel-deadlock denial-of-service issues) flagged by Grype in release v0.21.18.

---

### Related
<!-- If this PR addresses an issue, please provide the issue number below. -->

Resolves #1713

---

### Context

`golang.org/x/crypto` is an indirect (transitive) dependency here; no lifecycle source
file imports it directly. Ran `go get golang.org/x/crypto@v0.56.0 && go mod tidy` —
only go.mod/go.sum changed (the two `golang.org/x/crypto` version lines), no other
module churn.

Validation:
- `go build ./...` and `go vet ./...` pass.
- `go test ./...` passes except pre-existing failures in `./buildpack/...` and
  `./image/...` caused by this sandbox having no Docker daemon/binary — verified these
  reproduce identically on the unmodified base commit via `git stash`.
- `go test ./auth/...` (the package nearest the credential-helper chain) passes.
- `golangci-lint run -c golangci.yaml ./...` shows only 3 pre-existing staticcheck
  findings in `launch/bash.go`, a file this change does not touch.
- `govulncheck ./...` no longer lists `golang.org/x/crypto` after the bump; remaining
  reported vulnerabilities (containerd, docker-credential-acr-env) are unrelated and
  out of scope for this issue.
- Base branch CI is green aside from known-flaky, unrelated failures
  (`test-s390x.yml` and a scheduled `check-latest-release` job).